### PR TITLE
Ship the v0 wedge: push a note, get a public versioned page

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,15 @@
+# Local secrets for `wrangler dev`. Copy to `.dev.vars` and fill in; `.dev.vars`
+# is gitignored and must stay that way.
+#
+# In a deployed environment these are set with `wrangler secret put <NAME>`, not
+# in wrangler.jsonc.
+
+# Base url of the Brevilabs license server. The worker POSTs
+# {LICENSE_API_URL}/api/trpc/license.validateLicenseKey to validate a publisher's
+# Copilot Plus license key.
+LICENSE_API_URL="https://api.brevilabs.com"
+
+# Our server-side credential for that endpoint — NOT a publisher's license key.
+# Publisher keys arrive per request in the Authorization header and are never
+# stored; only their SHA-256 is.
+LICENSE_API_KEY=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ These are day-one decisions, not retrofits:
 - **No per-MAU or per-seat priced dependency** anywhere in the serving path.
 - Quotas and per-key rate limits ship with the feature they protect, not later.
 
-## Owed before anything is deployed
+## Owed before there is much data
 
 **D1 is currently the only record of who owns a doc, what it is called, and
 whether it was deleted.** R2 holds `docs/{id}/v{n}.html` and nothing else, so the
@@ -78,10 +78,11 @@ after each push as a snapshot of the doc's D1 state, and left behind as a
 tombstone on delete rather than swept with the version objects. Snapshot it, do
 not read-modify-write it.
 
-**Do this before provisioning anything.** Manifests are only worth having from
-the first doc onward — backfilling them requires the D1 you are insuring
-against. Until it ships, treat D1 as a system of record with a 30-day Time
-Travel window, not as a cache.
+**Not a deploy blocker.** Backfilling manifests needs the D1 they insure
+against, which sounds urgent but isn't while a rebuild would be a handful of
+rows — and D1 has a 30-day Time Travel window underneath. Do it well before
+there is enough data that reconstructing it by hand would hurt. Until then,
+treat D1 as a system of record, not as a cache.
 
 ## Owed when the real serving domain lands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,32 @@ These are day-one decisions, not retrofits:
   nothing.
 - **R2 is the system of record**, and the stored format is HTML. D1 holds pointer
   rows only — never content — and must be rebuildable by scanning R2 manifests.
+  **This does not hold yet — see below. Do not rely on it.**
 - Every push mints an **immutable version** served with `cache-control: immutable`.
   Render at push time, never at read time.
 - **No per-MAU or per-seat priced dependency** anywhere in the serving path.
 - Quotas and per-key rate limits ship with the feature they protect, not later.
+
+## Owed before anything is deployed
+
+**D1 is currently the only record of who owns a doc, what it is called, and
+whether it was deleted.** R2 holds `docs/{id}/v{n}.html` and nothing else, so the
+rebuildability the constraint above claims is not true today:
+
+- publisher, title and timestamps exist only in D1;
+- a deleted doc leaves an empty R2 prefix, so a rebuild could not tell a
+  withdrawn url from one that never existed, and it would answer 404 where it
+  promised 410.
+
+The fix is the per-doc `manifest.json` from `docs/cost-at-scale.md` §6: written
+after each push as a snapshot of the doc's D1 state, and left behind as a
+tombstone on delete rather than swept with the version objects. Snapshot it, do
+not read-modify-write it.
+
+**Do this before provisioning anything.** Manifests are only worth having from
+the first doc onward — backfilling them requires the D1 you are insuring
+against. Until it ships, treat D1 as a system of record with a 30-day Time
+Travel window, not as a cache.
 
 ## Owed when the real serving domain lands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,22 @@ These are day-one decisions, not retrofits:
 - **No per-MAU or per-seat priced dependency** anywhere in the serving path.
 - Quotas and per-key rate limits ship with the feature they protect, not later.
 
+## Owed when the real serving domain lands
+
+v0 runs on a `workers.dev` subdomain, which sits outside the CDN cache. Two
+things become true the moment user content moves to a real serving domain, and
+both are easy to miss because nothing fails loudly without them:
+
+- **Delete must purge the CDN cache.** Pinned `/v{n}` urls are served
+  `immutable` for a year. With no shared cache in front of the worker that is
+  harmless, but on a cached domain an unshared doc would keep being served from
+  the edge. Wire a purge into `deleteDoc`; the private-cache copies readers
+  already hold are unrecallable by any design, and the README says so.
+- **Set `SERVING_HOST` and `API_HOST`.** The router resolves surface by host
+  first and only falls back to path prefixes while both are empty. Leaving them
+  unset on a two-domain deployment means `/api/v1` stays reachable on the
+  sacrificial domain, which is the whole point of splitting them.
+
 ## Git hygiene
 
 Stage explicit paths (`git add src/foo.ts`), never `git add -A` / `git add .`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,31 @@ npm test
 npm run deploy     # wrangler deploy
 ```
 
+`README.md` carries the details these commands need: running against a local
+worker with no license server, and the provisioning sequence a first deploy
+requires. `scripts/smoke.sh` checks a *deployed* worker end to end and is run by
+hand — it needs a real license key, so it is deliberately not in CI.
+
+Tests run inside workerd against real R2 and D1 (Miniflare), never against test
+doubles for them. A binding double asserts our idea of Cloudflare rather than
+Cloudflare, so the only ones in the suite are deliberately broken bindings used
+to test failure paths.
+
+## The HTTP contract is frozen
+
+`README.md` § HTTP API is the contract Obsidian Copilot is written against, and
+it is the source of truth — not this repo's source. Nothing in it changes
+without a client release: not a status code, not an error `code`, not a field
+name. Adding to it is fine; changing what is there is a cross-repo decision.
+
+Two conventions in it are security properties rather than style, and both are
+easy to undo by accident:
+
+- **404, never 403.** A doc belonging to another publisher must be
+  indistinguishable from one that never existed, on every endpoint.
+- **404 vs 410.** A deleted doc keeps its D1 row forever so its url answers 410.
+  Delete destroys the R2 objects; it must never delete the row.
+
 ## Product context
 
 `docs/positioning.md` and `docs/cost-at-scale.md` are the source of truth for what

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ markdown branch on the server.
 ### `PUT /api/v1/docs/{docId}` — publish a new version
 
 Same body as `POST`. Omitting `title` keeps the doc's current title rather than
-blanking it.
+blanking it — omission is the only thing that means "leave it alone". A `title`
+that is present but blank is not a title, and becomes `Untitled` here exactly as
+it does on `POST`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ The doc's stored bytes are destroyed and its url starts answering `410 gone`
 deliberate: a reader holding the link learns it was withdrawn instead of
 concluding they mistyped it.
 
+What delete cannot do is recall a copy someone already has. Pinned `/v{n}` urls
+are served `immutable` with a one-year lifetime, because a version's bytes never
+change and that is what lets a widely-read doc cost one origin read; a cache
+holding one will go on serving it without asking us again. Unshare stops new
+readers, not readers who already fetched — the same way it cannot un-download a
+file. Treat it as withdrawing the link, not as revoking the content.
+
 `404 not_found` if the doc does not exist, belongs to another publisher, **or was
 already deleted**. A retry after a timeout therefore sees `404`, not `204`; what
 is idempotent is the outcome, which is the part a client cares about. Treat

--- a/README.md
+++ b/README.md
@@ -6,6 +6,60 @@ v0 is the wedge, nothing more: **HTML upload → public webpage**. The upload AP
 private and programmatic — the only caller is Obsidian Copilot's share action. No
 reader accounts, no permissions, no comments.
 
+## What works today
+
+Everything here is built and tested. Nothing is deployed yet, so none of it is
+reachable on the internet until someone runs [Deploying](#deploying).
+
+- **Publish a note.** Send rendered HTML, get back a link. Obsidian Copilot
+  renders the note locally, so callouts, wikilinks and dataview output survive —
+  a server-side markdown pipeline would have flattened them.
+- **Re-publish and the link stays the same.** Every push saves a new version, and
+  the link you already shared shows the latest one. Old versions keep working
+  forever at their own `/v2`-style urls, so a link you sent last week still shows
+  what you sent.
+- **Anyone with the link can read it.** No account, no sign-in, nothing to
+  install. Publishing needs a key; reading needs nothing.
+- **Pages are not indexed.** Every page tells search engines to skip it, so a
+  shared doc doesn't turn up in Google.
+- **Interactive documents work.** Scripts, charts and embedded simulations run,
+  which is the reason to serve HTML rather than sanitized markdown. Pages are
+  blocked from submitting forms or being embedded in other sites, which is what
+  keeps that safe to allow.
+- **Unshare.** Delete a doc and its link starts saying it was withdrawn, and the
+  stored files are destroyed. Copies already sitting in someone's browser cache
+  can't be recalled — no design can do that.
+- **See your docs.** List everything you've published, newest first.
+- **Publishing is gated to Copilot Plus.** Keys are checked against the existing
+  license server, and the answer is cached for an hour so a license-server outage
+  doesn't stop someone who has published before.
+- **Limits that stop abuse, not people.** 10MB per doc, 100 pushes a day, 500
+  docs — generous enough that a real user never notices.
+
+## What's coming
+
+Roughly in order. Nothing below is started.
+
+- **The Obsidian side.** A right-click "share" in Copilot that calls this API and
+  remembers the doc's id in the note. Without it, the only way to publish is
+  `curl` — this is the next thing to build.
+- **A real domain.** Today's `workers.dev` url works but sits outside
+  Cloudflare's cache, so every read hits the server. Real domains also let user
+  content live somewhere separate from the brand, so a bad doc can't damage
+  `updoc.md`'s reputation.
+- **Backups that don't depend on the database.** Right now the database is the
+  only record of who owns a doc and what it's called. The plan is for each doc to
+  carry its own description alongside its files, so the database could be rebuilt
+  from scratch. Not urgent while there is little data; it should land well before
+  there is a lot.
+- **Keeping old versions from piling up.** Every push is kept forever today.
+  Fine for people, less fine once agents push on every edit.
+- **Publishing for free users.** Only Plus license holders can publish, which
+  suits a design-partner launch and contradicts the free-wedge thesis long-term.
+- **Then the actual product**: comments anchored to passages, agents drafting
+  them for a human to approve, and version-to-version diffs. That is the wedge in
+  `docs/positioning.md` — share, then comment, then converge.
+
 ## Where this is going
 
 updoc is the first step of an agent-first docs product: a shared artifact where
@@ -25,9 +79,8 @@ load-bearing and are not retrofittable:
 - **`noindex` + `nofollow` by default** — this deletes most of the spam incentive.
 - **Publisher-gated, reader-open** — publishing needs a key, reading needs nothing.
 - **R2 holds the truth as HTML**; D1 is a small rebuildable pointer index.
-  (Not yet: v0 stores only version objects, so ownership, titles and deletion
-  tombstones live solely in D1. Per-doc manifests are owed before deploy — see
-  `CLAUDE.md`.)
+  (Not yet — v0 stores only version objects, so ownership, titles and deletion
+  tombstones live solely in D1. See "What's coming" above and `CLAUDE.md`.)
 - **Flat-fee dependencies only** in the serving path — no per-MAU pricing, ever.
 
 ## Stack
@@ -345,12 +398,12 @@ Alternatively, copy `.dev.vars.example` to `.dev.vars` and point
 
 # Deploying
 
-> **Not ready to deploy yet.** D1 is currently the only record of doc ownership,
-> titles and deletion tombstones, so the per-doc manifests that make it
-> rebuildable from R2 have to land first — they are only useful if they exist
-> from the first doc onward. See "Owed before anything is deployed" in
-> `CLAUDE.md`. The sequence below is correct and complete; it just should not be
-> run until then.
+> **Nothing has been deployed yet.** The sequence below is complete and creates
+> real resources on a real account. One thing to know going in: D1 is currently
+> the only record of who owns a doc, what it is called, and whether it was
+> deleted, so until per-doc manifests ship, back-ups mean D1's own 30-day Time
+> Travel window rather than "rebuild it from R2". That is fine at low volume and
+> should be fixed well before it isn't — see `CLAUDE.md`.
 
 Run once, in order, from a checkout with `npx wrangler login` already done. This
 creates real Cloudflare resources on whichever account wrangler is logged into.

--- a/README.md
+++ b/README.md
@@ -31,15 +31,353 @@ load-bearing and are not retrofittable:
 
 Cloudflare all the way down: Workers, R2, D1, Durable Objects, Queues, Turnstile.
 
-## Development
+---
+
+# HTTP API
+
+This section is the contract, and it is frozen: the Obsidian Copilot client is
+written against what is below, so nothing here changes without a client release.
+It is complete on purpose — a client author should never need to read this
+repo's source.
+
+## Surfaces
+
+Two surfaces, which will eventually be two domains:
+
+| Surface | Paths | Auth | Notes |
+| --- | --- | --- | --- |
+| API | `/api/v1/*` | required | Publisher-facing. JSON in, JSON out. |
+| Serving | `/d/*` | none | Reader-facing. Public HTML. Never sets a cookie. |
+
+In v0 both run on one `workers.dev` subdomain and the path prefix decides which
+is which. Later they split across a brand domain and a sacrificial serving
+domain; when that happens the `url` field returned by a push starts pointing at
+the serving domain, which is the only reason a client should never build a doc
+url itself. **Always use the `url` the API returns.**
+
+`GET /health` → `200 {"ok": true}` is reachable on both, unauthenticated.
+
+## Authentication
+
+Every `/api/v1/*` request carries a Copilot Plus license key:
+
+```http
+Authorization: Bearer <copilot plus license key>
+```
+
+The key is validated against the Brevilabs license server and cached for an hour.
+Only the key's SHA-256 is ever stored; the raw key is never persisted or logged.
+A publisher *is* that hash, so the same key always sees the same docs.
+
+Reading a doc requires nothing. Serving responses never set a cookie.
+
+## Endpoints
+
+```http
+POST   /api/v1/docs           {title?, html}  → 201 {docId, url, version}
+PUT    /api/v1/docs/{docId}   {title?, html}  → 200 {docId, url, version}
+DELETE /api/v1/docs/{docId}                   → 204
+GET    /api/v1/docs?limit&cursor              → 200 {docs[], cursor?}
+GET    /d/{docId}                             → 200 latest HTML
+GET    /d/{docId}/v{n}                        → 200 immutable HTML
+```
+
+Any other method or path under `/api/v1` is `404 not_found`.
+
+### `POST /api/v1/docs` — publish a new doc
+
+`Content-Type: application/json`.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `html` | string | yes | A whole HTML document. Max 10MB encoded as UTF-8. |
+| `title` | string | no | Display name in the doc list. Trimmed, capped at 512 characters. Missing, null or blank becomes `Untitled`. |
+
+```json
+{"title": "Q3 architecture review", "html": "<!doctype html><html>…</html>"}
+```
+
+```json
+{"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "url": "https://updoc.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "version": 1}
+```
+
+A `docId` is 26 characters of lowercase Crockford base32 (`0-9`, `a-z` without
+`i`, `l`, `o`, `u`) — 128 bits of randomness. It is the only access control a doc
+has: whoever holds the url holds the doc.
+
+The API accepts **HTML only**. Copilot renders markdown locally, because that is
+the only way callouts, wikilinks and dataview output survive. There is no
+markdown branch on the server.
+
+### `PUT /api/v1/docs/{docId}` — publish a new version
+
+Same body as `POST`. Omitting `title` keeps the doc's current title rather than
+blanking it.
+
+```json
+{"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "url": "https://updoc.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "version": 2}
+```
+
+The `url` never changes. `version` increments by one and the previous version
+stays readable forever at `/d/{docId}/v{n}`.
+
+`404 not_found` if the doc does not exist, belongs to another publisher, or was
+deleted — see [Not found, never forbidden](#not-found-never-forbidden).
+
+### `DELETE /api/v1/docs/{docId}` — unshare
+
+`204 No Content`, no body.
+
+The doc's stored bytes are destroyed and its url starts answering `410 gone`
+— for the shared link and every pinned `/v{n}` alike. `410` rather than `404` is
+deliberate: a reader holding the link learns it was withdrawn instead of
+concluding they mistyped it.
+
+`404 not_found` if the doc does not exist, belongs to another publisher, **or was
+already deleted**. A retry after a timeout therefore sees `404`, not `204`; what
+is idempotent is the outcome, which is the part a client cares about. Treat
+`404` from a delete as success.
+
+### `GET /api/v1/docs` — list my docs
+
+Only the calling publisher's live docs, newest first by creation time.
+
+| Query | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `limit` | integer 1–100 | 50 | Anything else is `400 bad_request`. |
+| `cursor` | opaque string | — | From a previous response. Pass it back unchanged; do not parse or construct one. Anything else is `400 bad_request`. |
+
+```json
+{"docs": [
+   {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
+    "title": "Q3 architecture review",
+    "url": "https://updoc.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+    "version": 2,
+    "updatedAt": 1785000000000}
+ ],
+ "cursor": "MTc4NTAwMDAwMDAwMC45ZjJrNG12cTd0MHhiejNuY3JoczV3ZGExcA"}
+```
+
+- `updatedAt` is epoch milliseconds — the last push, not the creation.
+- `version` is the newest version that has bytes. It is `null` in one rare case:
+  a doc whose very first push failed partway. Such a doc serves nothing, and it
+  is listed only so its publisher can delete it and free the slot.
+- `cursor` is present **only when another page exists**, so the walk ends when it
+  is absent rather than on an empty page.
+
+Paging is keyset, not offset: a doc published while you are walking pages appears
+on no page you have already read, and no doc is ever served twice or skipped.
+
+### `GET /d/{docId}` and `GET /d/{docId}/v{n}` — read
+
+Unauthenticated. `GET` and `HEAD` only; anything else is `404`.
+
+| | `/d/{docId}` | `/d/{docId}/v{n}` |
+| --- | --- | --- |
+| Serves | latest version | version `n`, forever |
+| `Cache-Control` | `public, max-age=60` | `public, max-age=31536000, immutable` |
+
+`{n}` is a decimal with no leading zeros and starts at 1. `ETag` and
+`If-None-Match` are supported (`304`).
+
+Every response on this surface — including its errors — carries:
+
+```http
+X-Robots-Tag: noindex, nofollow
+Content-Security-Policy: …; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+Referrer-Policy: no-referrer
+X-Content-Type-Options: nosniff
+```
+
+Uploaded scripts **do** run — interactive figures and embedded simulations are
+why the client uploads HTML at all. What the policy forbids is a doc using the
+origin against its readers: no form submission, no framing, no `<base>`
+retargeting. The origin is cookieless and holds nothing but already-public docs.
+
+Two things are injected into the document at push time, so the stored bytes and
+the served bytes are the same thing: a `<meta name="robots" content="noindex,nofollow">`
+in the head, and a small `Shared with updoc` footer before `</body>`. Nothing
+else is touched — the markup is never sanitized, rewritten or reformatted.
+
+`404` for an unknown id or version; `410` once the doc is deleted.
+
+## Errors
+
+Every failure, on both surfaces, is:
+
+```json
+{"error": {"code": "not_found", "message": "No doc with id ..."}}
+```
+
+Match on `code`. `message` is human-facing and free to change.
+
+| `code` | HTTP | When |
+| --- | --- | --- |
+| `bad_request` | 400 | Malformed JSON, `html` missing, empty or not a string, non-string `title`, junk `limit` or `cursor`. |
+| `unauthorized` | 401 | No `Authorization: Bearer` header, or the license server rejected the key. Carries `WWW-Authenticate: Bearer`. |
+| `not_found` | 404 | No such doc, not yours, already deleted, or no route. |
+| `gone` | 410 | The doc was deleted by its author. |
+| `too_large` | 413 | `html` over 10MB. |
+| `quota_exceeded` | 429 | Daily push or doc-count ceiling reached. |
+| `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |
+
+Two of these are worth handling deliberately in a client:
+
+- **`internal` is not `unauthorized`.** A license-server outage answers `500
+  internal`, never `401`, precisely so the client does not prompt for a new key
+  over a key that is perfectly good. Retry instead.
+- <a id="not-found-never-forbidden"></a>**Not found, never forbidden.** There is
+  no `403`. A doc belonging to another publisher answers exactly like a doc that
+  never existed, because a distinguishable reply would confirm the id is real.
+
+## Quotas
+
+Per license key. They cap the abuse and hoarding tail; a real user never reaches
+one.
+
+| Limit | Value | Exceeded |
+| --- | --- | --- |
+| HTML per doc | 10 MB | `413 too_large` |
+| Pushes per day | 100 (UTC day, rolls at midnight) | `429 quota_exceeded` |
+| Live docs held | 500 | `429 quota_exceeded` |
+
+Both `POST` and `PUT` spend one push. A rejected push spends nothing: a `413`,
+a `400`, or a `PUT` at a doc you do not own leaves the day's allowance intact.
+Deleting a doc frees a slot against the 500.
+
+## The docId round trip
+
+This is the whole client-side protocol, and getting it right is what makes
+re-sharing a note update the page instead of minting a second link.
+
+1. First share of a note: `POST /api/v1/docs`. The server mints the `docId`.
+2. **The client writes that `docId` into the note's own frontmatter** and keeps
+   it there.
+3. Every later share of the same note: `PUT /api/v1/docs/{docId}` with the id
+   from frontmatter. Same url, next version, and whoever already has the link
+   sees the update.
+
+```yaml
+---
+updoc: 9f2k4mvq7t0xbz3ncrhs5wda1p
+---
+```
+
+If a `PUT` answers `404`, the stored id is stale — the doc was deleted, or the
+note travelled to a vault signed in with a different license key. Fall back to
+`POST` and replace the id in frontmatter with the new one.
+
+## A whole round trip
+
+```bash
+BASE=https://updoc.example.workers.dev
+KEY=<copilot plus license key>
+
+# publish
+curl -sS -X POST "$BASE/api/v1/docs" \
+  -H "authorization: Bearer $KEY" -H 'content-type: application/json' \
+  -d '{"title":"Notes","html":"<!doctype html><html><body><p>hello</p></body></html>"}'
+# → {"docId":"9f2k…","url":"https://…/d/9f2k…","version":1}
+
+curl -sS "$BASE/d/9f2k…"                       # the public page, no auth
+curl -sS "$BASE/api/v1/docs?limit=10" -H "authorization: Bearer $KEY"
+curl -sS -X DELETE "$BASE/api/v1/docs/9f2k…" -H "authorization: Bearer $KEY" -i
+curl -sS "$BASE/d/9f2k…" -o /dev/null -w '%{http_code}\n'   # → 410
+```
+
+`scripts/smoke.sh` runs exactly this sequence against a deployment and checks
+every status.
+
+---
+
+# Development
 
 ```bash
 npm install
-npm run dev        # wrangler dev
 npm run typecheck
-npm test
+npm test           # vitest, inside workerd, against real R2 and D1 (Miniflare)
+npm run dev        # wrangler dev — local R2 and D1, no Cloudflare account needed
 ```
 
-## Deployment
+Tests need no credentials and no deployment: `@cloudflare/vitest-pool-workers`
+runs them in the real runtime with the migrations in `migrations/` applied to a
+per-test D1. CI runs `npm run typecheck` and `npm test`, and nothing else.
 
-`wrangler deploy`. All changes ship through a pull request; never push to `main`.
+`wrangler dev` needs a wrangler whose bundled runtime is new enough for the
+`compatibility_date` in `wrangler.jsonc`; if it refuses to start, `npm install
+wrangler@latest`.
+
+There is no license server locally, so the first push against `wrangler dev`
+fails with `internal`. Warm the validation cache by hand — the worker trusts a
+`publishers` row younger than an hour, and a publisher id is just the SHA-256 of
+the key:
+
+```bash
+KEY=any-string-you-like
+HASH=$(printf '%s' "$KEY" | shasum -a 256 | cut -d' ' -f1)
+
+npx wrangler d1 migrations apply updoc --local
+npx wrangler d1 execute updoc --local --command \
+  "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at)
+   VALUES ('$HASH', 'plus', $(($(date +%s) * 1000)))"
+
+UPDOC_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
+```
+
+Alternatively, copy `.dev.vars.example` to `.dev.vars` and point
+`LICENSE_API_URL` / `LICENSE_API_KEY` at the real license server.
+
+# Deploying
+
+Run once, in order, from a checkout with `npx wrangler login` already done. This
+creates real Cloudflare resources on whichever account wrangler is logged into.
+
+```bash
+# 1. The R2 bucket. The name must match `bucket_name` in wrangler.jsonc.
+npx wrangler r2 bucket create updoc-docs
+
+# 2. The D1 database. This prints a `database_id`.
+npx wrangler d1 create updoc
+```
+
+**Now edit `wrangler.jsonc`** and replace the `database_id` placeholder
+(`00000000-0000-0000-0000-000000000000`) with the id step 2 printed, then commit
+it. It is not a secret; the binding will not resolve without it.
+
+```bash
+# 3. Create the schema on the real database (--remote, not --local).
+npx wrangler d1 migrations apply updoc --remote
+
+# 4. Credentials for the license server. Both prompt for the value, so neither
+#    ends up in your shell history. LICENSE_API_KEY is *ours*, never a
+#    publisher's key. On a first deploy the Worker does not exist yet, so the
+#    first of these also asks whether to create it — answer yes; step 5
+#    overwrites the placeholder and the secrets survive it.
+npx wrangler secret put LICENSE_API_URL     # e.g. https://api.brevilabs.com
+npx wrangler secret put LICENSE_API_KEY
+
+# 5. Ship. This prints the workers.dev url.
+npx wrangler deploy
+
+# 6. Check what just shipped, end to end.
+UPDOC_LICENSE_KEY=<a real Copilot Plus key> \
+  scripts/smoke.sh https://updoc.<subdomain>.workers.dev
+```
+
+The smoke script publishes a doc, reads it, lists it, deletes it and confirms the
+`410`. It spends one push against that key's daily quota and leaves no live doc
+and no stored bytes behind — only the deleted doc's row, which every delete keeps
+so the url can go on answering `410`. It is not part of CI — CI has no key and no
+deployment.
+
+`SERVING_HOST` and `API_HOST` stay empty in `wrangler.jsonc` for v0: one
+workers.dev subdomain hosts both surfaces and the router falls back to path
+prefixes. Filling them in later moves doc serving onto the sacrificial domain
+without a code change — and the `url` the API returns follows automatically.
+
+Later deploys are steps 5 and 6 alone, plus step 3 whenever a migration is added.
+All changes ship through a pull request; never push to `main`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ load-bearing and are not retrofittable:
 - **`noindex` + `nofollow` by default** — this deletes most of the spam incentive.
 - **Publisher-gated, reader-open** — publishing needs a key, reading needs nothing.
 - **R2 holds the truth as HTML**; D1 is a small rebuildable pointer index.
+  (Not yet: v0 stores only version objects, so ownership, titles and deletion
+  tombstones live solely in D1. Per-doc manifests are owed before deploy — see
+  `CLAUDE.md`.)
 - **Flat-fee dependencies only** in the serving path — no per-MAU pricing, ever.
 
 ## Stack
@@ -341,6 +344,13 @@ Alternatively, copy `.dev.vars.example` to `.dev.vars` and point
 `LICENSE_API_URL` / `LICENSE_API_KEY` at the real license server.
 
 # Deploying
+
+> **Not ready to deploy yet.** D1 is currently the only record of doc ownership,
+> titles and deletion tombstones, so the per-doc manifests that make it
+> rebuildable from R2 have to land first — they are only useful if they exist
+> from the first doc onward. See "Owed before anything is deployed" in
+> `CLAUDE.md`. The sequence below is correct and complete; it just should not be
+> run until then.
 
 Run once, in order, from a checkout with `npx wrangler login` already done. This
 creates real Cloudflare resources on whichever account wrangler is logged into.

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,53 @@
+-- updoc v0 pointer index.
+--
+-- R2 is the system of record; every row here is rebuildable by scanning R2.
+-- Timestamps are epoch milliseconds (INTEGER), so no date parsing at read time.
+
+-- Publishers, keyed by the SHA-256 of their license key. Raw keys are never
+-- stored. This table doubles as the license-validation cache: `validated_at`
+-- is the last successful check, and a row younger than the TTL skips the
+-- license-server round trip.
+CREATE TABLE publishers (
+  key_hash     TEXT    PRIMARY KEY,
+  plan         TEXT    NOT NULL,
+  validated_at INTEGER NOT NULL
+);
+
+-- One row per shared doc. `latest_version` is the version counter; it is
+-- incremented with a single `UPDATE ... RETURNING`, which is the only
+-- atomicity this design needs.
+CREATE TABLE docs (
+  id             TEXT    PRIMARY KEY,
+  publisher      TEXT    NOT NULL REFERENCES publishers(key_hash),
+  title          TEXT    NOT NULL,
+  latest_version INTEGER NOT NULL DEFAULT 0,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL,
+  deleted_at     INTEGER
+);
+
+-- Serves both the cursor-paged "list my docs" scan and the live-doc count the
+-- per-key doc quota checks. Partial, so soft-deleted docs cost nothing.
+CREATE INDEX docs_by_publisher_live
+  ON docs (publisher, created_at DESC, id DESC)
+  WHERE deleted_at IS NULL;
+
+-- Immutable version log. One row per push; the R2 object for (doc_id, n) is
+-- written before the row, so a row always has bytes behind it.
+CREATE TABLE versions (
+  doc_id     TEXT    NOT NULL REFERENCES docs(id) ON DELETE CASCADE,
+  n          INTEGER NOT NULL,
+  size       INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (doc_id, n)
+);
+
+-- Daily push counter per publisher. `day` is a UTC `YYYY-MM-DD` string, so the
+-- window rolls without a scheduled reset. Read and written by one upsert on
+-- (publisher, day), which the primary key already covers.
+CREATE TABLE push_quota (
+  publisher TEXT    NOT NULL,
+  day       TEXT    NOT NULL,
+  pushes    INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (publisher, day)
+);

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -34,10 +34,15 @@ CREATE INDEX docs_by_publisher_live
 
 -- Immutable version log. One row per push; the R2 object for (doc_id, n) is
 -- written before the row, so a row always has bytes behind it.
+-- `title` is what this push asked the doc to be called, and null when it asked
+-- for nothing. It lives here rather than only on `docs` because a title belongs
+-- to the push that set it: two overlapping pushes can store out of order, and
+-- the doc's title has to resolve by version number, not by which commit ran last.
 CREATE TABLE versions (
   doc_id     TEXT    NOT NULL REFERENCES docs(id) ON DELETE CASCADE,
   n          INTEGER NOT NULL,
   size       INTEGER NOT NULL,
+  title      TEXT,
   created_at INTEGER NOT NULL,
   PRIMARY KEY (doc_id, n)
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "updoc",
       "version": "0.0.0",
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.12.21",
         "@cloudflare/workers-types": "^4.20250726.0",
         "@types/node": "^20",
         "typescript": "^5",
@@ -40,6 +41,696 @@
       },
       "peerDependenciesMeta": {
         "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.12.21",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.12.21.tgz",
+      "integrity": "sha512-xqvqVR+qAhekXWaTNY36UtFFmHrz13yGUoWVGOu6LDC2ABiQqI1E1lQ3eUZY8KVB+1FXY/mP5dB6oD07XUGnPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "^1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260310.0",
+        "wrangler": "4.72.0"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 3.2.x",
+        "@vitest/snapshot": "2.0.x - 3.2.x",
+        "vitest": "2.0.x - 3.2.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260310.1.tgz",
+      "integrity": "sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260310.1.tgz",
+      "integrity": "sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260310.1.tgz",
+      "integrity": "sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260310.1.tgz",
+      "integrity": "sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260310.1.tgz",
+      "integrity": "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
+      "version": "4.20260310.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260310.0.tgz",
+      "integrity": "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.18.2",
+        "workerd": "1.20260310.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260310.1.tgz",
+      "integrity": "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260310.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260310.1",
+        "@cloudflare/workerd-linux-64": "1.20260310.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260310.1",
+        "@cloudflare/workerd-windows-64": "1.20260310.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.72.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.72.0.tgz",
+      "integrity": "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.15.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260310.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260310.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260310.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
           "optional": true
         }
       }
@@ -1722,6 +2413,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.12.21",
     "@cloudflare/workers-types": "^4.20250726.0",
     "@types/node": "^20",
     "typescript": "^5",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke check against a *deployed* updoc worker.
+#
+#   UPDOC_LICENSE_KEY=... scripts/smoke.sh https://updoc.<subdomain>.workers.dev
+#
+# It publishes a doc, reads it back from its public url, finds it in the
+# publisher's list, deletes it, and confirms the url has become 410. Every step
+# asserts a status code; the first surprise prints what it expected, what it got
+# and the response body, and exits non-zero.
+#
+# Deliberately not wired into CI. It needs a real license key and a real
+# deployment, and CI has neither — running it there could only ever be a red
+# build for a missing credential. It is a post-deploy check a human runs.
+#
+# The license key comes from the environment and never leaves it: it is written
+# to a curl config file inside a private temp dir rather than passed as an
+# argument, because command-line arguments are visible to every process on the
+# machine via `ps`. Nothing here echoes it, and the API never returns it.
+set -euo pipefail
+
+BASE_URL=${1:-${UPDOC_BASE_URL:-}}
+
+usage() {
+  cat >&2 <<'EOF'
+usage: UPDOC_LICENSE_KEY=<copilot plus license key> scripts/smoke.sh <base url>
+
+  <base url>          e.g. https://updoc.<subdomain>.workers.dev
+                      (or set UPDOC_BASE_URL instead of passing it)
+  UPDOC_LICENSE_KEY   a Copilot Plus license key with a push quota to spare.
+                      Never passed as an argument, never printed.
+EOF
+  exit 2
+}
+
+[ -n "$BASE_URL" ] || usage
+[ -n "${UPDOC_LICENSE_KEY:-}" ] || usage
+
+# Trailing slashes would double up in every url built below.
+BASE_URL=${BASE_URL%/}
+
+command -v curl >/dev/null 2>&1 || {
+  echo "smoke: curl is required" >&2
+  exit 2
+}
+
+umask 077
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+AUTH="$WORK/auth.curl"
+BODY="$WORK/body"
+# Quoted, because curl's config parser cuts an unquoted value at the first run
+# of whitespace and would send a header with no key in it. `printf` is a shell
+# builtin, so escaping the key for that quoting never puts it in a process's
+# arguments either.
+printf 'header = "Authorization: Bearer %s"\n' \
+  "$(printf '%s' "$UPDOC_LICENSE_KEY" | sed 's/[\\"]/\\&/g')" >"$AUTH"
+
+HTTP_STATUS=""
+
+fail() {
+  printf 'smoke: %s\n' "$*" >&2
+  exit 1
+}
+
+# Every request goes through one of these two, so the auth header is attached by
+# the API one and structurally absent from the public one — reading a doc must
+# work with no credential at all, and a smoke check that sent one anyway would
+# not be checking that.
+api_request() {
+  method=$1
+  url=$2
+  shift 2
+  : >"$BODY"
+  HTTP_STATUS=$(curl --config "$AUTH" -sS -o "$BODY" -w '%{http_code}' \
+    -X "$method" "$url" "$@") || fail "could not reach $url"
+}
+
+public_request() {
+  url=$1
+  shift
+  : >"$BODY"
+  HTTP_STATUS=$(curl -sS -o "$BODY" -w '%{http_code}' "$url" "$@") ||
+    fail "could not reach $url"
+}
+
+expect_status() {
+  want=$1
+  what=$2
+  if [ "$HTTP_STATUS" != "$want" ]; then
+    printf 'FAIL  %s\n' "$what" >&2
+    printf '      expected HTTP %s, got HTTP %s\n' "$want" "$HTTP_STATUS" >&2
+    printf '      response body:\n' >&2
+    sed 's/^/        /' "$BODY" >&2
+    exit 1
+  fi
+  printf 'ok    %s (HTTP %s)\n' "$what" "$HTTP_STATUS"
+}
+
+expect_body() {
+  needle=$1
+  what=$2
+  grep -q -- "$needle" "$BODY" || fail "$what: response did not contain \"$needle\""
+  printf 'ok    %s\n' "$what"
+}
+
+# Enough of a JSON reader for four flat string fields, so the check needs
+# nothing installed beyond curl. The API's responses come from JSON.stringify,
+# so they are compact and unescaped for these fields.
+json_string() {
+  grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$BODY" |
+    head -n 1 |
+    sed -E 's/.*:[[:space:]]*"//; s/"$//'
+}
+
+# Marks the doc this run published, so the read-back is checking our own bytes
+# rather than any doc happening to be there.
+MARKER="updoc-smoke-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+cat >"$WORK/push.json" <<EOF
+{"title":"updoc smoke check $MARKER",
+ "html":"<!doctype html><html lang=en><head><meta charset=utf-8><title>smoke</title></head><body><p>$MARKER</p></body></html>"}
+EOF
+
+printf 'smoke: %s\n\n' "$BASE_URL"
+
+public_request "$BASE_URL/health"
+expect_status 200 "GET /health"
+
+api_request POST "$BASE_URL/api/v1/docs" \
+  -H 'content-type: application/json' \
+  --data-binary "@$WORK/push.json"
+expect_status 201 "POST /api/v1/docs"
+
+DOC_ID=$(json_string docId)
+DOC_URL=$(json_string url)
+[ -n "$DOC_ID" ] || fail "push response carried no docId"
+[ -n "$DOC_URL" ] || fail "push response carried no url"
+printf '      docId %s\n      url   %s\n' "$DOC_ID" "$DOC_URL"
+
+public_request "$DOC_URL"
+expect_status 200 "GET $DOC_URL"
+expect_body "$MARKER" "the page serves the bytes that were pushed"
+expect_body "Shared with updoc" "the page carries the updoc footer"
+
+api_request GET "$BASE_URL/api/v1/docs?limit=100"
+expect_status 200 "GET /api/v1/docs"
+expect_body "$DOC_ID" "the new doc appears in the publisher's list"
+
+api_request DELETE "$BASE_URL/api/v1/docs/$DOC_ID"
+expect_status 204 "DELETE /api/v1/docs/$DOC_ID"
+
+public_request "$DOC_URL"
+expect_status 410 "GET $DOC_URL after delete"
+
+printf '\nsmoke: all steps passed\n'

--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -1,0 +1,228 @@
+/**
+ * Manage: `DELETE /api/v1/docs/{docId}` withdraws a doc, `GET /api/v1/docs`
+ * lists the ones a publisher still holds (D8).
+ *
+ * Delete is the reason this file exists. Accidentally sharing the wrong note is
+ * the single most likely support request, so the fix has to be a call the client
+ * can make rather than a script someone runs for you — and it has to be
+ * immediate, which means dropping the bytes, not just hiding the row.
+ *
+ * The two halves of a delete are deliberately asymmetric: the D1 row is marked
+ * deleted and kept forever, while the R2 objects are destroyed. The row is what
+ * lets `/d/{docId}` answer 410 instead of 404 (phase 4), which is the difference
+ * between a reader learning the doc was withdrawn and a reader concluding they
+ * mistyped the link. It costs a few dozen bytes; the content, which is the part
+ * that actually had to disappear, is gone.
+ */
+import type { Publisher } from "../auth.js";
+import type { Env } from "../config.js";
+import { listPublisherDocs, softDeleteDoc, type DocListCursor, type DocListRow } from "../db.js";
+import { docNotFound, errorResponse } from "../errors.js";
+import { isDocId } from "../ids.js";
+import { docObjectPrefix } from "../storage.js";
+import { publicDocUrl } from "../urls.js";
+
+/** Docs per page when the caller names no `limit`. */
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Ceiling on `limit`. Not a politeness limit: every row costs a `versions`
+ * lookup and a url, and an unbounded page would let one request walk a
+ * publisher's entire 500-doc shelf in one D1 query.
+ */
+const MAX_LIMIT = 100;
+
+/** R2 caps both a list page and a bulk delete at 1000 keys. */
+const OBJECT_BATCH = 1000;
+
+/**
+ * Destroy every object under the doc's prefix.
+ *
+ * The prefix is the source of truth here, not the `versions` rows: R2 is the
+ * system of record, and a push that wrote an object and died before its row
+ * would leave bytes behind that a row-driven delete would silently miss. A doc
+ * can hold more than a page of versions — 100 pushes a day compounds — so this
+ * pages rather than assuming one listing covers it.
+ */
+async function deleteDocObjects(env: Env, docId: string): Promise<void> {
+  const prefix = docObjectPrefix(docId);
+  let cursor: string | undefined;
+
+  do {
+    const listing = await env.DOCS.list({ prefix, limit: OBJECT_BATCH, cursor });
+    if (listing.objects.length > 0) {
+      await env.DOCS.delete(listing.objects.map((object) => object.key));
+    }
+    // Cursors are positions in the key order, and everything before this one is
+    // already gone, so resuming from it never revisits a deleted key.
+    cursor = listing.truncated ? listing.cursor : undefined;
+  } while (cursor !== undefined);
+}
+
+/**
+ * Row first, bytes second.
+ *
+ * Marking the row is what stops the doc being served, so it happens before
+ * anything can fail. The other order would leave a doc D1 still calls live with
+ * no bytes behind it — a link that 404s while its publisher is told it is fine
+ * — which is a worse thing to be wrong about.
+ *
+ * A second delete is `docNotFound`, not another 204: an already-deleted doc has
+ * to be indistinguishable from one that never existed. What repeats safely is
+ * the outcome, which is the part a client retrying after a timeout cares about
+ * — the doc is deleted, its bytes are gone, and a second call changes nothing.
+ */
+export async function deleteDoc(
+  env: Env,
+  publisher: Publisher,
+  docId: string,
+): Promise<Response> {
+  // An id that cannot exist is answered without touching D1.
+  if (!isDocId(docId)) return docNotFound(docId);
+
+  if (!(await softDeleteDoc(env.DB, docId, publisher.id, Date.now()))) {
+    return docNotFound(docId);
+  }
+
+  try {
+    await deleteDocObjects(env, docId);
+  } catch (error) {
+    // Past this point the doc is withdrawn from every reader whatever R2 does,
+    // so answering anything but 204 would be a lie in the direction that costs
+    // the most: the publisher is told their unshare failed, and the retry they
+    // make answers 404 because the row is already marked. The failure costs
+    // orphaned objects instead — storage, not exposure, since nothing can reach
+    // them once the row says deleted — and this log is what makes them findable.
+    console.error("delete left objects behind", { docId, error });
+  }
+  return new Response(null, { status: 204 });
+}
+
+/** One doc as the list reports it. `updatedAt` is epoch ms, like every time here. */
+interface ListedDoc {
+  docId: string;
+  title: string;
+  url: string;
+  /**
+   * Latest version with bytes, or null for a doc whose first push died between
+   * creating the row and writing the object. Such a doc is listed rather than
+   * hidden: it still counts against the 500-doc ceiling, so the publisher needs
+   * its id to be able to delete it.
+   */
+  version: number | null;
+  updatedAt: number;
+}
+
+interface ListResponse {
+  docs: ListedDoc[];
+  /** Present only when another page exists. Opaque: pass it back unchanged. */
+  cursor?: string;
+}
+
+function base64UrlEncode(value: string): string {
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(value: string): string | null {
+  try {
+    return atob(value.replaceAll("-", "+").replaceAll("_", "/"));
+  } catch {
+    return null;
+  }
+}
+
+/** `{created_at}.{docId}` — the two columns the index scan orders by. */
+const CURSOR_PATTERN = /^([0-9]{1,15})\.([0-9a-z]+)$/;
+
+/**
+ * The cursor is base64url over the resume point rather than the raw columns,
+ * because it is a position in a scan, not a fact about a doc: encoding it says
+ * so, and leaves us free to change what a page resumes on without clients
+ * having built a parser for it.
+ */
+function encodeCursor(row: DocListRow): string {
+  return base64UrlEncode(`${row.created_at}.${row.id}`);
+}
+
+/**
+ * Null for anything this API did not issue. Every field is re-validated rather
+ * than trusted: the cursor arrives from the client, and it is bound straight
+ * into a comparison, so a timestamp has to be a real integer and an id has to be
+ * a real id before either goes near D1.
+ */
+function decodeCursor(raw: string): DocListCursor | null {
+  const decoded = base64UrlDecode(raw);
+  if (decoded === null) return null;
+
+  const match = CURSOR_PATTERN.exec(decoded);
+  if (match === null) return null;
+
+  const [, createdAt = "", id = ""] = match;
+  if (!isDocId(id)) return null;
+
+  const created_at = Number(createdAt);
+  return Number.isSafeInteger(created_at) ? { created_at, id } : null;
+}
+
+/** The requested page size, or null when the caller sent something that is not one. */
+function parseLimit(raw: string | null): number | null {
+  if (raw === null) return DEFAULT_LIMIT;
+  // Digits only, so `10.5`, `1e2`, ` 10` and `-1` are rejected rather than
+  // quietly coerced into a page size the caller did not ask for.
+  if (!/^[0-9]{1,3}$/.test(raw)) return null;
+
+  const limit = Number(raw);
+  return limit >= 1 && limit <= MAX_LIMIT ? limit : null;
+}
+
+/**
+ * `GET /api/v1/docs?limit&cursor` — this publisher's live docs, newest first.
+ *
+ * Newest by creation, which is the order the partial index is built in and the
+ * only order a keyset cursor can walk safely: a doc re-pushed mid-walk would
+ * move under an `updated_at` ordering and be seen twice or not at all.
+ *
+ * One row beyond the page is fetched to decide whether there is another page.
+ * The alternative — always returning a cursor and letting the caller discover
+ * the end with an empty page — costs every client one extra round trip.
+ */
+export async function listDocs(
+  requestUrl: URL,
+  env: Env,
+  publisher: Publisher,
+): Promise<Response> {
+  const limit = parseLimit(requestUrl.searchParams.get("limit"));
+  if (limit === null) {
+    return errorResponse(
+      "bad_request",
+      `\`limit\` must be a whole number between 1 and ${MAX_LIMIT}.`,
+    );
+  }
+
+  const rawCursor = requestUrl.searchParams.get("cursor");
+  const after = rawCursor === null ? null : decodeCursor(rawCursor);
+  if (rawCursor !== null && after === null) {
+    return errorResponse(
+      "bad_request",
+      "`cursor` must be a cursor from a previous list response.",
+    );
+  }
+
+  const rows = await listPublisherDocs(env.DB, publisher.id, after, limit + 1);
+  const page = rows.slice(0, limit);
+
+  const body: ListResponse = {
+    docs: page.map((row) => ({
+      docId: row.id,
+      title: row.title,
+      url: publicDocUrl(env, requestUrl, row.id),
+      version: row.version,
+      updatedAt: row.updated_at,
+    })),
+  };
+
+  const last = rows.length > limit ? page.at(-1) : undefined;
+  if (last !== undefined) body.cursor = encodeCursor(last);
+
+  return Response.json(body);
+}

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -1,0 +1,235 @@
+/**
+ * Push: `POST /api/v1/docs` mints a doc, `PUT /api/v1/docs/{docId}` mints the
+ * next version of one (D4). Both are the same three steps once the request is
+ * validated — reserve a version number, write the bytes, record the version.
+ *
+ * That order is load-bearing. The reservation is what makes the R2 key unique,
+ * so it comes first; the object is written before the row that names it, so a
+ * version row always has bytes behind it. A crash between the reservation and
+ * the write burns a version number, which is the deliberate trade: version
+ * numbers are cheap and immutability is not negotiable.
+ *
+ * On the create path the `docs` insert *is* the reservation, so the same crash
+ * burns a doc slot rather than a version number: a doc row with no versions and
+ * no bytes, unreachable because its id was never returned, still counting
+ * against the 500-doc ceiling. Only an R2 or D1 failure produces one, and the
+ * alternative — inserting the row after the write — would hand out a url before
+ * anything pointed at it. Rolling the row back is deliberately not attempted:
+ * the failure may equally be the version insert *after* a successful write, and
+ * a rollback there would strand the object it names.
+ */
+import type { Publisher } from "../auth.js";
+import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
+import type { Env } from "../config.js";
+import { FIRST_VERSION, insertDoc, insertVersion, ownsLiveDoc, reserveNextVersion } from "../db.js";
+import { errorResponse } from "../errors.js";
+import { isDocId, newDocId } from "../ids.js";
+import {
+  liveDocCount,
+  MAX_REQUEST_BYTES,
+  readBodyWithin,
+  reserveDailyPush,
+  utcDay,
+  utf8Length,
+} from "../quota.js";
+import { bakeServedHtml } from "../render.js";
+import { STORED_CONTENT_TYPE, versionObjectKey } from "../storage.js";
+import { publicDocUrl } from "../urls.js";
+
+/** Titles are display strings in a list, not documents; long ones are noise. */
+const MAX_TITLE_LENGTH = 512;
+
+/** A push with no usable title still publishes. Naming is not a gate. */
+const DEFAULT_TITLE = "Untitled";
+
+interface PushBody {
+  /** Null when the push carried no usable title. */
+  title: string | null;
+  html: string;
+}
+
+type ParsedPush = { ok: true; body: PushBody } | { ok: false; response: Response };
+
+/**
+ * 404 for a doc that does not exist, is not this publisher's, or was deleted.
+ *
+ * One message for all three on purpose: a 403 on someone else's doc would
+ * confirm that the id is real, which turns the id space into something worth
+ * probing. The id is echoed only because the caller supplied it.
+ */
+function noSuchDoc(docId: string): Response {
+  return errorResponse("not_found", `No doc with id ${docId}.`);
+}
+
+function tooLarge(message: string): Response {
+  return errorResponse("too_large", message);
+}
+
+function badRequest(message: string): Response {
+  return errorResponse("bad_request", message);
+}
+
+/** Trimmed and capped, or null when there is nothing worth storing. */
+function normalizeTitle(raw: string): string | null {
+  const title = raw.trim().slice(0, MAX_TITLE_LENGTH);
+  return title.length > 0 ? title : null;
+}
+
+/**
+ * Parse and vet `{title?, html}` (D13).
+ *
+ * Size is checked twice against two different ceilings: the request as a whole
+ * while it streams in, so an oversized push costs no memory, and then the
+ * `html` field itself, which is what D10's 10MB actually governs.
+ */
+async function parsePushBody(request: Request): Promise<ParsedPush> {
+  const raw = await readBodyWithin(request, MAX_REQUEST_BYTES);
+  if (raw === null) {
+    return { ok: false, response: tooLarge("That push is too large to accept.") };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(raw));
+  } catch {
+    return { ok: false, response: badRequest("Body must be JSON.") };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, response: badRequest("Body must be a JSON object.") };
+  }
+
+  const { html, title } = parsed as Record<string, unknown>;
+
+  // HTML only, and only from the client (D5). There is no markdown branch to
+  // fall back to, so an empty or absent field is a client bug worth surfacing.
+  if (typeof html !== "string" || html.length === 0) {
+    return { ok: false, response: badRequest("`html` must be a non-empty string.") };
+  }
+  if (utf8Length(html) > MAX_DOC_BYTES) {
+    return {
+      ok: false,
+      response: tooLarge(`A doc may be at most ${MAX_DOC_BYTES} bytes of HTML.`),
+    };
+  }
+
+  if (title !== undefined && title !== null && typeof title !== "string") {
+    return { ok: false, response: badRequest("`title` must be a string.") };
+  }
+
+  return {
+    ok: true,
+    body: { title: typeof title === "string" ? normalizeTitle(title) : null, html },
+  };
+}
+
+function dailyQuotaExceeded(): Response {
+  return errorResponse(
+    "quota_exceeded",
+    `You have used all ${MAX_PUSHES_PER_DAY} of today's pushes. Try again tomorrow (UTC).`,
+  );
+}
+
+/**
+ * Render, store, record — in that order, for the reasons at the top of the file.
+ *
+ * The version number is already reserved by the time this runs, so the key it
+ * writes cannot collide with another push and the object it writes is never
+ * read back or rewritten.
+ */
+async function storeVersion(
+  env: Env,
+  docId: string,
+  version: number,
+  html: string,
+  atMs: number,
+): Promise<void> {
+  const bytes = await bakeServedHtml(html);
+
+  await env.DOCS.put(versionObjectKey(docId, version), bytes, {
+    httpMetadata: { contentType: STORED_CONTENT_TYPE },
+  });
+
+  await insertVersion(env.DB, {
+    doc_id: docId,
+    n: version,
+    size: bytes.byteLength,
+    created_at: atMs,
+  });
+}
+
+function pushed(env: Env, requestUrl: URL, docId: string, version: number, status: number) {
+  return Response.json(
+    { docId, url: publicDocUrl(env, requestUrl, docId), version },
+    { status },
+  );
+}
+
+export async function createDoc(
+  request: Request,
+  requestUrl: URL,
+  env: Env,
+  publisher: Publisher,
+): Promise<Response> {
+  const parsed = await parsePushBody(request);
+  if (!parsed.ok) return parsed.response;
+
+  const now = Date.now();
+
+  // Doc count before the daily counter, so a publisher who is out of room does
+  // not also lose a push from today's allowance for a doc that was never made.
+  if ((await liveDocCount(env.DB, publisher.id)) >= MAX_DOCS_PER_PUBLISHER) {
+    return errorResponse(
+      "quota_exceeded",
+      `You are holding ${MAX_DOCS_PER_PUBLISHER} docs. Delete one to publish another.`,
+    );
+  }
+  if (!(await reserveDailyPush(env.DB, publisher.id, utcDay(now)))) {
+    return dailyQuotaExceeded();
+  }
+
+  const docId = newDocId();
+  await insertDoc(env.DB, {
+    id: docId,
+    publisher: publisher.id,
+    title: parsed.body.title ?? DEFAULT_TITLE,
+    created_at: now,
+    updated_at: now,
+  });
+
+  await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, now);
+  return pushed(env, requestUrl, docId, FIRST_VERSION, 201);
+}
+
+export async function updateDoc(
+  request: Request,
+  requestUrl: URL,
+  env: Env,
+  publisher: Publisher,
+  docId: string,
+): Promise<Response> {
+  // An id that cannot exist is answered without touching D1.
+  if (!isDocId(docId)) return noSuchDoc(docId);
+
+  const parsed = await parsePushBody(request);
+  if (!parsed.ok) return parsed.response;
+
+  // Ownership before quota: pushing at a doc that is not yours is not a push,
+  // so it must not spend one of today's. `reserveNextVersion` re-checks both
+  // atomically, which is what actually guarantees it — this read only fixes
+  // which error a rejected push gets.
+  if (!(await ownsLiveDoc(env.DB, docId, publisher.id))) {
+    return noSuchDoc(docId);
+  }
+
+  const now = Date.now();
+  if (!(await reserveDailyPush(env.DB, publisher.id, utcDay(now)))) {
+    return dailyQuotaExceeded();
+  }
+
+  const version = await reserveNextVersion(env.DB, docId, publisher.id, parsed.body.title, now);
+  if (version === null) return noSuchDoc(docId);
+
+  await storeVersion(env, docId, version, parsed.body.html, now);
+  return pushed(env, requestUrl, docId, version, 200);
+}

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -239,12 +239,21 @@ export async function createDoc(
     );
   }
 
-  if (!(await reserveDailyPush(env.DB, publisher.id, utcDay(now)))) {
+  const day = utcDay(now);
+  if (!(await reserveDailyPush(env.DB, publisher.id, day))) {
     await deleteDocRow(env.DB, docId);
     return dailyQuotaExceeded();
   }
 
-  await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now);
+  // A create is deletable before it answers: the row is visible to this
+  // publisher's own list the moment it is inserted, so they can delete the doc
+  // while its first version is still being written. Same answer as an update
+  // that loses that race — the doc is gone, and the push is given back rather
+  // than spent on a url that would serve 410.
+  if (!(await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now))) {
+    await refundDailyPush(env.DB, publisher.id, day);
+    return docNotFound(docId);
+  }
   return pushed(env, requestUrl, docId, FIRST_VERSION, 201);
 }
 

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -36,6 +36,7 @@ import { isDocId, newDocId } from "../ids.js";
 import {
   MAX_REQUEST_BYTES,
   readBodyWithin,
+  refundDailyPush,
   reserveDailyPush,
   utcDay,
   utf8Length,
@@ -246,17 +247,25 @@ export async function updateDoc(
   }
 
   const now = Date.now();
-  if (!(await reserveDailyPush(env.DB, publisher.id, utcDay(now)))) {
+  const day = utcDay(now);
+  if (!(await reserveDailyPush(env.DB, publisher.id, day))) {
     return dailyQuotaExceeded();
   }
 
+  // Past this point the push is paid for, and a delete can still land at either
+  // of the two steps below. Both give the push back: a rejected push costs the
+  // caller nothing, which is the same promise the ownership check above makes.
   const version = await reserveNextVersion(env.DB, docId, publisher.id, parsed.body.title, now);
-  if (version === null) return docNotFound(docId);
+  if (version === null) {
+    await refundDailyPush(env.DB, publisher.id, day);
+    return docNotFound(docId);
+  }
 
   // The doc can still be deleted while this version is being written. Answering
   // 200 would hand back a url that serves 410, so a lost race reads as what it
   // is from the caller's side: the doc is gone.
   if (!(await storeVersion(env, docId, version, parsed.body.html, now))) {
+    await refundDailyPush(env.DB, publisher.id, day);
     return docNotFound(docId);
   }
   return pushed(env, requestUrl, docId, version, 200);

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -24,6 +24,7 @@ import type { Env } from "../config.js";
 import {
   deleteDocRow,
   deleteVersionRow,
+  commitVersionMetadata,
   docIsDeleted,
   FIRST_VERSION,
   insertDocWithinQuota,
@@ -255,7 +256,7 @@ export async function updateDoc(
   // Past this point the push is paid for, and a delete can still land at either
   // of the two steps below. Both give the push back: a rejected push costs the
   // caller nothing, which is the same promise the ownership check above makes.
-  const version = await reserveNextVersion(env.DB, docId, publisher.id, parsed.body.title, now);
+  const version = await reserveNextVersion(env.DB, docId, publisher.id);
   if (version === null) {
     await refundDailyPush(env.DB, publisher.id, day);
     return docNotFound(docId);
@@ -268,5 +269,9 @@ export async function updateDoc(
     await refundDailyPush(env.DB, publisher.id, day);
     return docNotFound(docId);
   }
+
+  // Only now: the title and timestamp in "my docs" describe what the public url
+  // is serving, so they move after the bytes do, never before.
+  await commitVersionMetadata(env.DB, docId, parsed.body.title, now);
   return pushed(env, requestUrl, docId, version, 200);
 }

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -21,11 +21,19 @@
 import type { Publisher } from "../auth.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
 import type { Env } from "../config.js";
-import { FIRST_VERSION, insertDoc, insertVersion, ownsLiveDoc, reserveNextVersion } from "../db.js";
+import {
+  deleteDocRow,
+  deleteVersionRow,
+  docIsDeleted,
+  FIRST_VERSION,
+  insertDocWithinQuota,
+  insertVersion,
+  ownsLiveDoc,
+  reserveNextVersion,
+} from "../db.js";
 import { docNotFound, errorResponse } from "../errors.js";
 import { isDocId, newDocId } from "../ids.js";
 import {
-  liveDocCount,
   MAX_REQUEST_BYTES,
   readBodyWithin,
   reserveDailyPush,
@@ -123,6 +131,9 @@ function dailyQuotaExceeded(): Response {
  * The version number is already reserved by the time this runs, so the key it
  * writes cannot collide with another push and the object it writes is never
  * read back or rewritten.
+ *
+ * Returns false when a concurrent delete won the race and this version was
+ * rolled back; see below.
  */
 async function storeVersion(
   env: Env,
@@ -130,10 +141,11 @@ async function storeVersion(
   version: number,
   html: string,
   atMs: number,
-): Promise<void> {
+): Promise<boolean> {
   const bytes = await bakeServedHtml(html);
+  const key = versionObjectKey(docId, version);
 
-  await env.DOCS.put(versionObjectKey(docId, version), bytes, {
+  await env.DOCS.put(key, bytes, {
     httpMetadata: { contentType: STORED_CONTENT_TYPE },
   });
 
@@ -143,6 +155,22 @@ async function storeVersion(
     size: bytes.byteLength,
     created_at: atMs,
   });
+
+  // A delete that lands between the version reservation and this write has
+  // already finished its prefix scan, so it never saw these bytes: unshare
+  // would report success while leaving content in the bucket. There is no lock
+  // to take — v0 has no per-doc coordinator on purpose (D7) — so the write
+  // compensates for itself. Losing the race means undoing it, not preventing it.
+  //
+  // The version row goes with the object it named. The doc row is untouched,
+  // which is what keeps the deleted url answering 410 rather than 404.
+  if (await docIsDeleted(env.DB, docId)) {
+    await env.DOCS.delete(key);
+    await deleteVersionRow(env.DB, docId, version);
+    return false;
+  }
+
+  return true;
 }
 
 function pushed(env: Env, requestUrl: URL, docId: string, version: number, status: number) {
@@ -163,26 +191,34 @@ export async function createDoc(
 
   const now = Date.now();
 
-  // Doc count before the daily counter, so a publisher who is out of room does
+  // Capacity before the daily counter, so a publisher who is out of room does
   // not also lose a push from today's allowance for a doc that was never made.
-  if ((await liveDocCount(env.DB, publisher.id)) >= MAX_DOCS_PER_PUBLISHER) {
+  // The check lives inside the insert: counting first and inserting after would
+  // let concurrent creates all read the same count and all proceed, so the
+  // documented ceiling would hold only for callers who push one at a time.
+  const docId = newDocId();
+  const inserted = await insertDocWithinQuota(
+    env.DB,
+    {
+      id: docId,
+      publisher: publisher.id,
+      title: parsed.body.title ?? DEFAULT_TITLE,
+      created_at: now,
+      updated_at: now,
+    },
+    MAX_DOCS_PER_PUBLISHER,
+  );
+  if (!inserted) {
     return errorResponse(
       "quota_exceeded",
       `You are holding ${MAX_DOCS_PER_PUBLISHER} docs. Delete one to publish another.`,
     );
   }
+
   if (!(await reserveDailyPush(env.DB, publisher.id, utcDay(now)))) {
+    await deleteDocRow(env.DB, docId);
     return dailyQuotaExceeded();
   }
-
-  const docId = newDocId();
-  await insertDoc(env.DB, {
-    id: docId,
-    publisher: publisher.id,
-    title: parsed.body.title ?? DEFAULT_TITLE,
-    created_at: now,
-    updated_at: now,
-  });
 
   await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, now);
   return pushed(env, requestUrl, docId, FIRST_VERSION, 201);
@@ -217,6 +253,11 @@ export async function updateDoc(
   const version = await reserveNextVersion(env.DB, docId, publisher.id, parsed.body.title, now);
   if (version === null) return docNotFound(docId);
 
-  await storeVersion(env, docId, version, parsed.body.html, now);
+  // The doc can still be deleted while this version is being written. Answering
+  // 200 would hand back a url that serves 410, so a lost race reads as what it
+  // is from the caller's side: the doc is gone.
+  if (!(await storeVersion(env, docId, version, parsed.body.html, now))) {
+    return docNotFound(docId);
+  }
   return pushed(env, requestUrl, docId, version, 200);
 }

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -22,7 +22,7 @@ import type { Publisher } from "../auth.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
 import type { Env } from "../config.js";
 import { FIRST_VERSION, insertDoc, insertVersion, ownsLiveDoc, reserveNextVersion } from "../db.js";
-import { errorResponse } from "../errors.js";
+import { docNotFound, errorResponse } from "../errors.js";
 import { isDocId, newDocId } from "../ids.js";
 import {
   liveDocCount,
@@ -50,25 +50,6 @@ interface PushBody {
 
 type ParsedPush = { ok: true; body: PushBody } | { ok: false; response: Response };
 
-/**
- * 404 for a doc that does not exist, is not this publisher's, or was deleted.
- *
- * One message for all three on purpose: a 403 on someone else's doc would
- * confirm that the id is real, which turns the id space into something worth
- * probing. The id is echoed only because the caller supplied it.
- */
-function noSuchDoc(docId: string): Response {
-  return errorResponse("not_found", `No doc with id ${docId}.`);
-}
-
-function tooLarge(message: string): Response {
-  return errorResponse("too_large", message);
-}
-
-function badRequest(message: string): Response {
-  return errorResponse("bad_request", message);
-}
-
 /** Trimmed and capped, or null when there is nothing worth storing. */
 function normalizeTitle(raw: string): string | null {
   const title = raw.trim().slice(0, MAX_TITLE_LENGTH);
@@ -85,18 +66,21 @@ function normalizeTitle(raw: string): string | null {
 async function parsePushBody(request: Request): Promise<ParsedPush> {
   const raw = await readBodyWithin(request, MAX_REQUEST_BYTES);
   if (raw === null) {
-    return { ok: false, response: tooLarge("That push is too large to accept.") };
+    return {
+      ok: false,
+      response: errorResponse("too_large", "That push is too large to accept."),
+    };
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(new TextDecoder().decode(raw));
   } catch {
-    return { ok: false, response: badRequest("Body must be JSON.") };
+    return { ok: false, response: errorResponse("bad_request", "Body must be JSON.") };
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return { ok: false, response: badRequest("Body must be a JSON object.") };
+    return { ok: false, response: errorResponse("bad_request", "Body must be a JSON object.") };
   }
 
   const { html, title } = parsed as Record<string, unknown>;
@@ -104,17 +88,20 @@ async function parsePushBody(request: Request): Promise<ParsedPush> {
   // HTML only, and only from the client (D5). There is no markdown branch to
   // fall back to, so an empty or absent field is a client bug worth surfacing.
   if (typeof html !== "string" || html.length === 0) {
-    return { ok: false, response: badRequest("`html` must be a non-empty string.") };
+    return {
+      ok: false,
+      response: errorResponse("bad_request", "`html` must be a non-empty string."),
+    };
   }
   if (utf8Length(html) > MAX_DOC_BYTES) {
     return {
       ok: false,
-      response: tooLarge(`A doc may be at most ${MAX_DOC_BYTES} bytes of HTML.`),
+      response: errorResponse("too_large", `A doc may be at most ${MAX_DOC_BYTES} bytes of HTML.`),
     };
   }
 
   if (title !== undefined && title !== null && typeof title !== "string") {
-    return { ok: false, response: badRequest("`title` must be a string.") };
+    return { ok: false, response: errorResponse("bad_request", "`title` must be a string.") };
   }
 
   return {
@@ -209,7 +196,7 @@ export async function updateDoc(
   docId: string,
 ): Promise<Response> {
   // An id that cannot exist is answered without touching D1.
-  if (!isDocId(docId)) return noSuchDoc(docId);
+  if (!isDocId(docId)) return docNotFound(docId);
 
   const parsed = await parsePushBody(request);
   if (!parsed.ok) return parsed.response;
@@ -219,7 +206,7 @@ export async function updateDoc(
   // atomically, which is what actually guarantees it — this read only fixes
   // which error a rejected push gets.
   if (!(await ownsLiveDoc(env.DB, docId, publisher.id))) {
-    return noSuchDoc(docId);
+    return docNotFound(docId);
   }
 
   const now = Date.now();
@@ -228,7 +215,7 @@ export async function updateDoc(
   }
 
   const version = await reserveNextVersion(env.DB, docId, publisher.id, parsed.body.title, now);
-  if (version === null) return noSuchDoc(docId);
+  if (version === null) return docNotFound(docId);
 
   await storeVersion(env, docId, version, parsed.body.html, now);
   return pushed(env, requestUrl, docId, version, 200);

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -53,8 +53,16 @@ const MAX_TITLE_LENGTH = 512;
 const DEFAULT_TITLE = "Untitled";
 
 interface PushBody {
-  /** Null when the push carried no usable title. */
-  title: string | null;
+  /**
+   * The title the push asked for: a string, `null` when the field was present
+   * but blank, and `undefined` when it was absent.
+   *
+   * Those last two are kept apart on purpose. Absence is the only signal that
+   * means "keep the doc's current title"; a blank string is not a title, and
+   * becomes `Untitled` on create and update alike. Collapsing them would make
+   * `""` mean one thing to POST and another to PUT.
+   */
+  title: string | null | undefined;
   html: string;
 }
 
@@ -93,7 +101,10 @@ async function parsePushBody(request: Request): Promise<ParsedPush> {
     return { ok: false, response: errorResponse("bad_request", "Body must be a JSON object.") };
   }
 
-  const { html, title } = parsed as Record<string, unknown>;
+  const fields = parsed as Record<string, unknown>;
+  const { html } = fields;
+  const titleGiven = "title" in fields;
+  const title = fields.title;
 
   // HTML only, and only from the client (D5). There is no markdown branch to
   // fall back to, so an empty or absent field is a client bug worth surfacing.
@@ -116,7 +127,11 @@ async function parsePushBody(request: Request): Promise<ParsedPush> {
 
   return {
     ok: true,
-    body: { title: typeof title === "string" ? normalizeTitle(title) : null, html },
+    body: {
+      // `null` for a present-but-blank title, `undefined` for an absent one.
+      title: titleGiven ? (typeof title === "string" ? normalizeTitle(title) : null) : undefined,
+      html,
+    },
   };
 }
 
@@ -272,6 +287,8 @@ export async function updateDoc(
 
   // Only now: the title and timestamp in "my docs" describe what the public url
   // is serving, so they move after the bytes do, never before.
-  await commitVersionMetadata(env.DB, docId, parsed.body.title, now);
+  // Absent title keeps the current one; a blank one resets it, same as on create.
+  const title = parsed.body.title === undefined ? null : (parsed.body.title ?? DEFAULT_TITLE);
+  await commitVersionMetadata(env.DB, docId, version, title, now);
   return pushed(env, requestUrl, docId, version, 200);
 }

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -157,6 +157,7 @@ async function storeVersion(
   docId: string,
   version: number,
   html: string,
+  title: string | null,
   atMs: number,
 ): Promise<boolean> {
   const bytes = await bakeServedHtml(html);
@@ -170,6 +171,9 @@ async function storeVersion(
     doc_id: docId,
     n: version,
     size: bytes.byteLength,
+    // What this push asked the doc to be called. Null means it asked for
+    // nothing, which is how the doc's title survives a push that omits one.
+    title,
     created_at: atMs,
   });
 
@@ -207,6 +211,9 @@ export async function createDoc(
   if (!parsed.ok) return parsed.response;
 
   const now = Date.now();
+  // A create always names the doc something: absent and blank alike land on the
+  // default rather than leaving it nameless in the list.
+  const title = parsed.body.title ?? DEFAULT_TITLE;
 
   // Capacity before the daily counter, so a publisher who is out of room does
   // not also lose a push from today's allowance for a doc that was never made.
@@ -219,7 +226,7 @@ export async function createDoc(
     {
       id: docId,
       publisher: publisher.id,
-      title: parsed.body.title ?? DEFAULT_TITLE,
+      title,
       created_at: now,
       updated_at: now,
     },
@@ -237,7 +244,7 @@ export async function createDoc(
     return dailyQuotaExceeded();
   }
 
-  await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, now);
+  await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now);
   return pushed(env, requestUrl, docId, FIRST_VERSION, 201);
 }
 
@@ -277,18 +284,21 @@ export async function updateDoc(
     return docNotFound(docId);
   }
 
+  // Absent title keeps the doc's current one; a blank one resets it, same as on
+  // create. The version row records which of those this push asked for, so the
+  // doc's title resolves by version number rather than by commit order.
+  const title = parsed.body.title === undefined ? null : (parsed.body.title ?? DEFAULT_TITLE);
+
   // The doc can still be deleted while this version is being written. Answering
   // 200 would hand back a url that serves 410, so a lost race reads as what it
   // is from the caller's side: the doc is gone.
-  if (!(await storeVersion(env, docId, version, parsed.body.html, now))) {
+  if (!(await storeVersion(env, docId, version, parsed.body.html, title, now))) {
     await refundDailyPush(env.DB, publisher.id, day);
     return docNotFound(docId);
   }
 
   // Only now: the title and timestamp in "my docs" describe what the public url
   // is serving, so they move after the bytes do, never before.
-  // Absent title keeps the current one; a blank one resets it, same as on create.
-  const title = parsed.body.title === undefined ? null : (parsed.body.title ?? DEFAULT_TITLE);
-  await commitVersionMetadata(env.DB, docId, version, title, now);
+  await commitVersionMetadata(env.DB, docId, version, now);
   return pushed(env, requestUrl, docId, version, 200);
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -82,7 +82,8 @@ export async function authenticateRequest(
       message: "Expected an Authorization: Bearer <license key> header.",
     };
   }
-  return resolvePublisher(token, env, deps);
+  // `return await`: see the note on the router's catch in index.ts.
+  return await resolvePublisher(token, env, deps);
 }
 
 export async function resolvePublisher(

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,248 @@
+/**
+ * Publisher authentication.
+ *
+ * A publisher is a Copilot Plus license key, and the only identifier the rest of
+ * the system ever sees is that key's SHA-256 (D2). The raw key exists inside this
+ * module for exactly as long as it takes to hash it and hand it to the license
+ * server — it is never stored, logged, or returned, not even a prefix of it.
+ * Everything downstream depends on `Publisher.id`, so swapping in a free-tier
+ * identity later means adding a branch here and touching nothing else.
+ *
+ * Validation is cached for an hour in the `publishers` row. The cache is also the
+ * outage story: if the license server is unreachable but this key has validated
+ * before, the push is allowed. A key that has never validated cannot publish
+ * during an outage, which is the accepted trade (see the plan's risks).
+ *
+ * The fallback covers outages only, never rejections. A key the server actively
+ * refuses is denied even when it has a warm cache row — otherwise revoking a key
+ * would never take effect, since the fallback would re-admit it on every request.
+ */
+import { LICENSE_CACHE_TTL_MS, type Env } from "./config.js";
+import { d1PublisherStore, type PublisherStore } from "./db.js";
+import { errorResponse, type ErrorCode } from "./errors.js";
+
+/** tRPC endpoint on the license server, appended to `LICENSE_API_URL`. */
+const VALIDATE_PATH = "/api/trpc/license.validateLicenseKey";
+
+/**
+ * The license server sits in the push path, so a hung connection must fail
+ * rather than hold the request open until the worker's own limit kills it: a
+ * timeout here lands on the cached-validation fallback, a worker timeout does not.
+ */
+const LICENSE_TIMEOUT_MS = 5_000;
+
+/** Plan recorded when the license server validates a key but names no plan. */
+const UNKNOWN_PLAN = "unknown";
+
+export interface Publisher {
+  /** SHA-256 hex of the license key. The only publisher identity in the system. */
+  id: string;
+  plan: string;
+}
+
+export type PublisherFailure =
+  /** No usable `Authorization: Bearer <key>` header on the request. */
+  | "missing_credentials"
+  /** The license server answered, and the answer was no. */
+  | "invalid_license"
+  /** The license server could not answer and this key has no cached validation. */
+  | "license_unavailable";
+
+export type PublisherResolution =
+  | { ok: true; publisher: Publisher }
+  | { ok: false; reason: PublisherFailure; message: string };
+
+export interface AuthDeps {
+  /** Injected by tests so they never touch the network. */
+  fetch?: typeof fetch;
+  now?: () => number;
+  store?: PublisherStore;
+}
+
+/**
+ * `Bearer <token>`, scheme-insensitive per RFC 7235. Anything else — no header,
+ * another scheme, an empty token — is no credential at all.
+ */
+export function parseBearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = /^Bearer[ \t]+(\S+)$/i.exec(header.trim());
+  return match?.[1] ?? null;
+}
+
+export async function authenticateRequest(
+  request: Request,
+  env: Env,
+  deps: AuthDeps = {},
+): Promise<PublisherResolution> {
+  const token = parseBearerToken(request.headers.get("authorization"));
+  if (token === null) {
+    return {
+      ok: false,
+      reason: "missing_credentials",
+      message: "Expected an Authorization: Bearer <license key> header.",
+    };
+  }
+  return resolvePublisher(token, env, deps);
+}
+
+export async function resolvePublisher(
+  token: string,
+  env: Env,
+  deps: AuthDeps = {},
+): Promise<PublisherResolution> {
+  const now = deps.now ?? Date.now;
+  const store = deps.store ?? d1PublisherStore(env.DB);
+
+  const id = await sha256Hex(token);
+  const cached = await store.read(id);
+  const checkedAt = now();
+
+  if (cached && checkedAt - cached.validated_at < LICENSE_CACHE_TTL_MS) {
+    return { ok: true, publisher: { id, plan: cached.plan } };
+  }
+
+  const check = await validateLicense(token, env, deps);
+
+  switch (check.status) {
+    case "valid":
+      await store.save({ key_hash: id, plan: check.plan, validated_at: checkedAt });
+      return { ok: true, publisher: { id, plan: check.plan } };
+
+    case "denied":
+      // Deliberately no row write and no row delete: a previously valid key that
+      // has since lapsed keeps its `publishers` row, because `docs.publisher`
+      // still references it. It just stops resolving.
+      return {
+        ok: false,
+        reason: "invalid_license",
+        message: "That license key is not valid for publishing.",
+      };
+
+    case "unreachable":
+      if (cached) {
+        // Stale but real. An outage must not lock out a publisher who has
+        // published before.
+        return { ok: true, publisher: { id, plan: cached.plan } };
+      }
+      return {
+        ok: false,
+        reason: "license_unavailable",
+        message: "License validation is temporarily unavailable. Please try again shortly.",
+      };
+  }
+}
+
+const FAILURE_STATUS: Record<PublisherFailure, ErrorCode> = {
+  missing_credentials: "unauthorized",
+  invalid_license: "unauthorized",
+  // Not the caller's fault and not a credential problem: telling Copilot 401
+  // here would make it prompt for a key that is perfectly good.
+  license_unavailable: "internal",
+};
+
+export function publisherErrorResponse(failure: {
+  reason: PublisherFailure;
+  message: string;
+}): Response {
+  const code = FAILURE_STATUS[failure.reason];
+  const headers = code === "unauthorized" ? { "www-authenticate": "Bearer" } : undefined;
+  return errorResponse(code, failure.message, headers);
+}
+
+type LicenseCheck =
+  | { status: "valid"; plan: string }
+  | { status: "denied" }
+  | { status: "unreachable" };
+
+/** Only an explicit verdict from the license server can deny a key. */
+const UNREACHABLE: LicenseCheck = { status: "unreachable" };
+
+/**
+ * The tRPC error code that is a verdict on the publisher's key rather than a
+ * fault on our side.
+ *
+ * `license.validateLicenseKey` throws `TRPCError NOT_FOUND` when the key is
+ * absent or deleted, and that is the *only* way it reports a bad key: every
+ * success path returns `isValid: true`, so `isValid: false` never arrives from
+ * this server. Its own route handler logs exactly this code as a warning rather
+ * than an error, which is what marks it a routine verdict instead of a fault.
+ * brevilabs-api's `license_service.py` reaches the same conclusion, answering
+ * 403 on any error envelope.
+ *
+ * Every other code stays `unreachable` on purpose, which is where we diverge
+ * from that reference: `UNAUTHORIZED` means *our* `LICENSE_API_KEY` is wrong,
+ * and a misconfigured worker must not tell every paying publisher that their
+ * key is bad.
+ */
+const KEY_REJECTED_CODE = "NOT_FOUND";
+
+async function validateLicense(token: string, env: Env, deps: AuthDeps): Promise<LicenseCheck> {
+  const { LICENSE_API_URL, LICENSE_API_KEY } = env;
+  // An unconfigured worker is handled exactly like an outage: cached publishers
+  // keep working, and nothing unvalidated ever gets through.
+  if (!LICENSE_API_URL || !LICENSE_API_KEY) return UNREACHABLE;
+
+  const doFetch = deps.fetch ?? globalThis.fetch.bind(globalThis);
+  const url = `${LICENSE_API_URL.replace(/\/+$/, "")}${VALIDATE_PATH}`;
+
+  let response: Response;
+  try {
+    response = await doFetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        // Our server-side credential, not the publisher's key.
+        authorization: `Bearer ${LICENSE_API_KEY}`,
+      },
+      body: JSON.stringify({ json: { licenseKey: token } }),
+      signal: AbortSignal.timeout(LICENSE_TIMEOUT_MS),
+    });
+  } catch {
+    return UNREACHABLE;
+  }
+
+  // Deliberately no `response.ok` check. tRPC delivers a genuine verdict with a
+  // 4xx status — a rejected key is HTTP 404 carrying a NOT_FOUND envelope — so
+  // the body is the only thing that separates a rejection from an outage. A
+  // status with no tRPC envelope behind it (an HTML 502 from the edge, say)
+  // fails the parse below and lands on `unreachable` anyway.
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return UNREACHABLE;
+  }
+
+  const root = asRecord(body);
+  if (!root) return UNREACHABLE;
+
+  if ("error" in root) {
+    // superjson error envelope: `{error: {json: {data: {code}}}}`.
+    const code = asRecord(asRecord(asRecord(root.error)?.json)?.data)?.code;
+    return code === KEY_REJECTED_CODE ? { status: "denied" } : UNREACHABLE;
+  }
+
+  const payload = asRecord(asRecord(asRecord(root.result)?.data)?.json);
+  if (!payload || typeof payload.isValid !== "boolean") return UNREACHABLE;
+
+  const isValid = payload.isValid;
+  // Older license-server responses omit `backendAccess`; absent means "same as
+  // isValid", so a valid key is not silently denied by a missing field.
+  const backendAccess =
+    typeof payload.backendAccess === "boolean" ? payload.backendAccess : isValid;
+  if (!isValid || !backendAccess) return { status: "denied" };
+
+  // The server plan is an uppercase enum (`PLUS`, `BELIEVER`); store it folded
+  // so nothing downstream has to guess the casing, as the reference does too.
+  const plan = typeof payload.plan === "string" ? payload.plan.toLowerCase() : UNKNOWN_PLAN;
+  return { status: "valid", plan };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,28 @@
+/**
+ * Worker bindings and the quota ceilings from the plan (D10).
+ *
+ * `SERVING_HOST` / `API_HOST` are declared in wrangler.jsonc but left empty in
+ * v0, where everything runs on one workers.dev subdomain and the router falls
+ * back to path prefixes. Setting them later splits the surfaces across the
+ * brand and sacrificial domains without a code change (D3).
+ */
+export interface Env {
+  /** R2 bucket holding the served bytes. System of record. */
+  DOCS: R2Bucket;
+  /** D1 pointer index. Rebuildable from R2; never holds content. */
+  DB: D1Database;
+
+  /** Host that serves public docs. Empty in v0. */
+  SERVING_HOST?: string;
+  /** Host that exposes /api/v1. Empty in v0. */
+  API_HOST?: string;
+}
+
+/** Largest HTML body a single push may carry, before injection. */
+export const MAX_DOC_BYTES = 10 * 1024 * 1024;
+
+/** Pushes a single publisher key may make in one UTC day. */
+export const MAX_PUSHES_PER_DAY = 100;
+
+/** Live (non-deleted) docs a single publisher key may hold. */
+export const MAX_DOCS_PER_PUBLISHER = 500;

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,27 @@ export interface Env {
   SERVING_HOST?: string;
   /** Host that exposes /api/v1. Empty in v0. */
   API_HOST?: string;
+
+  /**
+   * Base url of the Brevilabs license server, e.g. `https://api.brevilabs.com`.
+   * Optional at the type level because it is supplied per environment (.dev.vars
+   * locally, a var/secret once the worker is provisioned) rather than committed;
+   * auth treats it as an outage when unset rather than trusting an unvalidated key.
+   */
+  LICENSE_API_URL?: string;
+  /**
+   * Server-side credential for the license server. This is *ours*, never a
+   * publisher's license key, and the two must never be confused.
+   */
+  LICENSE_API_KEY?: string;
 }
+
+/**
+ * How long a successful license validation is trusted before the license server
+ * is asked again. One hour means steady-state load of one call per publisher per
+ * hour, and it bounds how long a revoked key keeps working.
+ */
+export const LICENSE_CACHE_TTL_MS = 60 * 60 * 1000;
 
 /** Largest HTML body a single push may carry, before injection. */
 export const MAX_DOC_BYTES = 10 * 1024 * 1024;

--- a/src/db.ts
+++ b/src/db.ts
@@ -89,41 +89,25 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
 }
 
 /**
- * Create the `docs` row for a first push, already carrying version 1.
+ * Create the `docs` row for a first push, already carrying version 1 — but only
+ * while this publisher is under `maxDocs` live docs. Returns false at the
+ * ceiling.
  *
  * A freshly minted id is private to this request, so nothing can race for its
  * first version and the insert *is* the reservation — the `UPDATE ... RETURNING`
  * dance below only earns its keep once a doc is reachable by id.
  *
+ * The capacity count is a predicate on that same insert rather than a read
+ * before it, for the reason `reserveNextVersion` exists: a publisher at the
+ * ceiling firing concurrent creates would otherwise have every one of them read
+ * the same count and every one of them insert. A quota documented as a hard
+ * number has to behave like one under the concurrency an agent produces.
+ * `docs_by_publisher_live` covers the subquery, so it is an index scan of only
+ * this publisher's live rows.
+ *
  * `publisher` is a foreign key onto `publishers`, so this fails unless auth has
  * already written that row. That is the intended coupling: no doc without a
  * publisher we validated.
- */
-export async function insertDoc(
-  db: D1Database,
-  doc: Omit<DocRow, "deleted_at" | "latest_version">,
-): Promise<void> {
-  await db
-    .prepare(
-      `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(doc.id, doc.publisher, doc.title, FIRST_VERSION, doc.created_at, doc.updated_at)
-    .run();
-}
-
-/**
- * The same insert, but only while this publisher is under `maxDocs` live docs.
- * Returns false when they are at the ceiling.
- *
- * The count is a predicate on the insert rather than a read before it, for the
- * reason `reserveNextVersion` exists: a publisher at 499 docs firing concurrent
- * creates would otherwise have every one of them read 499 and every one of them
- * insert. A quota documented as a hard number has to behave like one under the
- * concurrency an agent produces.
- *
- * `docs_by_publisher_live` covers the subquery, so the count is an index scan of
- * only this publisher's live rows.
  */
 export async function insertDocWithinQuota(
   db: D1Database,

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,44 @@
+/**
+ * Row types for the D1 pointer index, one per table in 0001_init.sql.
+ *
+ * D1 holds pointers only — ids, sizes, timestamps. The bytes live in R2, and
+ * every row here is reconstructible from it, so a lost D1 is a rebuild rather
+ * than a data loss. Queries land here as the phase that needs them arrives.
+ */
+
+/** Publisher row, which doubles as the license-validation cache (phase 2). */
+export interface PublisherRow {
+  /** SHA-256 of the license key. Raw keys are never stored. */
+  key_hash: string;
+  plan: string;
+  /** Epoch ms of the last successful license-server validation. */
+  validated_at: number;
+}
+
+export interface DocRow {
+  id: string;
+  /** `publishers.key_hash` of the owner. */
+  publisher: string;
+  title: string;
+  /** Highest version number minted; 0 before the first push lands. */
+  latest_version: number;
+  created_at: number;
+  updated_at: number;
+  /** Epoch ms when soft-deleted, else null. Deleted docs serve 410, not 404. */
+  deleted_at: number | null;
+}
+
+export interface VersionRow {
+  doc_id: string;
+  n: number;
+  /** Byte length of the stored R2 object. */
+  size: number;
+  created_at: number;
+}
+
+export interface PushQuotaRow {
+  publisher: string;
+  /** UTC day, `YYYY-MM-DD`. */
+  day: string;
+  pushes: number;
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -20,7 +20,15 @@ export interface DocRow {
   /** `publishers.key_hash` of the owner. */
   publisher: string;
   title: string;
-  /** Highest version number minted; 0 before the first push lands. */
+  /**
+   * Highest version number *reserved*; 0 before the first push lands.
+   *
+   * Reserved, not stored: the number is minted before the R2 object is written,
+   * so a push that dies in between leaves this one above the newest version
+   * that actually has bytes. It is the counter, never the pointer — anything
+   * resolving a doc to bytes must go through `versions`, whose rows are written
+   * after their object and therefore always have one.
+   */
   latest_version: number;
   created_at: number;
   updated_at: number;
@@ -53,6 +61,9 @@ export interface PublisherStore {
   save(row: PublisherRow): Promise<void>;
 }
 
+/** Version numbers start at 1; a `docs` row at 0 has never been pushed to. */
+export const FIRST_VERSION = 1;
+
 export function d1PublisherStore(db: D1Database): PublisherStore {
   return {
     read(keyHash) {
@@ -75,4 +86,103 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
         .run();
     },
   };
+}
+
+/**
+ * Create the `docs` row for a first push, already carrying version 1.
+ *
+ * A freshly minted id is private to this request, so nothing can race for its
+ * first version and the insert *is* the reservation — the `UPDATE ... RETURNING`
+ * dance below only earns its keep once a doc is reachable by id.
+ *
+ * `publisher` is a foreign key onto `publishers`, so this fails unless auth has
+ * already written that row. That is the intended coupling: no doc without a
+ * publisher we validated.
+ */
+export async function insertDoc(
+  db: D1Database,
+  doc: Omit<DocRow, "deleted_at" | "latest_version">,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(doc.id, doc.publisher, doc.title, FIRST_VERSION, doc.created_at, doc.updated_at)
+    .run();
+}
+
+/**
+ * Mint the next version number for a doc, or null if this publisher has no such
+ * doc to push to.
+ *
+ * The whole coordination story of v0 is this one statement (D7). Incrementing
+ * and reading back in a single write means two concurrent pushes to the same
+ * doc get 2 and 3, never 2 and 2 — which matters because the number is an R2
+ * key, and two pushes sharing a key would mean one overwriting the other's
+ * immutable bytes.
+ *
+ * Ownership and liveness are predicates on that same statement rather than an
+ * earlier read, so a doc deleted or transferred in between cannot slip through.
+ * Null covers "no such doc", "not yours" and "deleted" alike: the caller must
+ * answer all three with 404, because distinguishing them would confirm that
+ * another publisher's doc exists.
+ *
+ * `title` is null on a push that does not carry one, which keeps the existing
+ * title rather than blanking it.
+ */
+export async function reserveNextVersion(
+  db: D1Database,
+  docId: string,
+  publisher: string,
+  title: string | null,
+  atMs: number,
+): Promise<number | null> {
+  const reserved = await db
+    .prepare(
+      `UPDATE docs
+          SET latest_version = latest_version + 1,
+              title = COALESCE(?, title),
+              updated_at = ?
+        WHERE id = ? AND publisher = ? AND deleted_at IS NULL
+        RETURNING latest_version`,
+    )
+    .bind(title, atMs, docId, publisher)
+    .first<{ latest_version: number }>();
+
+  return reserved?.latest_version ?? null;
+}
+
+/**
+ * Record that a version exists.
+ *
+ * Written *after* its R2 object, never before, so every row here has bytes
+ * behind it. The reverse failure — an object with no row — is the one this
+ * ordering chooses to allow: it costs storage, where a row with no object would
+ * be a doc that 500s.
+ */
+export async function insertVersion(db: D1Database, version: VersionRow): Promise<void> {
+  await db
+    .prepare("INSERT INTO versions (doc_id, n, size, created_at) VALUES (?, ?, ?, ?)")
+    .bind(version.doc_id, version.n, version.size, version.created_at)
+    .run();
+}
+
+/**
+ * Whether this publisher owns a live doc with that id — the same conflation of
+ * "missing", "someone else's" and "deleted" that `reserveNextVersion` makes,
+ * for the same reason, and answered identically for all three so the shape of
+ * the reply cannot confirm another publisher's doc exists.
+ */
+export async function ownsLiveDoc(
+  db: D1Database,
+  docId: string,
+  publisher: string,
+): Promise<boolean> {
+  const row = await db
+    .prepare("SELECT 1 FROM docs WHERE id = ? AND publisher = ? AND deleted_at IS NULL")
+    .bind(docId, publisher)
+    .first();
+
+  return row !== null;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -217,10 +217,17 @@ export async function reserveNextVersion(
  * is the honest answer, because the previous push is still what is being served.
  *
  * `version` is the one just stored, and the write only lands while it is still
- * the newest. Two overlapping pushes reserve 2 and 3; if 3 stores first, 2 must
- * not follow it and leave the row advertising 3 with 2's title. The loser writes
- * nothing and loses nothing: its bytes are stored and its `/v{n}` url works, it
- * simply is not what the shared link resolves to.
+ * the newest *stored* version. Two overlapping pushes reserve 2 and 3; if 3
+ * stores first, 2 must not follow it and leave the row advertising 3 with 2's
+ * title. The loser writes nothing and loses nothing: its bytes are stored and
+ * its `/v{n}` url works, it simply is not what the shared link resolves to.
+ *
+ * The comparison is against `MAX(versions.n)` rather than `docs.latest_version`,
+ * because the counter can be ahead of what exists: a push that reserves a number
+ * and then fails burns it. Testing against the counter would let that dead
+ * reservation veto the commit of a version that really did land, leaving the
+ * shared link serving content the listing does not describe. This row is already
+ * inserted by the time this runs, so the check is "nothing newer stored".
  *
  * `title` is null on a push that does not carry one, which keeps the existing
  * title rather than blanking it.
@@ -235,9 +242,10 @@ export async function commitVersionMetadata(
   await db
     .prepare(
       `UPDATE docs SET title = COALESCE(?, title), updated_at = ?
-        WHERE id = ? AND latest_version = ?`,
+        WHERE id = ?
+          AND ? >= (SELECT COALESCE(MAX(n), 0) FROM versions WHERE doc_id = ?)`,
     )
-    .bind(title, atMs, docId, version)
+    .bind(title, atMs, docId, version, docId)
     .run();
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -113,6 +113,79 @@ export async function insertDoc(
 }
 
 /**
+ * The same insert, but only while this publisher is under `maxDocs` live docs.
+ * Returns false when they are at the ceiling.
+ *
+ * The count is a predicate on the insert rather than a read before it, for the
+ * reason `reserveNextVersion` exists: a publisher at 499 docs firing concurrent
+ * creates would otherwise have every one of them read 499 and every one of them
+ * insert. A quota documented as a hard number has to behave like one under the
+ * concurrency an agent produces.
+ *
+ * `docs_by_publisher_live` covers the subquery, so the count is an index scan of
+ * only this publisher's live rows.
+ */
+export async function insertDocWithinQuota(
+  db: D1Database,
+  doc: Omit<DocRow, "deleted_at" | "latest_version">,
+  maxDocs: number,
+): Promise<boolean> {
+  const result = await db
+    .prepare(
+      `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+       SELECT ?, ?, ?, ?, ?, ?
+        WHERE (SELECT COUNT(*) FROM docs WHERE publisher = ? AND deleted_at IS NULL) < ?`,
+    )
+    .bind(
+      doc.id,
+      doc.publisher,
+      doc.title,
+      FIRST_VERSION,
+      doc.created_at,
+      doc.updated_at,
+      doc.publisher,
+      maxDocs,
+    )
+    .run();
+
+  return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * Hard-delete a `docs` row. Only for rolling back a create that failed after the
+ * row existed: the id was minted this request and nothing else can have seen it,
+ * so there are no versions, no objects, and no url to leave behind.
+ *
+ * Unsharing a *published* doc is a soft delete (`softDeleteDoc`) — that row has
+ * to survive so its url keeps answering 410 rather than pretending it never was.
+ */
+export async function deleteDocRow(db: D1Database, docId: string): Promise<void> {
+  await db.prepare("DELETE FROM docs WHERE id = ?").bind(docId).run();
+}
+
+/** Whether a doc has been soft-deleted since a push started writing to it. */
+export async function docIsDeleted(db: D1Database, docId: string): Promise<boolean> {
+  const row = await db
+    .prepare("SELECT 1 FROM docs WHERE id = ? AND deleted_at IS NOT NULL")
+    .bind(docId)
+    .first();
+
+  return row !== null;
+}
+
+/**
+ * Drop one version row, for a version whose object has just been removed again
+ * after losing a race with delete. The row only ever named those bytes.
+ */
+export async function deleteVersionRow(
+  db: D1Database,
+  docId: string,
+  version: number,
+): Promise<void> {
+  await db.prepare("DELETE FROM versions WHERE doc_id = ? AND n = ?").bind(docId, version).run();
+}
+
+/**
  * Mint the next version number for a doc, or null if this publisher has no such
  * doc to push to.
  *

--- a/src/db.ts
+++ b/src/db.ts
@@ -41,6 +41,8 @@ export interface VersionRow {
   n: number;
   /** Byte length of the stored R2 object. */
   size: number;
+  /** The title this push asked for, or null when it asked for none. */
+  title: string | null;
   created_at: number;
 }
 
@@ -216,37 +218,51 @@ export async function reserveNextVersion(
  * this leaves a burned version number and the previous push's metadata — which
  * is the honest answer, because the previous push is still what is being served.
  *
- * `version` is the one just stored, and the write only lands while it is still
- * the newest *stored* version. Two overlapping pushes reserve 2 and 3; if 3
- * stores first, 2 must not follow it and leave the row advertising 3 with 2's
- * title. The loser writes nothing and loses nothing: its bytes are stored and
- * its `/v{n}` url works, it simply is not what the shared link resolves to.
+ * Two things move, on two different rules, because they answer two different
+ * questions.
  *
- * The comparison is against `MAX(versions.n)` rather than `docs.latest_version`,
- * because the counter can be ahead of what exists: a push that reserves a number
- * and then fails burns it. Testing against the counter would let that dead
- * reservation veto the commit of a version that really did land, leaving the
- * shared link serving content the listing does not describe. This row is already
- * inserted by the time this runs, so the check is "nothing newer stored".
+ * **Title** is whatever the highest-numbered stored version asked for. Deriving
+ * it from the version rows rather than writing it here makes it independent of
+ * the order commits happen to run in: overlapping pushes can reserve 2 and 3,
+ * store in either order, and an explicit title on 2 is not lost because 3 —
+ * which asked for no title — committed first. Versions that omitted a title are
+ * skipped rather than treated as blanking it, which is what makes omission mean
+ * "leave it alone" no matter how many pushes are in flight.
  *
- * `title` is null on a push that does not carry one, which keeps the existing
- * title rather than blanking it.
+ * **`updated_at`** moves only while this version is the newest stored one, since
+ * it describes what the shared link resolves to. The comparison is against
+ * `MAX(versions.n)` and not `docs.latest_version`, because the counter can be
+ * ahead of what exists: a push that reserves a number and then fails burns it,
+ * and a dead reservation must not veto a version that really landed.
+ *
+ * Batched, so a reader cannot catch the pair mid-update.
  */
 export async function commitVersionMetadata(
   db: D1Database,
   docId: string,
   version: number,
-  title: string | null,
   atMs: number,
 ): Promise<void> {
-  await db
-    .prepare(
-      `UPDATE docs SET title = COALESCE(?, title), updated_at = ?
-        WHERE id = ?
-          AND ? >= (SELECT COALESCE(MAX(n), 0) FROM versions WHERE doc_id = ?)`,
-    )
-    .bind(title, atMs, docId, version, docId)
-    .run();
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE docs
+            SET title = COALESCE(
+              (SELECT v.title FROM versions v
+                WHERE v.doc_id = ? AND v.title IS NOT NULL
+                ORDER BY v.n DESC LIMIT 1),
+              title)
+          WHERE id = ?`,
+      )
+      .bind(docId, docId),
+    db
+      .prepare(
+        `UPDATE docs SET updated_at = ?
+          WHERE id = ?
+            AND ? >= (SELECT COALESCE(MAX(n), 0) FROM versions WHERE doc_id = ?)`,
+      )
+      .bind(atMs, docId, version, docId),
+  ]);
 }
 
 /**
@@ -259,8 +275,8 @@ export async function commitVersionMetadata(
  */
 export async function insertVersion(db: D1Database, version: VersionRow): Promise<void> {
   await db
-    .prepare("INSERT INTO versions (doc_id, n, size, created_at) VALUES (?, ?, ?, ?)")
-    .bind(version.doc_id, version.n, version.size, version.created_at)
+    .prepare("INSERT INTO versions (doc_id, n, size, title, created_at) VALUES (?, ?, ?, ?, ?)")
+    .bind(version.doc_id, version.n, version.size, version.title, version.created_at)
     .run();
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -185,29 +185,50 @@ export async function deleteVersionRow(
  * answer all three with 404, because distinguishing them would confirm that
  * another publisher's doc exists.
  *
- * `title` is null on a push that does not carry one, which keeps the existing
- * title rather than blanking it.
+ * It mints the number and nothing else. Title and `updated_at` describe the
+ * content a reader gets, so they are committed by `commitVersionMetadata` only
+ * once the bytes are actually stored — writing them here would let a failed
+ * push leave "my docs" describing a version the public url is not serving.
  */
 export async function reserveNextVersion(
   db: D1Database,
   docId: string,
   publisher: string,
-  title: string | null,
-  atMs: number,
 ): Promise<number | null> {
   const reserved = await db
     .prepare(
       `UPDATE docs
-          SET latest_version = latest_version + 1,
-              title = COALESCE(?, title),
-              updated_at = ?
+          SET latest_version = latest_version + 1
         WHERE id = ? AND publisher = ? AND deleted_at IS NULL
         RETURNING latest_version`,
     )
-    .bind(title, atMs, docId, publisher)
+    .bind(docId, publisher)
     .first<{ latest_version: number }>();
 
   return reserved?.latest_version ?? null;
+}
+
+/**
+ * Point a doc's listing metadata at the version that just landed.
+ *
+ * Runs after the bytes are stored, so the pair a reader sees in "my docs" always
+ * describes content the public url will actually serve. A push that dies before
+ * this leaves a burned version number and the previous push's metadata — which
+ * is the honest answer, because the previous push is still what is being served.
+ *
+ * `title` is null on a push that does not carry one, which keeps the existing
+ * title rather than blanking it.
+ */
+export async function commitVersionMetadata(
+  db: D1Database,
+  docId: string,
+  title: string | null,
+  atMs: number,
+): Promise<void> {
+  await db
+    .prepare("UPDATE docs SET title = COALESCE(?, title), updated_at = ? WHERE id = ?")
+    .bind(title, atMs, docId)
+    .run();
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -201,7 +201,8 @@ export async function findServableVersion(
   docId: string,
   pinned: number | null,
 ): Promise<ServableVersion | null> {
-  return db
+  // `return await`: see the note on the router's catch in index.ts.
+  return await db
     .prepare(
       `SELECT d.deleted_at AS deleted_at,
               (SELECT MAX(v.n)
@@ -232,4 +233,120 @@ export async function ownsLiveDoc(
     .first();
 
   return row !== null;
+}
+
+/**
+ * Soft-delete a doc, returning false when this publisher has no live doc with
+ * that id — missing, someone else's, or already deleted, conflated for the same
+ * reason as everywhere else on the write path.
+ *
+ * Soft, not hard: the row is what lets the serving path answer 410 rather than
+ * 404, so a reader who bookmarked the link learns it was withdrawn instead of
+ * wondering whether they mistyped it. The bytes are a separate matter and the
+ * caller drops them; this row outlives them on purpose.
+ *
+ * Ownership and liveness are predicates on the write itself rather than an
+ * earlier read, so two concurrent deletes of the same doc produce exactly one
+ * true — which is what makes "delete the objects" safe to run only on that one.
+ */
+export async function softDeleteDoc(
+  db: D1Database,
+  docId: string,
+  publisher: string,
+  atMs: number,
+): Promise<boolean> {
+  const deleted = await db
+    .prepare(
+      `UPDATE docs
+          SET deleted_at = ?
+        WHERE id = ? AND publisher = ? AND deleted_at IS NULL
+        RETURNING id`,
+    )
+    .bind(atMs, docId, publisher)
+    .first<{ id: string }>();
+
+  return deleted !== null;
+}
+
+/** One row of the publisher's doc list, as the index scan yields it. */
+export interface DocListRow {
+  id: string;
+  title: string;
+  created_at: number;
+  updated_at: number;
+  /**
+   * Newest version that has bytes, from `versions` rather than the
+   * `latest_version` counter — the counter can sit one above it after a push
+   * that died mid-write, and a list that reported it would name a version the
+   * doc's url does not serve. Null for a doc whose first push never landed.
+   */
+  version: number | null;
+}
+
+/**
+ * Where a page of the list stopped, in the order the scan runs. Both columns
+ * are needed: `created_at` is milliseconds and two docs pushed in the same
+ * millisecond are entirely possible, so the id is what breaks the tie and keeps
+ * the order total.
+ */
+export interface DocListCursor {
+  created_at: number;
+  id: string;
+}
+
+/**
+ * A page of one publisher's live docs, newest first.
+ *
+ * Keyset, not OFFSET. The `docs_by_publisher_live` partial index is
+ * `(publisher, created_at DESC, id DESC)`, and it supplies both the filter and
+ * the ordering, so no page is ever sorted in a temp b-tree. It is also the only
+ * paging that stays correct while the publisher keeps pushing: OFFSET renumbers
+ * the moment a newer doc appears, so a doc would shift onto a page the caller
+ * has already read and be missed.
+ *
+ * Ordering by `created_at` rather than `updated_at` is what makes that hold — a
+ * doc's created_at never moves, so a doc cannot jump backwards past a cursor
+ * because it was re-pushed mid-walk.
+ *
+ * The resume predicate is a row-value comparison rather than the expanded
+ * `a < ? OR (a = ? AND b < ?)`. The two mean the same thing, but only the row
+ * value becomes an index range constraint — `EXPLAIN QUERY PLAN` shows
+ * `(publisher=? AND (created_at,id)<(?,?))` against the expanded form's
+ * `(publisher=?)`, which walks from the newest doc and discards rows until it
+ * passes the cursor. Both are correct; one seeks.
+ *
+ * The two statements differ only in that predicate. Written out rather than
+ * folded into one with `(? IS NULL OR ...)`, which SQLite cannot use the index
+ * for at all.
+ */
+export async function listPublisherDocs(
+  db: D1Database,
+  publisher: string,
+  after: DocListCursor | null,
+  limit: number,
+): Promise<DocListRow[]> {
+  const columns = `d.id AS id, d.title AS title, d.created_at AS created_at,
+                   d.updated_at AS updated_at,
+                   (SELECT MAX(v.n) FROM versions v WHERE v.doc_id = d.id) AS version`;
+  const order = "ORDER BY d.created_at DESC, d.id DESC LIMIT ?";
+
+  const statement =
+    after === null
+      ? db
+          .prepare(
+            `SELECT ${columns} FROM docs d
+              WHERE d.publisher = ? AND d.deleted_at IS NULL
+              ${order}`,
+          )
+          .bind(publisher, limit)
+      : db
+          .prepare(
+            `SELECT ${columns} FROM docs d
+              WHERE d.publisher = ? AND d.deleted_at IS NULL
+                AND (d.created_at, d.id) < (?, ?)
+              ${order}`,
+          )
+          .bind(publisher, after.created_at, after.id, limit);
+
+  return (await statement.all<DocListRow>()).results;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -168,6 +168,53 @@ export async function insertVersion(db: D1Database, version: VersionRow): Promis
     .run();
 }
 
+/** What the serving path needs to know about a doc, in one read. */
+export interface ServableVersion {
+  /** Epoch ms when the doc was soft-deleted, else null. Deleted serves 410. */
+  deleted_at: number | null;
+  /** The version that has bytes, or null when the request names none. */
+  version: number | null;
+}
+
+/**
+ * Resolve a public url to the version whose bytes should be served, or null if
+ * no doc has that id at all.
+ *
+ * `pinned` is the version from `/d/{docId}/v{n}`, or null for `/d/{docId}`.
+ *
+ * The version comes from `versions`, never from `docs.latest_version`, because
+ * that counter is a *reservation*: a push that dies between minting the number
+ * and writing the object leaves it one above the newest version that actually
+ * has bytes, and serving that number would 404 a doc that is perfectly fine.
+ * Taking the highest row instead also steps over the gap such a push leaves
+ * behind. The same subquery answers the pinned case, where matching the exact
+ * `n` is what proves the version exists rather than merely being below the
+ * counter.
+ *
+ * Liveness is *not* a predicate here: a deleted doc must still be found, so the
+ * caller can tell 410 from 404. That distinction is the one thing this query
+ * exists to preserve, and it is safe to expose because a doc id is 128 random
+ * bits — knowing one already means having been given the link.
+ */
+export async function findServableVersion(
+  db: D1Database,
+  docId: string,
+  pinned: number | null,
+): Promise<ServableVersion | null> {
+  return db
+    .prepare(
+      `SELECT d.deleted_at AS deleted_at,
+              (SELECT MAX(v.n)
+                 FROM versions v
+                WHERE v.doc_id = d.id
+                  AND (? IS NULL OR v.n = ?)) AS version
+         FROM docs d
+        WHERE d.id = ?`,
+    )
+    .bind(pinned, pinned, docId)
+    .first<ServableVersion>();
+}
+
 /**
  * Whether this publisher owns a live doc with that id — the same conflation of
  * "missing", "someone else's" and "deleted" that `reserveNextVersion` makes,

--- a/src/db.ts
+++ b/src/db.ts
@@ -216,18 +216,28 @@ export async function reserveNextVersion(
  * this leaves a burned version number and the previous push's metadata — which
  * is the honest answer, because the previous push is still what is being served.
  *
+ * `version` is the one just stored, and the write only lands while it is still
+ * the newest. Two overlapping pushes reserve 2 and 3; if 3 stores first, 2 must
+ * not follow it and leave the row advertising 3 with 2's title. The loser writes
+ * nothing and loses nothing: its bytes are stored and its `/v{n}` url works, it
+ * simply is not what the shared link resolves to.
+ *
  * `title` is null on a push that does not carry one, which keeps the existing
  * title rather than blanking it.
  */
 export async function commitVersionMetadata(
   db: D1Database,
   docId: string,
+  version: number,
   title: string | null,
   atMs: number,
 ): Promise<void> {
   await db
-    .prepare("UPDATE docs SET title = COALESCE(?, title), updated_at = ? WHERE id = ?")
-    .bind(title, atMs, docId)
+    .prepare(
+      `UPDATE docs SET title = COALESCE(?, title), updated_at = ?
+        WHERE id = ? AND latest_version = ?`,
+    )
+    .bind(title, atMs, docId, version)
     .run();
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -42,3 +42,37 @@ export interface PushQuotaRow {
   day: string;
   pushes: number;
 }
+
+/**
+ * The publisher row as auth needs it: read the cached validation, write it back
+ * after a fresh one. It is an interface rather than two loose functions so the
+ * auth tests can run against an in-memory double instead of a database.
+ */
+export interface PublisherStore {
+  read(keyHash: string): Promise<PublisherRow | null>;
+  save(row: PublisherRow): Promise<void>;
+}
+
+export function d1PublisherStore(db: D1Database): PublisherStore {
+  return {
+    read(keyHash) {
+      return db
+        .prepare("SELECT key_hash, plan, validated_at FROM publishers WHERE key_hash = ?")
+        .bind(keyHash)
+        .first<PublisherRow>();
+    },
+
+    // `docs.publisher` is a foreign key onto this table, so this upsert is also
+    // what guarantees a row exists before the first push inserts a doc.
+    async save(row) {
+      await db
+        .prepare(
+          `INSERT INTO publishers (key_hash, plan, validated_at) VALUES (?, ?, ?)
+           ON CONFLICT(key_hash) DO UPDATE SET plan = excluded.plan,
+                                               validated_at = excluded.validated_at`,
+        )
+        .bind(row.key_hash, row.plan, row.validated_at)
+        .run();
+    },
+  };
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,3 +31,18 @@ export function errorResponse(code: ErrorCode, message: string, headers?: Header
   const body: ErrorBody = { error: { code, message } };
   return Response.json(body, { status: ERROR_STATUS[code], headers });
 }
+
+/**
+ * The one answer every publisher-facing endpoint gives for a doc that does not
+ * exist, is not the caller's, or was deleted.
+ *
+ * It lives here rather than in each handler because being *identical* across
+ * all three causes and all three endpoints is the point: a 403 on someone
+ * else's doc, or a differently worded 404, would confirm that the id is real
+ * and turn the id space into something worth probing. Two copies of this
+ * message would be two places for that property to drift. The id is echoed back
+ * only because the caller supplied it.
+ */
+export function docNotFound(docId: string): Response {
+  return errorResponse("not_found", `No doc with id ${docId}.`);
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,33 @@
+/**
+ * The error contract: every failure is `{error: {code, message}}` with the
+ * status derived from the code, so the code is the stable thing clients match
+ * on and the message stays free to change.
+ */
+export type ErrorCode =
+  | "bad_request"
+  | "unauthorized"
+  | "not_found"
+  | "gone"
+  | "too_large"
+  | "quota_exceeded"
+  | "internal";
+
+const ERROR_STATUS: Record<ErrorCode, number> = {
+  bad_request: 400,
+  unauthorized: 401,
+  not_found: 404,
+  gone: 410,
+  too_large: 413,
+  quota_exceeded: 429,
+  internal: 500,
+};
+
+/** The wire shape. Clients match on `code`; `message` is human-facing only. */
+export interface ErrorBody {
+  error: { code: ErrorCode; message: string };
+}
+
+export function errorResponse(code: ErrorCode, message: string, headers?: HeadersInit): Response {
+  const body: ErrorBody = { error: { code, message } };
+  return Response.json(body, { status: ERROR_STATUS[code], headers });
+}

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -1,0 +1,51 @@
+/**
+ * Doc ids: 128 bits of CSPRNG entropy in lowercase Crockford base32.
+ *
+ * The id is the only thing standing between a public url and the doc behind it,
+ * so it has to be unguessable — 128 bits, never a counter or a hash of anything
+ * the publisher controls. Crockford's alphabet drops i/l/o/u, which keeps the id
+ * url-safe, case-insensitively unambiguous, and safe to read aloud.
+ */
+const ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
+
+/** Bytes of entropy per id. */
+export const DOC_ID_BYTES = 16;
+
+/** ceil(128 / 5) — 25 full characters, then one carrying the last 3 bits. */
+export const DOC_ID_LENGTH = 26;
+
+const DOC_ID_PATTERN = new RegExp(`^[${ALPHABET}]{${DOC_ID_LENGTH}}$`);
+
+/** Big-endian base32 with no padding. */
+export function encodeBase32(bytes: Uint8Array): string {
+  let out = "";
+  let buffer = 0;
+  let bits = 0;
+
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += ALPHABET[(buffer >>> bits) & 31];
+    }
+  }
+  if (bits > 0) {
+    out += ALPHABET[(buffer << (5 - bits)) & 31];
+  }
+  return out;
+}
+
+export function newDocId(): string {
+  const bytes = new Uint8Array(DOC_ID_BYTES);
+  crypto.getRandomValues(bytes);
+  return encodeBase32(bytes);
+}
+
+/**
+ * Cheap shape check so the serving path can reject junk before it costs a D1
+ * read. Passing this says nothing about whether the doc exists.
+ */
+export function isDocId(value: string): boolean {
+  return DOC_ID_PATTERN.test(value);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { createDoc, updateDoc } from "./api/push.js";
 import { authenticateRequest, publisherErrorResponse } from "./auth.js";
 import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
@@ -70,8 +71,24 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
   const auth = await authenticateRequest(request, env);
   if (!auth.ok) return publisherErrorResponse(auth);
 
-  // Phase 3 (push) and phase 5 (manage) mount their handlers here, keyed by
-  // `auth.publisher.id`.
+  // `/api/v1/docs` and `/api/v1/docs/{docId}` are the whole surface. Anything
+  // the host matched into the API but that no route claims is a 404, never a
+  // fall-through to the serving surface.
+  const [collection, docId, ...extra] = url.pathname
+    .slice(API_PREFIX.length)
+    .split("/")
+    .filter(Boolean);
+
+  if (collection === "docs" && extra.length === 0) {
+    if (docId === undefined && request.method === "POST") {
+      return createDoc(request, url, env, auth.publisher);
+    }
+    if (docId !== undefined && request.method === "PUT") {
+      return updateDoc(request, url, env, auth.publisher, docId);
+    }
+  }
+
+  // Phase 5 (delete, list) mounts here.
   return errorResponse("not_found", `No API route for ${url.pathname}`);
 }
 
@@ -95,13 +112,24 @@ export default {
       apiHost: env.API_HOST,
     });
 
-    switch (surface) {
-      case "api":
-        return handleApi(request, url, env);
-      case "serving":
-        return handleServing(request, url, env);
-      default:
-        return errorResponse("not_found", `No route for ${url.pathname}`);
+    try {
+      // `return await`, not `return`: a bare return hands the promise back
+      // unawaited, so a binding that rejects would sail straight past this catch.
+      switch (surface) {
+        case "api":
+          return await handleApi(request, url, env);
+        case "serving":
+          return handleServing(request, url, env);
+        default:
+          return errorResponse("not_found", `No route for ${url.pathname}`);
+      }
+    } catch (error) {
+      // R2 and D1 can fail mid-request. Left uncaught they become workerd's
+      // plain-text 500 — the one response the frozen contract does not describe,
+      // and Copilot parses `{error:{code}}` on every failure. The cause is
+      // logged rather than returned: it can quote a query or a key.
+      console.error("unhandled error", { path: url.pathname, error });
+      return errorResponse("internal", "Something went wrong on our end. Please try again.");
     }
   },
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { createDoc, updateDoc } from "./api/push.js";
 import { authenticateRequest, publisherErrorResponse } from "./auth.js";
 import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
+import { handleServing, servingError, SERVING_PREFIX } from "./serve.js";
 
 /**
  * The two surfaces. They are separate because user HTML has to be served from a
@@ -18,7 +19,6 @@ export interface SurfaceConfig {
 }
 
 const API_PREFIX = "/api/v1";
-const SERVING_PREFIX = "/d";
 
 /**
  * Lowercase and drop the trailing root dot, so `A.Com` and `a.com.` both match
@@ -58,11 +58,6 @@ export function resolveSurface(hostname: string, pathname: string, config: Surfa
   return "unknown";
 }
 
-/** Nothing on the serving host is ever indexable, including its errors. */
-const SERVING_HEADERS: HeadersInit = {
-  "x-robots-tag": "noindex, nofollow",
-};
-
 /**
  * Every API request authenticates before any handler sees it, so a handler can
  * assume a publisher and never has to reason about the license key.
@@ -92,11 +87,6 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
   return errorResponse("not_found", `No API route for ${url.pathname}`);
 }
 
-// Phase 4 mounts the /d/{docId} and /d/{docId}/v{n} handlers here.
-function handleServing(_request: Request, url: URL, _env: Env): Response {
-  return errorResponse("not_found", `No doc at ${url.pathname}`, SERVING_HEADERS);
-}
-
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
@@ -119,7 +109,7 @@ export default {
         case "api":
           return await handleApi(request, url, env);
         case "serving":
-          return handleServing(request, url, env);
+          return await handleServing(request, url, env);
         default:
           return errorResponse("not_found", `No route for ${url.pathname}`);
       }
@@ -129,7 +119,12 @@ export default {
       // and Copilot parses `{error:{code}}` on every failure. The cause is
       // logged rather than returned: it can quote a query or a key.
       console.error("unhandled error", { path: url.pathname, error });
-      return errorResponse("internal", "Something went wrong on our end. Please try again.");
+      const message = "Something went wrong on our end. Please try again.";
+      // The surface still decides the headers. A 500 on a doc url is a serving
+      // response like any other, and has to carry the robots tag that proves it.
+      return surface === "serving"
+        ? servingError("internal", message)
+        : errorResponse("internal", message);
     }
   },
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,98 @@
-export interface Env {}
+import type { Env } from "./config.js";
+import { errorResponse } from "./errors.js";
+
+/**
+ * The two surfaces. They are separate because user HTML has to be served from a
+ * sacrificial host that never carries the API — a doc that turns out to be
+ * phishing should cost us the serving domain, not the brand domain.
+ */
+export type Surface = "api" | "serving" | "unknown";
+
+export interface SurfaceConfig {
+  /** Host serving public docs. Empty/undefined in v0. */
+  servingHost?: string;
+  /** Host exposing /api/v1. Empty/undefined in v0. */
+  apiHost?: string;
+}
+
+const API_PREFIX = "/api/v1";
+const SERVING_PREFIX = "/d";
+
+/**
+ * Lowercase and drop the trailing root dot, so `A.Com` and `a.com.` both match
+ * `a.com`. The root dot matters: `new URL("https://updoc.page./x").hostname` is
+ * `"updoc.page."`, so without this a request with a dotted Host header would
+ * miss the serving-host match and fall through to the path prefix — which is
+ * exactly how `/api/v1` would become reachable on the serving domain.
+ */
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/\.$/, "");
+}
+
+function hostMatches(hostname: string, configured: string | undefined): boolean {
+  if (!configured) return false;
+  return normalizeHostname(hostname) === normalizeHostname(configured);
+}
+
+function pathIsUnder(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+/**
+ * Host first, path second.
+ *
+ * Once the hosts are configured, the host alone decides the surface: a request
+ * arriving on SERVING_HOST is the serving surface no matter what path it asks
+ * for, which is what makes `/api/v1` unreachable there rather than merely
+ * unadvertised. When the host matches nothing configured — the v0 workers.dev
+ * case, and the migration window before DNS moves — the path prefix decides.
+ */
+export function resolveSurface(hostname: string, pathname: string, config: SurfaceConfig): Surface {
+  if (hostMatches(hostname, config.servingHost)) return "serving";
+  if (hostMatches(hostname, config.apiHost)) return "api";
+
+  if (pathIsUnder(pathname, API_PREFIX)) return "api";
+  if (pathIsUnder(pathname, SERVING_PREFIX)) return "serving";
+  return "unknown";
+}
+
+/** Nothing on the serving host is ever indexable, including its errors. */
+const SERVING_HEADERS: HeadersInit = {
+  "x-robots-tag": "noindex, nofollow",
+};
+
+// Phase 3 (push) and phase 5 (manage) mount their handlers here.
+function handleApi(_request: Request, url: URL, _env: Env): Response {
+  return errorResponse("not_found", `No API route for ${url.pathname}`);
+}
+
+// Phase 4 mounts the /d/{docId} and /d/{docId}/v{n} handlers here.
+function handleServing(_request: Request, url: URL, _env: Env): Response {
+  return errorResponse("not_found", `No doc at ${url.pathname}`, SERVING_HEADERS);
+}
 
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
+    // Deliberately outside the surface split: the deploy smoke check has to
+    // reach it on whichever host it lands on, and it discloses nothing.
     if (url.pathname === "/health") {
       return Response.json({ ok: true });
     }
 
-    return new Response("Not Found", { status: 404 });
+    const surface = resolveSurface(url.hostname, url.pathname, {
+      servingHost: env.SERVING_HOST,
+      apiHost: env.API_HOST,
+    });
+
+    switch (surface) {
+      case "api":
+        return handleApi(request, url, env);
+      case "serving":
+        return handleServing(request, url, env);
+      default:
+        return errorResponse("not_found", `No route for ${url.pathname}`);
+    }
   },
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { authenticateRequest, publisherErrorResponse } from "./auth.js";
 import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
 
@@ -61,8 +62,16 @@ const SERVING_HEADERS: HeadersInit = {
   "x-robots-tag": "noindex, nofollow",
 };
 
-// Phase 3 (push) and phase 5 (manage) mount their handlers here.
-function handleApi(_request: Request, url: URL, _env: Env): Response {
+/**
+ * Every API request authenticates before any handler sees it, so a handler can
+ * assume a publisher and never has to reason about the license key.
+ */
+async function handleApi(request: Request, url: URL, env: Env): Promise<Response> {
+  const auth = await authenticateRequest(request, env);
+  if (!auth.ok) return publisherErrorResponse(auth);
+
+  // Phase 3 (push) and phase 5 (manage) mount their handlers here, keyed by
+  // `auth.publisher.id`.
   return errorResponse("not_found", `No API route for ${url.pathname}`);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { deleteDoc, listDocs } from "./api/manage.js";
 import { createDoc, updateDoc } from "./api/push.js";
 import { authenticateRequest, publisherErrorResponse } from "./auth.js";
 import type { Env } from "./config.js";
@@ -74,16 +75,23 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
     .split("/")
     .filter(Boolean);
 
+  // Every dispatch is `return await`, never a bare `return` of the handler's
+  // promise, for the reason spelled out on the catch below.
   if (collection === "docs" && extra.length === 0) {
     if (docId === undefined && request.method === "POST") {
-      return createDoc(request, url, env, auth.publisher);
+      return await createDoc(request, url, env, auth.publisher);
+    }
+    if (docId === undefined && request.method === "GET") {
+      return await listDocs(url, env, auth.publisher);
     }
     if (docId !== undefined && request.method === "PUT") {
-      return updateDoc(request, url, env, auth.publisher, docId);
+      return await updateDoc(request, url, env, auth.publisher, docId);
+    }
+    if (docId !== undefined && request.method === "DELETE") {
+      return await deleteDoc(env, auth.publisher, docId);
     }
   }
 
-  // Phase 5 (delete, list) mounts here.
   return errorResponse("not_found", `No API route for ${url.pathname}`);
 }
 
@@ -103,8 +111,11 @@ export default {
     });
 
     try {
-      // `return await`, not `return`: a bare return hands the promise back
-      // unawaited, so a binding that rejects would sail straight past this catch.
+      // `return await`, not `return` — here, and at every dispatch either
+      // surface makes. A bare return hands somebody else's promise back
+      // unawaited: the rejection sails straight past this catch, and workerd
+      // reports it as an unhandled rejection even when a caller further up did
+      // handle it, which fails the whole test run.
       switch (surface) {
         case "api":
           return await handleApi(request, url, env);

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -97,16 +97,7 @@ export async function reserveDailyPush(
   return claimed !== null;
 }
 
-/**
- * Live docs the publisher holds. Soft-deleted docs do not count — deleting is
- * how a publisher at the ceiling makes room — and `docs_by_publisher_live` is
- * the partial index that makes this a cheap count rather than a table scan.
- */
-export async function liveDocCount(db: D1Database, publisher: string): Promise<number> {
-  const row = await db
-    .prepare("SELECT COUNT(*) AS n FROM docs WHERE publisher = ? AND deleted_at IS NULL")
-    .bind(publisher)
-    .first<{ n: number }>();
-
-  return row?.n ?? 0;
-}
+// The doc ceiling is enforced by `insertDocWithinQuota` in db.ts, where the
+// count is a predicate on the insert. A standalone count belongs nowhere near
+// it: reading the number and acting on it separately is the race that fix
+// removed, and a spare helper is an invitation to reintroduce it.

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -9,16 +9,23 @@ import { MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "./config.js";
 
 /**
  * Byte ceiling on the whole request, as opposed to `MAX_DOC_BYTES`, which is
- * the ceiling on the `html` field inside it.
+ * the ceiling on the `html` field inside it and the only one the contract
+ * documents. This one exists so an oversized body is rejected while it is still
+ * arriving rather than after it has been buffered.
  *
- * The two differ by the JSON envelope: the field name, the title, and whatever
- * escaping the document's own bytes need. A megabyte of slack covers escaping
- * for any real document — reaching it would take a tenth of the file to be
- * quotes, backslashes or control characters — and it is what lets an oversized
- * body be rejected while it is still arriving rather than after it has been
- * buffered.
+ * It has to clear the worst case the JSON envelope can add, not the typical
+ * one. Every `"` and `\` in the document costs two bytes instead of one, and a
+ * control character costs six as `\uXXXX`; attribute-dense HTML passes 10%
+ * quote density without being remarkable. A ceiling that only covered typical
+ * escaping would turn into an undocumented second limit that refuses documents
+ * under the published one.
+ *
+ * Doubling is affordable: the worst case holds the raw bytes, the decoded
+ * string and the parsed field at once, and content escape-dense enough to reach
+ * this bound is ASCII by definition, which V8 stores one byte per character.
+ * That is roughly 60MB against the isolate's 128MB.
  */
-export const MAX_REQUEST_BYTES = MAX_DOC_BYTES + 1024 * 1024;
+export const MAX_REQUEST_BYTES = 2 * MAX_DOC_BYTES + 1024 * 1024;
 
 /**
  * Read the body, giving up the moment it passes `limit`.
@@ -101,3 +108,29 @@ export async function reserveDailyPush(
 // count is a predicate on the insert. A standalone count belongs nowhere near
 // it: reading the number and acting on it separately is the race that fix
 // removed, and a spare helper is an invitation to reintroduce it.
+
+/**
+ * Give back a push claimed for work that then did not happen.
+ *
+ * The claim has to come before the work — that is what stops two concurrent
+ * pushes both seeing 99 — so a push that loses a race to a concurrent delete
+ * has already been counted by the time it finds out. The contract is that a
+ * rejected push costs nothing, so the counter is repaid rather than the
+ * reservation moved later.
+ *
+ * `pushes > 0` keeps a double refund, or one crossing a UTC day boundary into
+ * a row it never incremented, from writing a negative count.
+ */
+export async function refundDailyPush(
+  db: D1Database,
+  publisher: string,
+  day: string,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE push_quota SET pushes = pushes - 1
+        WHERE publisher = ? AND day = ? AND pushes > 0`,
+    )
+    .bind(publisher, day)
+    .run();
+}

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -1,0 +1,112 @@
+/**
+ * The three ceilings from D10, enforced on the push path.
+ *
+ * They exist to cap the abuse and hoarding tail, not to monetize: a real
+ * Copilot user never reaches any of them. The numbers themselves live in
+ * `config.ts`; this file is how they are counted.
+ */
+import { MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "./config.js";
+
+/**
+ * Byte ceiling on the whole request, as opposed to `MAX_DOC_BYTES`, which is
+ * the ceiling on the `html` field inside it.
+ *
+ * The two differ by the JSON envelope: the field name, the title, and whatever
+ * escaping the document's own bytes need. A megabyte of slack covers escaping
+ * for any real document — reaching it would take a tenth of the file to be
+ * quotes, backslashes or control characters — and it is what lets an oversized
+ * body be rejected while it is still arriving rather than after it has been
+ * buffered.
+ */
+export const MAX_REQUEST_BYTES = MAX_DOC_BYTES + 1024 * 1024;
+
+/**
+ * Read the body, giving up the moment it passes `limit`.
+ *
+ * `request.arrayBuffer()` would buffer whatever the client chose to send — up
+ * to Cloudflare's 100MB request limit — before there was anything to compare
+ * against the quota, so a 10MB ceiling enforced after the read is not a ceiling
+ * on memory at all. Returns null when the body is too large; the bytes
+ * otherwise.
+ */
+export async function readBodyWithin(request: Request, limit: number): Promise<Uint8Array | null> {
+  if (!request.body) return new Uint8Array(0);
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+/** Bytes a string occupies once encoded, which is what the ceiling is in. */
+export function utf8Length(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+/**
+ * The `push_quota.day` key: a UTC `YYYY-MM-DD` string, so the window rolls over
+ * on its own and no scheduled job has to reset a counter.
+ */
+export function utcDay(atMs: number): string {
+  return new Date(atMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Claim one of today's pushes, returning false when there are none left.
+ *
+ * Claim rather than check: the count is read and incremented by a single
+ * statement, so two concurrent pushes cannot both see 99 and both proceed. The
+ * `WHERE` on the upsert's update branch is what enforces the limit — when it
+ * fails SQLite leaves the row alone and `RETURNING` yields nothing, which is
+ * the rejection.
+ */
+export async function reserveDailyPush(
+  db: D1Database,
+  publisher: string,
+  day: string,
+): Promise<boolean> {
+  const claimed = await db
+    .prepare(
+      `INSERT INTO push_quota (publisher, day, pushes) VALUES (?, ?, 1)
+       ON CONFLICT(publisher, day) DO UPDATE SET pushes = push_quota.pushes + 1
+         WHERE push_quota.pushes < ?
+       RETURNING pushes`,
+    )
+    .bind(publisher, day, MAX_PUSHES_PER_DAY)
+    .first<{ pushes: number }>();
+
+  return claimed !== null;
+}
+
+/**
+ * Live docs the publisher holds. Soft-deleted docs do not count — deleting is
+ * how a publisher at the ceiling makes room — and `docs_by_publisher_live` is
+ * the partial index that makes this a cheap count rather than a table scan.
+ */
+export async function liveDocCount(db: D1Database, publisher: string): Promise<number> {
+  const row = await db
+    .prepare("SELECT COUNT(*) AS n FROM docs WHERE publisher = ? AND deleted_at IS NULL")
+    .bind(publisher)
+    .first<{ n: number }>();
+
+  return row?.n ?? 0;
+}

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -13,12 +13,18 @@ import { MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "./config.js";
  * documents. This one exists so an oversized body is rejected while it is still
  * arriving rather than after it has been buffered.
  *
- * It has to clear the worst case the JSON envelope can add, not the typical
- * one. Every `"` and `\` in the document costs two bytes instead of one, and a
- * control character costs six as `\uXXXX`; attribute-dense HTML passes 10%
- * quote density without being remarkable. A ceiling that only covered typical
- * escaping would turn into an undocumented second limit that refuses documents
+ * It has to clear the worst case *a real document* produces, which is 2x: every
+ * `"` and `\` costs two bytes instead of one, and attribute-dense HTML passes
+ * 10% quote density without being remarkable. A ceiling budgeted for typical
+ * escaping instead would be an undocumented second limit that refuses documents
  * under the published one.
+ *
+ * Not 6x. A control character escapes to `\uXXXX`, but control characters are
+ * not valid in HTML text, so reaching that bound takes ~1.7M of them — an
+ * adversarial payload, not a note. It gets a clean 413, and budgeting for it
+ * would mean holding ~60MB of raw bytes plus the decoded string plus the parsed
+ * field against a 128MB isolate: a real OOM risk on ordinary large docs, traded
+ * for a document that does not exist.
  *
  * Doubling is affordable: the worst case holds the raw bytes, the decoded
  * string and the parsed field at once, and content escape-dense enough to reach

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,99 @@
+/**
+ * Push-time rendering: the one pass that turns an uploaded document into the
+ * bytes readers get.
+ *
+ * It runs once per version, at push time, and what it produces is what R2
+ * stores (D11) — serving is a pure passthrough, so this cost is paid once per
+ * push rather than once per read, and a served page can never disagree with the
+ * stored object.
+ *
+ * It is emphatically *not* a sanitizer. Uploaded scripts run (D6): the document
+ * arrives already rendered by Obsidian, complete with callouts, dataview output
+ * and embedded interactive figures, and stripping or escaping any of it would
+ * destroy the fidelity that is the whole reason the client renders HTML. Safety
+ * comes from the serving headers and a cookieless sacrificial origin, not from
+ * rewriting the publisher's markup. The only edits made here are the two
+ * additions below.
+ *
+ * HTMLRewriter rather than string surgery, because it is a real HTML tokenizer:
+ * a `<head>` written inside a comment or emitted by `document.write("<head>")`
+ * is text to it, so injection lands in the document's actual head or nowhere.
+ */
+
+/**
+ * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
+ * authoritative signal — it applies to every response including errors — but
+ * the meta tag travels with the bytes, so a doc that is copied, mirrored, or
+ * served from anywhere else keeps asking not to be indexed.
+ */
+export const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
+
+/**
+ * The "shared with updoc" byline (D9).
+ *
+ * `all:initial` first, then only the properties we want back: the page's own
+ * stylesheet has no way to guess this class, but it very often styles `div`,
+ * and a footer inheriting a 4rem serif body font would look like a bug. Inline
+ * styles keep it self-contained — no stylesheet to fetch, nothing for the CSP
+ * to allow.
+ */
+export const UPDOC_FOOTER =
+  '<div class="updoc-footer" style="' +
+  "all:initial;display:block;box-sizing:border-box;width:100%;clear:both;" +
+  "margin:4rem 0 0;padding:1rem 0;border-top:1px solid rgba(128,128,128,0.25);" +
+  "font:400 13px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;" +
+  'color:#888;text-align:center">Shared with updoc</div>';
+
+/** HTMLRewriter treats injected content as markup, not text, only when asked. */
+const AS_HTML = { html: true } as const;
+
+/**
+ * Inject the robots meta and the footer, and change nothing else.
+ *
+ * Both injections have a fallback, because a document is not guaranteed to have
+ * the tag we want to hang them on:
+ *
+ * - The meta goes first inside `<head>`. A document with no `<head>` gets it at
+ *   the end instead, where the parser hoists it into the body — weaker, since a
+ *   robots meta outside the head is not honoured, which is exactly why the
+ *   header carries the real signal.
+ * - The footer goes immediately before `</body>`. `append()` is not used for
+ *   this: it silently does nothing when an element has no end tag, and an
+ *   unclosed `<body>` is common enough in hand-written HTML that a silently
+ *   missing footer would be a real outcome. Hooking the end tag instead tells
+ *   us whether the injection actually landed, and the document-end fallback
+ *   covers every case where it did not.
+ *
+ * Returns the bytes to store: the caller needs their length for the version row
+ * and hands the same buffer to R2, so a string round-trip would copy 10MB for
+ * nothing.
+ */
+export async function bakeServedHtml(html: string): Promise<Uint8Array> {
+  let metaPlaced = false;
+  let footerPlaced = false;
+
+  const baked = new HTMLRewriter()
+    .on("head", {
+      element(head) {
+        metaPlaced = true;
+        head.prepend(NOINDEX_META, AS_HTML);
+      },
+    })
+    .on("body", {
+      element(body) {
+        body.onEndTag((endTag) => {
+          footerPlaced = true;
+          endTag.before(UPDOC_FOOTER, AS_HTML);
+        });
+      },
+    })
+    .onDocument({
+      end(end) {
+        if (!metaPlaced) end.append(NOINDEX_META, AS_HTML);
+        if (!footerPlaced) end.append(UPDOC_FOOTER, AS_HTML);
+      },
+    })
+    .transform(new Response(html));
+
+  return new Uint8Array(await baked.arrayBuffer());
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,317 @@
+/**
+ * The public serving surface: `GET /d/{docId}` and `GET /d/{docId}/v{n}`.
+ *
+ * Injection already happened at push time (D11), so this file reads an R2
+ * object and streams it back untouched. It never parses, rewrites or even
+ * decodes the bytes — a served page is byte-identical to the stored version,
+ * which is what makes `immutable` an honest thing to say about `/v{n}`.
+ *
+ * What it does add is the header policy below. Since the bytes are somebody
+ * else's HTML with somebody else's scripts in it (D6), those headers are the
+ * part of the security boundary that lives in this service, and they are
+ * attached here — on the response — rather than injected into the markup,
+ * because the two directives that matter most (`frame-ancestors`, and
+ * `form-action` against a document that may rewrite its own DOM) are only
+ * honoured as a real header.
+ */
+import type { Env } from "./config.js";
+import { findServableVersion } from "./db.js";
+import { errorResponse } from "./errors.js";
+import { isDocId } from "./ids.js";
+import { STORED_CONTENT_TYPE, versionObjectKey } from "./storage.js";
+
+/** Path prefix of the serving surface, used by the router's path fallback. */
+export const SERVING_PREFIX = "/d";
+
+/** Everything this surface serves lives under `/d/`. `/d` alone is not a doc. */
+const DOC_PATH_PREFIX = `${SERVING_PREFIX}/`;
+
+/**
+ * `v` then a decimal with no leading zeros, so one version has exactly one url.
+ * Bounded at nine digits: the number only ever reaches R2 as part of a key, and
+ * a bound here means no unbounded digit string ever becomes a `Number`.
+ */
+const VERSION_SEGMENT = /^v([1-9][0-9]{0,8})$/;
+
+/**
+ * The Content Security Policy. This is the security boundary of updoc, so every
+ * directive below is a deliberate choice rather than a copied default.
+ *
+ * The threat model is unusual and worth stating plainly: the page's own author
+ * is the untrusted party. Publishers upload whole documents including scripts,
+ * and we run them on purpose (D6) — interactive figures and embedded
+ * simulations are the reason the client renders HTML at all. So this policy is
+ * not trying to stop a doc from executing code. It is trying to stop a doc from
+ * using our origin to harm *readers*, and to keep one doc's blast radius off
+ * the rest of the internet.
+ *
+ * Three things make that a defensible trade, none of them in this string: the
+ * origin is cookieless and holds nothing but already-public docs, so there is
+ * no session or private data on it to steal; docs are served from a sacrificial
+ * host, never the brand domain; and publishing is gated on a paid license key.
+ *
+ * Directive by directive:
+ *
+ * - `default-src` is the floor for every fetch type not named below (manifests,
+ *   prefetch, and whatever a future browser adds). It admits the same sources
+ *   the named directives do, so an unanticipated fetch type behaves like the
+ *   ones we thought about instead of breaking a legitimate doc.
+ * - `script-src` allows inline and https, because that is the feature. It also
+ *   allows `'unsafe-eval'`: wasm and Pyodide-class simulations need it, and
+ *   refusing eval defends a *trusted* page against injected code — it buys
+ *   nothing when the author can simply write the code inline instead.
+ * - `style-src`, `img-src`, `font-src`, `media-src` mirror that: inline, https,
+ *   and data: urls, which is exactly what a self-contained exported document
+ *   uses for embedded images and fonts.
+ * - `connect-src` is open to https on purpose, and it is worth being honest
+ *   about what that means: nothing here prevents a script from posting data it
+ *   collected to another origin. Nothing could, while scripts run at all. The
+ *   defence against a doc collecting something worth posting is `form-action`
+ *   plus a cookieless origin, not a connect allowlist that would break every
+ *   figure that loads a dataset.
+ * - `frame-src` allows https so an embedded video or map keeps working, and
+ *   blob: for viewers that frame a generated document. Those local-scheme
+ *   frames inherit this policy from their creator, so they are not a way around
+ *   the two 'none' directives below. An `https:` frame does not inherit it —
+ *   the framed origin's own policy governs that document — which is one of the
+ *   reasons `form-action` is not the phishing defence it looks like.
+ * - `worker-src` allows blob:, which is how a bundled simulation spawns a
+ *   worker without a second request.
+ * - `object-src 'none'`: `<object>`/`<embed>` load plugin content, historically
+ *   the one content type that could ignore the embedding page's CSP. Rendered
+ *   notes use `<img>`, `<iframe>` and `<canvas>`, so this costs nothing.
+ * - `base-uri 'none'`: a single `<base>` tag silently re-points every relative
+ *   url in the document. Docs are self-contained single files that never need
+ *   one, so forbidding it removes the primitive that makes a link resolve
+ *   somewhere other than where it reads.
+ * - `form-action 'none'` closes the cheapest phishing path: a page that renders
+ *   a convincing login box has nowhere to POST it, from any markup, to any
+ *   origin. It is worth stating what it is *not*, because the shape of the
+ *   directive invites the wrong conclusion — it is not a phishing defence.
+ *   `connect-src` hands the same page a `fetch()`, and `frame-src https:` lets
+ *   it embed somebody else's login form governed by somebody else's policy.
+ *   No CSP closes phishing on an origin that runs the author's scripts (D6);
+ *   what bounds it is the sacrificial host, the paid-key gate, and an origin
+ *   holding nothing but public docs.
+ * - `frame-ancestors 'none'`: no page may frame a doc. That blocks clickjacking
+ *   a doc's own content, and blocks borrowing a doc as the visible layer of
+ *   somebody else's attack. It holds against a doc framing another doc too:
+ *   `frame-src 'self'` permits the request, and this directive on the reply
+ *   refuses it.
+ *
+ * Deliberately absent: `upgrade-insecure-requests`, which is moot when no
+ * directive admits http: in the first place, and `sandbox` — the one omission
+ * worth arguing about. `sandbox allow-scripts` *without* `allow-same-origin`
+ * would put every doc in its own opaque origin, which is the only per-doc
+ * isolation available while all docs share one host: no localStorage shared
+ * between docs, no doc reading another by id. It is off because that isolation
+ * has nothing to protect yet — the origin carries no session and no private
+ * data — while its cost is immediate, since an opaque origin makes
+ * `localStorage`, `document.cookie` and `history.pushState` throw, breaking the
+ * stateful interactive docs D6 exists to allow. Revisit when free-tier
+ * publishing lands and the paid-key gate stops carrying the argument.
+ */
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self' https: data: blob:",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https: data: blob:",
+  "style-src 'self' 'unsafe-inline' https: data:",
+  "img-src 'self' https: data: blob:",
+  "font-src 'self' https: data:",
+  "media-src 'self' https: data: blob:",
+  "connect-src 'self' https: data: blob:",
+  "frame-src 'self' https: blob:",
+  "worker-src 'self' blob:",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+/** D9. The header, not the meta tag, is what applies to a 404 as well. */
+const ROBOTS = "noindex, nofollow";
+
+/** D12: the shared link is stable and serves latest directly, so it can age. */
+const LATEST_CACHE_CONTROL = "public, max-age=60";
+
+/** A version's bytes are written once and never rewritten. A year is the cap. */
+const PINNED_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+/**
+ * Every response this surface produces, including its errors, carries the whole
+ * policy. Built fresh per response because `Headers` is mutable and one shared
+ * instance would let a handler leak a header into the next request's reply.
+ *
+ * No `Set-Cookie` is ever added here or anywhere downstream. The origin being
+ * cookieless is not an accident of having nothing to store — it is the property
+ * that makes running strangers' scripts on a shared origin acceptable, so it
+ * belongs in this file's contract next to the CSP.
+ */
+function servingHeaders(cacheControl: string): Headers {
+  return new Headers({
+    "content-security-policy": CONTENT_SECURITY_POLICY,
+    "x-robots-tag": ROBOTS,
+    // The stored type is always `text/html`, so this blocks nothing today. It
+    // is here for the day an object is stored with a type that disagrees.
+    "x-content-type-options": "nosniff",
+    // The doc id *is* the access control: whoever holds the url holds the doc.
+    // Without this it would ride in `Referer` to every site the doc links to or
+    // loads an image from, handing the capability to third parties.
+    "referrer-policy": "no-referrer",
+    "cache-control": cacheControl,
+  });
+}
+
+/**
+ * Every failure this surface answers with, exported because the router's
+ * catch-all needs one too: a binding that throws mid-read must still produce a
+ * *serving* response, or an outage becomes the one doc url that invites a
+ * crawler in. Routing a thrown error back through here is what makes the header
+ * policy a property of the surface rather than of remembering to add it.
+ *
+ * All of them are `no-store` rather than cacheable. 410 in particular is
+ * heuristically cacheable by default, and a delete is the one answer a publisher
+ * may need to be able to correct. Uncached costs us nothing: none of these ever
+ * reached R2.
+ */
+export function servingError(code: "not_found" | "gone" | "internal", message: string): Response {
+  return errorResponse(code, message, servingHeaders("no-store"));
+}
+
+/**
+ * One message for "no such id", "malformed id" and "no such version" alike. The
+ * id space is not worth probing at 128 bits, but a reply that distinguished the
+ * cases would still be telling a stranger which ids are real.
+ */
+function noDocAt(pathname: string): Response {
+  return servingError("not_found", `No doc at ${pathname}`);
+}
+
+interface DocRoute {
+  docId: string;
+  /** The version from `/v{n}`, or null for the latest-version url. */
+  pinned: number | null;
+}
+
+/**
+ * Parse `/d/{docId}` and `/d/{docId}/v{n}`, or null for anything else.
+ *
+ * The prefix is matched rather than sliced off blind: on the serving host every
+ * path lands here, so `/dx{docId}` reaches this function too and must not be
+ * mistaken for a doc url.
+ *
+ * `isDocId` runs before anything else touches the database (phase 1), so junk
+ * and crawler noise cost a regex rather than a D1 read.
+ */
+function parseDocPath(pathname: string): DocRoute | null {
+  if (!pathname.startsWith(DOC_PATH_PREFIX)) return null;
+
+  const segments = pathname.slice(DOC_PATH_PREFIX.length).split("/");
+  // `/d/{docId}/` is the same page as `/d/{docId}`; a trailing slash is a
+  // browser and copy-paste artifact, not a different resource.
+  if (segments.length > 1 && segments.at(-1) === "") segments.pop();
+
+  const [docId, versionSegment, ...extra] = segments;
+  if (docId === undefined || extra.length > 0) return null;
+  if (!isDocId(docId)) return null;
+  if (versionSegment === undefined) return { docId, pinned: null };
+
+  const digits = VERSION_SEGMENT.exec(versionSegment)?.[1];
+  return digits === undefined ? null : { docId, pinned: Number(digits) };
+}
+
+/**
+ * The conditional headers R2 may act on, and only those.
+ *
+ * A failed `onlyIf` comes back as an object with no body, and R2 answers a
+ * failed `If-Match` the same way it answers a matched `If-None-Match` — but the
+ * first is a 412 and the second a 304. Forwarding only the two preconditions
+ * whose failure means "not modified" makes a bodyless result unambiguous
+ * instead of a guess.
+ */
+function notModifiedConditions(from: Headers): Headers {
+  const conditions = new Headers();
+  for (const name of ["if-none-match", "if-modified-since"]) {
+    const value = from.get(name);
+    if (value !== null) conditions.set(name, value);
+  }
+  return conditions;
+}
+
+/**
+ * Stream one version's stored bytes back, unmodified.
+ *
+ * `version` is the one that resolved to bytes; `route.pinned` is only whether
+ * the reader asked for a version by number, which is what the TTL follows. A
+ * `/v{n}` url will never mean anything else, while the shared link changes what
+ * it serves on the author's next push.
+ *
+ * The content type is this service's constant rather than the object's own
+ * metadata: we wrote these bytes and we know what they are, and reading it back
+ * off the object would let a stored value decide how a page is interpreted.
+ */
+async function serveObject(
+  request: Request,
+  env: Env,
+  route: DocRoute,
+  version: number,
+  pathname: string,
+): Promise<Response> {
+  const key = versionObjectKey(route.docId, version);
+  const headers = servingHeaders(
+    route.pinned === null ? LATEST_CACHE_CONTROL : PINNED_CACHE_CONTROL,
+  );
+
+  // A `versions` row without an object should not exist — the row is written
+  // after the object it names — but R2 is the system of record, so its answer
+  // wins over D1's rather than becoming a 500.
+  if (request.method === "HEAD") {
+    const object = await env.DOCS.head(key);
+    if (object === null) return noDocAt(pathname);
+
+    headers.set("content-type", STORED_CONTENT_TYPE);
+    headers.set("etag", object.httpEtag);
+    // Set only here. On a GET the runtime frames the body itself, and a length
+    // we computed would be a second opinion that content-encoding can falsify.
+    headers.set("content-length", String(object.size));
+    return new Response(null, { status: 200, headers });
+  }
+
+  const object = await env.DOCS.get(key, { onlyIf: notModifiedConditions(request.headers) });
+  if (object === null) return noDocAt(pathname);
+
+  headers.set("etag", object.httpEtag);
+  if (!("body" in object)) return new Response(null, { status: 304, headers });
+
+  headers.set("content-type", STORED_CONTENT_TYPE);
+  // The stream, never the bytes: a 10MB doc passes through the worker without
+  // ever being a 10MB string in it.
+  return new Response(object.body, { status: 200, headers });
+}
+
+/**
+ * The whole public surface.
+ *
+ * Order matters at the end: a deleted doc is 410 before its version is even
+ * looked at, so `GET /d/{id}/v1` on a deleted doc does not leak that v1 once
+ * existed by answering differently from `/v99`.
+ */
+export async function handleServing(request: Request, url: URL, env: Env): Promise<Response> {
+  // Two verbs, no third. A 405 would need an error code the frozen contract
+  // does not have, and nothing that legitimately reads a doc sends anything
+  // else — a POST to a doc url is a probe, and it gets what a probe gets.
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return noDocAt(url.pathname);
+  }
+
+  const route = parseDocPath(url.pathname);
+  if (route === null) return noDocAt(url.pathname);
+
+  const found = await findServableVersion(env.DB, route.docId, route.pinned);
+  if (found === null) return noDocAt(url.pathname);
+  if (found.deleted_at !== null) {
+    return servingError("gone", "This doc was deleted by its author.");
+  }
+  if (found.version === null) return noDocAt(url.pathname);
+
+  return serveObject(request, env, route, found.version, url.pathname);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -313,5 +313,9 @@ export async function handleServing(request: Request, url: URL, env: Env): Promi
   }
   if (found.version === null) return noDocAt(url.pathname);
 
-  return serveObject(request, env, route, found.version, url.pathname);
+  // `return await`, not `return`, for the reason spelled out in index.ts: an
+  // async function that hands back somebody else's promise unawaited drops
+  // itself out of the rejection's stack and, in workerd, gets the rejection
+  // reported as unhandled even though the router catches it.
+  return await serveObject(request, env, route, found.version, url.pathname);
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -238,6 +238,40 @@ function notModifiedConditions(from: Headers): Headers {
 }
 
 /**
+ * The same question `onlyIf` answers, asked directly — because `R2.head()` has
+ * no `onlyIf`, and fetching a body on a HEAD just to have R2 evaluate it would
+ * pay for bytes the method promises not to send.
+ *
+ * Precedence follows RFC 9110: `If-None-Match` wins outright when present, and
+ * `If-Modified-Since` is consulted only in its absence.
+ */
+function matchesConditions(conditions: Headers, object: R2Object): boolean {
+  const ifNoneMatch = conditions.get("if-none-match");
+  if (ifNoneMatch !== null) {
+    if (ifNoneMatch.trim() === "*") return true;
+    // Weak comparison: `W/"x"` and `"x"` are the same entity for this purpose,
+    // which is the only comparison If-None-Match is allowed to use.
+    const wanted = ifNoneMatch
+      .split(",")
+      .map((tag) => tag.trim().replace(/^W\//, ""))
+      .filter((tag) => tag.length > 0);
+    return wanted.includes(object.httpEtag.replace(/^W\//, ""));
+  }
+
+  const ifModifiedSince = conditions.get("if-modified-since");
+  if (ifModifiedSince !== null) {
+    const since = Date.parse(ifModifiedSince);
+    // An unparseable date is not a condition, so it cannot make this a 304.
+    // Second precision, because that is all an HTTP-date carries.
+    if (!Number.isNaN(since)) {
+      return Math.floor(object.uploaded.getTime() / 1000) <= Math.floor(since / 1000);
+    }
+  }
+
+  return false;
+}
+
+/**
  * Stream one version's stored bytes back, unmodified.
  *
  * `version` is the one that resolved to bytes; `route.pinned` is only whether
@@ -261,6 +295,8 @@ async function serveObject(
     route.pinned === null ? LATEST_CACHE_CONTROL : PINNED_CACHE_CONTROL,
   );
 
+  const conditions = notModifiedConditions(request.headers);
+
   // A `versions` row without an object should not exist — the row is written
   // after the object it names — but R2 is the system of record, so its answer
   // wins over D1's rather than becoming a 500.
@@ -268,15 +304,22 @@ async function serveObject(
     const object = await env.DOCS.head(key);
     if (object === null) return noDocAt(pathname);
 
-    headers.set("content-type", STORED_CONTENT_TYPE);
     headers.set("etag", object.httpEtag);
+    // A validator has to mean the same thing whichever method asks. HEAD is
+    // defined as GET without the body, so a cache revalidating with HEAD must
+    // get the 304 that GET would give it, not a 200 that says the doc changed.
+    if (matchesConditions(conditions, object)) {
+      return new Response(null, { status: 304, headers });
+    }
+
+    headers.set("content-type", STORED_CONTENT_TYPE);
     // Set only here. On a GET the runtime frames the body itself, and a length
     // we computed would be a second opinion that content-encoding can falsify.
     headers.set("content-length", String(object.size));
     return new Response(null, { status: 200, headers });
   }
 
-  const object = await env.DOCS.get(key, { onlyIf: notModifiedConditions(request.headers) });
+  const object = await env.DOCS.get(key, { onlyIf: conditions });
   if (object === null) return noDocAt(pathname);
 
   headers.set("etag", object.httpEtag);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,37 @@
+/**
+ * The R2 key layout. R2 is the system of record, so this file is the schema of
+ * the thing D1 is rebuildable *from*: a key names its doc and its version and
+ * nothing else is needed to reconstruct a pointer row.
+ *
+ * Every object is grouped under one prefix per doc, so deleting a doc is a
+ * prefix scan rather than a version-by-version walk of D1.
+ *
+ * Objects are written exactly once and never rewritten. The version number in
+ * the key is minted by an atomic D1 reservation, which is what makes "write
+ * before the row exists" safe: two pushes can never target the same key.
+ */
+
+/** Root prefix for doc content. Nothing else lives in the bucket. */
+const DOCS_PREFIX = "docs/";
+
+/**
+ * Every object belonging to one doc. Not exported yet: delete (phase 5) is the
+ * first caller that needs it from outside, and it can export it then.
+ */
+function docObjectPrefix(docId: string): string {
+  return `${DOCS_PREFIX}${docId}/`;
+}
+
+/**
+ * The immutable object holding version `n` of `docId` — `docs/{docId}/v{n}.html`.
+ * `n` starts at 1; there is no v0.
+ */
+export function versionObjectKey(docId: string, n: number): string {
+  return `${docObjectPrefix(docId)}v${n}.html`;
+}
+
+/**
+ * Content type of every stored object. Injection happens at push time (D11), so
+ * these bytes are the served bytes and this is the type they are served with.
+ */
+export const STORED_CONTENT_TYPE = "text/html; charset=utf-8";

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -15,10 +15,12 @@
 const DOCS_PREFIX = "docs/";
 
 /**
- * Every object belonging to one doc. Not exported yet: delete (phase 5) is the
- * first caller that needs it from outside, and it can export it then.
+ * Every object belonging to one doc, and nothing else. Delete lists and drops
+ * this prefix rather than walking `versions` row by row, which is what makes
+ * "all the bytes are gone" a property of R2's own listing rather than of D1's
+ * pointer index being complete.
  */
-function docObjectPrefix(docId: string): string {
+export function docObjectPrefix(docId: string): string {
   return `${DOCS_PREFIX}${docId}/`;
 }
 

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,0 +1,20 @@
+/**
+ * The public url of a doc — the one thing a publisher actually pastes into a
+ * chat, so it has to be right the first time and stable forever after (D4).
+ */
+import type { Env } from "./config.js";
+
+/**
+ * `https://{serving host}/d/{docId}`.
+ *
+ * The serving host is preferred when configured, because the url has to point
+ * at the sacrificial domain even though the push arrived on the brand one. In
+ * v0 nothing is configured and both surfaces share one workers.dev subdomain,
+ * so the request's own origin is the answer — which also means a preview
+ * deployment hands out its own urls rather than production's.
+ */
+export function publicDocUrl(env: Env, requestUrl: URL, docId: string): string {
+  const servingHost = env.SERVING_HOST?.trim();
+  const origin = servingHost ? `${requestUrl.protocol}//${servingHost}` : requestUrl.origin;
+  return `${origin}/d/${docId}`;
+}

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -428,6 +428,13 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
         });
         return { success: true };
       },
+      // Reached only once a request is past the gate: `GET /api/v1/docs` is the
+      // first handler on the other side of it, and all it wants to know is that
+      // this publisher holds no docs. Auth is what these tests are about.
+      async all() {
+        if (!/^\s*SELECT/i.test(sql)) throw new Error(`all() on non-select: ${sql}`);
+        return { results: [] };
+      },
     };
     return statement;
   };
@@ -462,8 +469,8 @@ describe("/api/v1 is gated on a publisher", () => {
 
     const res = await call(`Bearer ${KEY}`);
 
-    // The unauthenticated path 404s here in phase 1, so a 401 proves the gate
-    // answered first.
+    // This path answers 200 with a doc list once a key gets through, so a 401
+    // proves the gate answered before the handler ran.
     expect(res.status).toBe(401);
     await expect(res.json()).resolves.toEqual({
       error: { code: "unauthorized", message: expect.any(String) },
@@ -476,12 +483,11 @@ describe("/api/v1 is gated on a publisher", () => {
 
     const res = await call(`Bearer ${KEY}`, db);
 
-    // Phase 1's placeholder answer: auth passed and dispatch continued.
-    expect(res.status).toBe(404);
-    await expect(res.json()).resolves.toEqual({
-      error: { code: "not_found", message: expect.stringContaining("/api/v1/docs") },
-    });
-    // The row a phase 3 doc insert will hang its foreign key off.
+    // Auth passed and dispatch continued: this is the list handler's own answer
+    // for a publisher holding nothing.
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ docs: [] });
+    // The row every doc insert hangs its foreign key off.
     expect(db.rows.get(KEY_HASH)?.plan).toBe("plus");
   });
 
@@ -500,7 +506,7 @@ describe("/api/v1 is gated on a publisher", () => {
 
     const res = await call(`Bearer ${KEY}`, db);
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
   });
 
   it("fails a cold key during an outage as a server problem, not a bad key", async () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,515 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authenticateRequest, parseBearerToken, resolvePublisher } from "../src/auth.js";
+import { LICENSE_CACHE_TTL_MS, type Env } from "../src/config.js";
+import type { PublisherRow, PublisherStore } from "../src/db.js";
+import worker from "../src/index.js";
+
+/** A plausible Copilot Plus key. Distinctive so leak assertions mean something. */
+const KEY = "cplus_live_9f4c1a77e0b24d3e";
+/** Computed independently of the implementation. */
+const KEY_HASH = createHash("sha256").update(KEY).digest("hex");
+
+const NOW = 1_800_000_000_000;
+const now = () => NOW;
+
+const env = (over: Partial<Env> = {}): Env =>
+  ({
+    LICENSE_API_URL: "https://license.test",
+    LICENSE_API_KEY: "server-side-secret",
+    ...over,
+  }) as Env;
+
+interface MemoryStore extends PublisherStore {
+  rows: Map<string, PublisherRow>;
+}
+
+function memoryStore(...seed: PublisherRow[]): MemoryStore {
+  const rows = new Map(seed.map((row) => [row.key_hash, row]));
+  return {
+    rows,
+    async read(keyHash) {
+      return rows.get(keyHash) ?? null;
+    },
+    async save(row) {
+      rows.set(row.key_hash, { ...row });
+    },
+  };
+}
+
+const validatedAt = (msAgo: number): PublisherRow => ({
+  key_hash: KEY_HASH,
+  plan: "plus",
+  validated_at: NOW - msAgo,
+});
+
+interface LicenseStub {
+  fetch: typeof fetch;
+  calls: { url: string; init: RequestInit }[];
+}
+
+/** Records every call and answers with `reply`; never touches the network. */
+function licenseServer(reply: () => Response | Promise<Response>): LicenseStub {
+  const calls: LicenseStub["calls"] = [];
+  const stub = async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    return reply();
+  };
+  return { fetch: stub as unknown as typeof fetch, calls };
+}
+
+/** The tRPC success envelope: `{result: {data: {json: ...}}}`. */
+const answers = (json: Record<string, unknown>) => () =>
+  Response.json({ result: { data: { json } } });
+
+/**
+ * The tRPC error envelope as the license server actually emits it: superjson
+ * shape, and the HTTP status tRPC derives from the code — so a rejected key
+ * really does arrive as a 404, not a 200.
+ */
+const trpcError = (code: string, httpStatus: number) => () =>
+  Response.json(
+    { error: { json: { message: `[license] ${code}`, code: -32004, data: { code, httpStatus } } } },
+    { status: httpStatus },
+  );
+
+const validPlus = answers({ isValid: true, plan: "plus", backendAccess: true });
+
+const headerOf = (init: RequestInit, name: string) =>
+  new Headers(init.headers as HeadersInit).get(name);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("parseBearerToken", () => {
+  it("accepts the scheme in any case and with padded whitespace", () => {
+    expect(parseBearerToken("Bearer abc")).toBe("abc");
+    expect(parseBearerToken("bearer abc")).toBe("abc");
+    expect(parseBearerToken("BEARER\tabc")).toBe("abc");
+    expect(parseBearerToken("  Bearer   abc  ")).toBe("abc");
+  });
+
+  it("rejects anything that is not a single bearer token", () => {
+    expect(parseBearerToken(null)).toBeNull();
+    expect(parseBearerToken("")).toBeNull();
+    expect(parseBearerToken("abc")).toBeNull();
+    expect(parseBearerToken("Basic abc")).toBeNull();
+    expect(parseBearerToken("Bearer")).toBeNull();
+    expect(parseBearerToken("Bearer ")).toBeNull();
+    expect(parseBearerToken("Bearer abc def")).toBeNull();
+  });
+});
+
+describe("resolvePublisher — a valid key", () => {
+  it("resolves to the key's SHA-256 and caches the validation", async () => {
+    const store = memoryStore();
+    const license = licenseServer(validPlus);
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "plus" } });
+    expect(license.calls).toHaveLength(1);
+    expect(store.rows.get(KEY_HASH)).toEqual({
+      key_hash: KEY_HASH,
+      plan: "plus",
+      validated_at: NOW,
+    });
+  });
+
+  it("asks the license server with our own credential, not the publisher's key", async () => {
+    const license = licenseServer(validPlus);
+
+    await resolvePublisher(KEY, env(), { store: memoryStore(), now, fetch: license.fetch });
+
+    const call = license.calls[0]!;
+    expect(call.url).toBe("https://license.test/api/trpc/license.validateLicenseKey");
+    expect(call.init.method).toBe("POST");
+    expect(headerOf(call.init, "content-type")).toBe("application/json");
+    expect(headerOf(call.init, "authorization")).toBe("Bearer server-side-secret");
+    expect(JSON.parse(String(call.init.body))).toEqual({ json: { licenseKey: KEY } });
+  });
+
+  it("tolerates a trailing slash on LICENSE_API_URL", async () => {
+    const license = licenseServer(validPlus);
+
+    await resolvePublisher(KEY, env({ LICENSE_API_URL: "https://license.test/" }), {
+      store: memoryStore(),
+      now,
+      fetch: license.fetch,
+    });
+
+    expect(license.calls[0]!.url).toBe("https://license.test/api/trpc/license.validateLicenseKey");
+  });
+
+  it("never lets the raw key out of the module", async () => {
+    const store = memoryStore();
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(validPlus).fetch,
+    });
+
+    expect(JSON.stringify([...store.rows.values()])).not.toContain(KEY);
+    // Not even a prefix long enough to narrow a brute force.
+    expect(JSON.stringify(result)).not.toContain(KEY.slice(0, 8));
+  });
+
+  it("folds the server's uppercase plan enum", async () => {
+    const store = memoryStore();
+
+    // The live server returns the DB enum: `PLUS`, `BELIEVER`.
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(answers({ isValid: true, plan: "PLUS", backendAccess: true })).fetch,
+    });
+
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "plus" } });
+    expect(store.rows.get(KEY_HASH)?.plan).toBe("plus");
+  });
+
+  it("treats a missing backendAccess as granted, so a valid key still resolves", async () => {
+    const result = await resolvePublisher(KEY, env(), {
+      store: memoryStore(),
+      now,
+      fetch: licenseServer(answers({ isValid: true, plan: "plus" })).fetch,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("resolvePublisher — the one-hour cache", () => {
+  it("makes no license-server call for a key validated within the hour", async () => {
+    const store = memoryStore(validatedAt(59 * 60 * 1000));
+    const license = licenseServer(validPlus);
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "plus" } });
+    expect(license.calls).toHaveLength(0);
+  });
+
+  it("revalidates once the row reaches the TTL, and refreshes the row", async () => {
+    const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
+    const license = licenseServer(answers({ isValid: true, plan: "believer", backendAccess: true }));
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(license.calls).toHaveLength(1);
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+    expect(store.rows.get(KEY_HASH)).toEqual({
+      key_hash: KEY_HASH,
+      plan: "believer",
+      validated_at: NOW,
+    });
+  });
+
+  it("revalidates a key whose cached validation has long expired", async () => {
+    const store = memoryStore(validatedAt(25 * 60 * 60 * 1000));
+    const license = licenseServer(validPlus);
+
+    await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(license.calls).toHaveLength(1);
+    expect(store.rows.get(KEY_HASH)?.validated_at).toBe(NOW);
+  });
+});
+
+describe("resolvePublisher — a key the license server rejects", () => {
+  const denied = (reply: () => Response) => async () => {
+    const store = memoryStore();
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(reply).fetch,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
+    // Nothing is written, so an unauthorized key never gets a publishers row a
+    // later doc insert could hang a foreign key off.
+    expect(store.rows.size).toBe(0);
+  };
+
+  // How the real server reports a key it has no row for, or one flagged deleted:
+  // a thrown TRPCError, which tRPC serialises as a 404. It has no other way to
+  // say no — every success path it takes returns `isValid: true`.
+  it("denies a key the server does not know (tRPC NOT_FOUND)", denied(trpcError("NOT_FOUND", 404)));
+
+  it("denies an invalid key", denied(answers({ isValid: false, plan: "free" })));
+
+  it(
+    "denies a valid key without backend access",
+    denied(answers({ isValid: true, plan: "free", backendAccess: false })),
+  );
+
+  it(
+    "denies an invalid key even if backendAccess is true",
+    denied(answers({ isValid: false, backendAccess: true })),
+  );
+
+  it("leaves an existing row untouched when the key has since lapsed", async () => {
+    const stale = validatedAt(2 * 60 * 60 * 1000);
+    const store = memoryStore(stale);
+
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(answers({ isValid: false })).fetch,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
+    // The row stays: docs.publisher references it. It simply stops resolving.
+    expect(store.rows.get(KEY_HASH)).toEqual(stale);
+  });
+
+  it("locks out a revoked key that still has a cached validation", async () => {
+    const store = memoryStore(validatedAt(3 * 60 * 60 * 1000));
+
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(trpcError("NOT_FOUND", 404)).fetch,
+    });
+
+    // The outage fallback must never cover a key the server actively refused.
+    // If it did, revocation would never take effect: each request would fail to
+    // revalidate and be waved through on the stale row, forever.
+    expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
+  });
+});
+
+describe("resolvePublisher — the license server is down", () => {
+  const unreachable = [
+    ["the connection fails", () => Promise.reject(new Error("connect ECONNREFUSED"))],
+    ["it returns 500", () => new Response("boom", { status: 500 })],
+    ["it faults internally", trpcError("INTERNAL_SERVER_ERROR", 500)],
+    // Our own LICENSE_API_KEY is wrong or missing. Nothing to do with the
+    // publisher, so it must never surface as a bad license key.
+    ["it rejects our own credential", trpcError("UNAUTHORIZED", 401)],
+    ["it returns a bare 401 with no envelope", () => new Response("nope", { status: 401 })],
+    ["it returns an error envelope with no code", () => Response.json({ error: { json: {} } })],
+    ["it returns an unparseable body", () => new Response("<html>502</html>")],
+    ["it returns a body with no verdict", () => Response.json({ result: { data: { json: {} } } })],
+  ] as const;
+
+  for (const [label, reply] of unreachable) {
+    it(`allows a previously validated publisher when ${label}`, async () => {
+      const store = memoryStore(validatedAt(3 * 60 * 60 * 1000));
+
+      const result = await resolvePublisher(KEY, env(), {
+        store,
+        now,
+        fetch: licenseServer(reply as () => Response).fetch,
+      });
+
+      expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "plus" } });
+    });
+
+    it(`refuses an unknown key when ${label}`, async () => {
+      const store = memoryStore();
+
+      const result = await resolvePublisher(KEY, env(), {
+        store,
+        now,
+        fetch: licenseServer(reply as () => Response).fetch,
+      });
+
+      // Not `invalid_license`: an outage must never be reported as a bad key.
+      expect(result).toMatchObject({ ok: false, reason: "license_unavailable" });
+      expect(store.rows.size).toBe(0);
+    });
+  }
+
+  it("does not refresh the cached validation while the server is down", async () => {
+    const stale = validatedAt(3 * 60 * 60 * 1000);
+    const store = memoryStore(stale);
+
+    await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(() => Promise.reject(new Error("down"))).fetch,
+    });
+
+    // Otherwise an outage would silently extend the TTL of an unverified key.
+    expect(store.rows.get(KEY_HASH)).toEqual(stale);
+  });
+});
+
+describe("resolvePublisher — license env not configured", () => {
+  it("never calls out and refuses an unknown key", async () => {
+    const license = licenseServer(validPlus);
+
+    const result = await resolvePublisher(KEY, env({ LICENSE_API_KEY: "" }), {
+      store: memoryStore(),
+      now,
+      fetch: license.fetch,
+    });
+
+    expect(license.calls).toHaveLength(0);
+    expect(result).toMatchObject({ ok: false, reason: "license_unavailable" });
+  });
+
+  it("still honours a cached validation", async () => {
+    const result = await resolvePublisher(KEY, env({ LICENSE_API_URL: "" }), {
+      store: memoryStore(validatedAt(0)),
+      now,
+      fetch: licenseServer(validPlus).fetch,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("authenticateRequest", () => {
+  const request = (authorization?: string) =>
+    new Request("https://updoc.test/api/v1/docs", {
+      headers: authorization === undefined ? {} : { authorization },
+    });
+
+  it("reads the token out of the Authorization header", async () => {
+    const result = await authenticateRequest(request(`Bearer ${KEY}`), env(), {
+      store: memoryStore(),
+      now,
+      fetch: licenseServer(validPlus).fetch,
+    });
+
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "plus" } });
+  });
+
+  it("fails on a missing or malformed header without consulting anything", async () => {
+    const license = licenseServer(validPlus);
+    // A store that would throw if it were read: the header check must come first.
+    const store = {
+      read: () => Promise.reject(new Error("must not be read")),
+      save: () => Promise.reject(new Error("must not be written")),
+    } satisfies PublisherStore;
+
+    for (const header of [undefined, "", "Basic hunter2", "Bearer", `Token ${KEY}`]) {
+      const result = await authenticateRequest(request(header), env(), {
+        store,
+        now,
+        fetch: license.fetch,
+      });
+      expect(result).toMatchObject({ ok: false, reason: "missing_credentials" });
+    }
+    expect(license.calls).toHaveLength(0);
+  });
+});
+
+/**
+ * Just enough D1 to run the real `d1PublisherStore` statements, so the worker
+ * wiring is exercised end to end rather than through an injected store.
+ */
+function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
+  const rows = new Map<string, PublisherRow>();
+  const prepare = (sql: string) => {
+    let args: unknown[] = [];
+    const statement = {
+      bind(...bound: unknown[]) {
+        args = bound;
+        return statement;
+      },
+      async first() {
+        if (!/^\s*SELECT/i.test(sql)) throw new Error(`first() on non-select: ${sql}`);
+        return rows.get(String(args[0])) ?? null;
+      },
+      async run() {
+        if (!/^\s*INSERT/i.test(sql)) throw new Error(`run() on non-insert: ${sql}`);
+        rows.set(String(args[0]), {
+          key_hash: String(args[0]),
+          plan: String(args[1]),
+          validated_at: Number(args[2]),
+        });
+        return { success: true };
+      },
+    };
+    return statement;
+  };
+  return { prepare, rows } as unknown as D1Database & { rows: Map<string, PublisherRow> };
+}
+
+describe("/api/v1 is gated on a publisher", () => {
+  const ctx = {} as ExecutionContext;
+  const call = (authorization?: string, db: D1Database = fakeD1()) =>
+    worker.fetch(
+      new Request("https://updoc.workers.dev/api/v1/docs", {
+        headers: authorization === undefined ? {} : { authorization },
+      }),
+      env({ DB: db, SERVING_HOST: "", API_HOST: "" }),
+      ctx,
+    );
+
+  it("401s a request with no usable Authorization header", async () => {
+    for (const header of [undefined, "", "Basic hunter2", "Bearer", `Token ${KEY}`]) {
+      const res = await call(header);
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toBe("Bearer");
+      await expect(res.json()).resolves.toEqual({
+        error: { code: "unauthorized", message: expect.any(String) },
+      });
+    }
+  });
+
+  it("401s a key the license server rejects, before any handler runs", async () => {
+    // The real rejection shape: a 404 carrying a tRPC NOT_FOUND envelope.
+    vi.stubGlobal("fetch", licenseServer(trpcError("NOT_FOUND", 404)).fetch);
+
+    const res = await call(`Bearer ${KEY}`);
+
+    // The unauthenticated path 404s here in phase 1, so a 401 proves the gate
+    // answered first.
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "unauthorized", message: expect.any(String) },
+    });
+  });
+
+  it("lets a valid key through to the handlers and records the publisher", async () => {
+    vi.stubGlobal("fetch", licenseServer(validPlus).fetch);
+    const db = fakeD1();
+
+    const res = await call(`Bearer ${KEY}`, db);
+
+    // Phase 1's placeholder answer: auth passed and dispatch continued.
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "not_found", message: expect.stringContaining("/api/v1/docs") },
+    });
+    // The row a phase 3 doc insert will hang its foreign key off.
+    expect(db.rows.get(KEY_HASH)?.plan).toBe("plus");
+  });
+
+  it("does not 401 a known publisher when the license server is down", async () => {
+    vi.stubGlobal(
+      "fetch",
+      licenseServer(() => Promise.reject(new Error("down"))).fetch,
+    );
+    const db = fakeD1();
+    // Real wall clock here: the worker path uses the real `Date.now`.
+    db.rows.set(KEY_HASH, {
+      key_hash: KEY_HASH,
+      plan: "plus",
+      validated_at: Date.now() - 5 * 60 * 60 * 1000,
+    });
+
+    const res = await call(`Bearer ${KEY}`, db);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("fails a cold key during an outage as a server problem, not a bad key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      licenseServer(() => Promise.reject(new Error("down"))).fetch,
+    );
+
+    const res = await call(`Bearer ${KEY}`);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "internal", message: expect.stringContaining("temporarily unavailable") },
+    });
+  });
+});

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -53,7 +53,11 @@ function licenseServer(reply: () => Response | Promise<Response>): LicenseStub {
   const calls: LicenseStub["calls"] = [];
   const stub = async (input: unknown, init?: RequestInit) => {
     calls.push({ url: String(input), init: init ?? {} });
-    return reply();
+    // `return await`, not `return`: a bare return hands the rejection back by
+    // promise adoption, which leaves it momentarily unhandled — and workerd,
+    // where these tests now run, reports that as an unhandled rejection even
+    // though `validateLicense` catches it a tick later.
+    return await reply();
   };
   return { fetch: stub as unknown as typeof fetch, calls };
 }

--- a/test/env.d.ts
+++ b/test/env.d.ts
@@ -1,0 +1,8 @@
+import type { Env } from "../src/config.js";
+
+declare module "cloudflare:test" {
+  /** `env` inside a test is the worker's own Env, plus the migrations to apply. */
+  interface ProvidedEnv extends Env {
+    TEST_MIGRATIONS: D1Migration[];
+  }
+}

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
 import worker from "../src/index.js";
 
-const call = (path: string) => worker.fetch(new Request(`https://updoc.test${path}`));
+const env = { SERVING_HOST: "", API_HOST: "" } as Env;
+const ctx = {} as ExecutionContext;
+
+const call = (path: string) =>
+  worker.fetch(new Request(`https://updoc.test${path}`), env, ctx);
 
 describe("worker", () => {
   it("serves a health check", async () => {

--- a/test/ids.test.ts
+++ b/test/ids.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { DOC_ID_BYTES, DOC_ID_LENGTH, encodeBase32, isDocId, newDocId } from "../src/ids.js";
+
+const CROCKFORD = /^[0-9abcdefghjkmnpqrstvwxyz]+$/;
+
+describe("encodeBase32", () => {
+  it("encodes big-endian, five bits at a time", () => {
+    expect(encodeBase32(new Uint8Array([0x00]))).toBe("00");
+    expect(encodeBase32(new Uint8Array([0xff]))).toBe("zw");
+    expect(encodeBase32(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00]))).toBe("00000000");
+    expect(encodeBase32(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff]))).toBe("zzzzzzzz");
+  });
+
+  it("is injective across single-byte inputs", () => {
+    const seen = new Set<string>();
+    for (let b = 0; b < 256; b++) {
+      seen.add(encodeBase32(new Uint8Array([b])));
+    }
+    expect(seen.size).toBe(256);
+  });
+
+  it("pads the trailing partial group with zero bits, not characters", () => {
+    // 16 bytes = 128 bits = 25 full groups of 5 bits, then 3 bits left over
+    // that get zero-padded out to a 26th character.
+    expect(encodeBase32(new Uint8Array(DOC_ID_BYTES))).toHaveLength(DOC_ID_LENGTH);
+    expect(encodeBase32(new Uint8Array(DOC_ID_BYTES))).not.toContain("=");
+  });
+
+  it("carries all 128 bits — flipping any single bit changes the id", () => {
+    // The encoder shifts a 32-bit accumulator, so a bit dropped off the top
+    // would silently collapse distinct inputs onto one id and shrink the
+    // guessing space well below 2^128.
+    const seen = new Set<string>();
+    for (let bit = 0; bit < DOC_ID_BYTES * 8; bit++) {
+      const bytes = new Uint8Array(DOC_ID_BYTES);
+      bytes[bit >> 3] = 1 << bit % 8;
+      seen.add(encodeBase32(bytes));
+    }
+    expect(seen.size).toBe(DOC_ID_BYTES * 8);
+  });
+});
+
+describe("newDocId", () => {
+  const ids = Array.from({ length: 1000 }, newDocId);
+
+  it("is 26 lowercase Crockford base32 characters", () => {
+    for (const id of ids) {
+      expect(id).toHaveLength(DOC_ID_LENGTH);
+      expect(id).toMatch(CROCKFORD);
+    }
+  });
+
+  it("omits the ambiguous letters i, l, o and u", () => {
+    expect(ids.join("")).not.toMatch(/[ilou]/);
+  });
+
+  it("is url-safe as a single path segment", () => {
+    for (const id of ids.slice(0, 50)) {
+      expect(encodeURIComponent(id)).toBe(id);
+      expect(new URL(`https://updoc.page/d/${id}`).pathname).toBe(`/d/${id}`);
+    }
+  });
+
+  it("does not repeat", () => {
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("spends its full entropy budget rather than a fixed prefix", () => {
+    // Every one of the 26 characters carries data — the last one 3 bits — so a
+    // sequential or constant-seeded id would leave some position never varying.
+    for (let i = 0; i < DOC_ID_LENGTH; i++) {
+      const distinct = new Set(ids.map((id) => id[i]));
+      expect(distinct.size).toBeGreaterThan(1);
+    }
+  });
+});
+
+describe("isDocId", () => {
+  it("accepts what newDocId produces", () => {
+    expect(isDocId(newDocId())).toBe(true);
+  });
+
+  it("rejects wrong length, wrong case, and excluded letters", () => {
+    const id = newDocId();
+    expect(isDocId(id.slice(0, DOC_ID_LENGTH - 1))).toBe(false);
+    expect(isDocId(`${id}0`)).toBe(false);
+    expect(isDocId(id.toUpperCase())).toBe(false);
+    expect(isDocId(`i${id.slice(1)}`)).toBe(false);
+    expect(isDocId("")).toBe(false);
+  });
+
+  it("rejects path traversal and query junk", () => {
+    expect(isDocId("../../etc/passwd")).toBe(false);
+    expect(isDocId(`${newDocId()}/v1`)).toBe(false);
+    expect(isDocId(`${newDocId()}?x=1`)).toBe(false);
+  });
+});

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -1,0 +1,570 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import type { DocRow } from "../src/db.js";
+import { docObjectPrefix, versionObjectKey } from "../src/storage.js";
+import worker from "../src/index.js";
+
+/** v0 runs both surfaces on one workers.dev subdomain. */
+const API_ORIGIN = "https://updoc.workers.dev";
+
+const KEY_A = "cplus_live_a1b2c3d4e5f60718";
+const KEY_B = "cplus_live_9988776655443322";
+
+/** A doc id of the right shape that no push ever minted. */
+const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrs";
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Give a key a publisher row validated just now — what a real request leaves
+ * behind after auth, and what `docs.publisher` needs as a foreign key. These
+ * tests are about managing docs, not about authenticating, so the license cache
+ * is warm and no license server is ever reached.
+ */
+async function seedPublisher(key: string): Promise<string> {
+  const id = await sha256Hex(key);
+  await env.DB.prepare(
+    "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at) VALUES (?, 'plus', ?)",
+  )
+    .bind(id, Date.now())
+    .run();
+  return id;
+}
+
+let publisherA = "";
+let publisherB = "";
+
+beforeEach(async () => {
+  publisherA = await seedPublisher(KEY_A);
+  publisherB = await seedPublisher(KEY_B);
+});
+
+/** Statuses whose responses may not carry a body, per the Response constructor. */
+const BODILESS = new Set([204, 205, 304]);
+
+async function send(
+  method: string,
+  path: string,
+  key: string | null,
+  body?: unknown,
+  overrides: Partial<Env> = {},
+): Promise<Response> {
+  const headers = new Headers();
+  if (key !== null) headers.set("authorization", `Bearer ${key}`);
+
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    headers.set("content-type", "application/json");
+    init.body = JSON.stringify(body);
+  }
+
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(
+    new Request(`${API_ORIGIN}${path}`, init),
+    { ...env, ...overrides },
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+
+  // A served page is an R2 stream; left open past the test's end the pool's
+  // per-test storage isolation fails on it. Buffering here lets every test read
+  // the body, or not, without having to remember to drain it.
+  const buffered = await response.arrayBuffer();
+  return new Response(BODILESS.has(response.status) ? null : buffered, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+const del = (key: string | null, docId: string) => send("DELETE", `/api/v1/docs/${docId}`, key);
+
+const list = (key: string | null, query = "") => send("GET", `/api/v1/docs${query}`, key);
+
+const read = (path: string) => send("GET", path, null);
+
+const page = (body: string) =>
+  `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>A note</title>\n</head>\n<body>\n${body}\n</body>\n</html>\n`;
+
+interface PushResponse {
+  docId: string;
+  url: string;
+  version: number;
+}
+
+/**
+ * Publish through the real push handler. Delete is a claim about what a push
+ * left behind, so the setup has to be a real push rather than seeded rows.
+ */
+async function push(key: string, body: unknown, docId?: string): Promise<PushResponse> {
+  const response =
+    docId === undefined
+      ? await send("POST", "/api/v1/docs", key, body)
+      : await send("PUT", `/api/v1/docs/${docId}`, key, body);
+
+  expect(response.status).toBe(docId === undefined ? 201 : 200);
+  return (await response.json()) as PushResponse;
+}
+
+const publish = (key: string, title: string) => push(key, { title, html: page(`<p>${title}</p>`) });
+
+interface ListedDoc {
+  docId: string;
+  title: string;
+  url: string;
+  version: number | null;
+  updatedAt: number;
+}
+
+interface ListResponse {
+  docs: ListedDoc[];
+  cursor?: string;
+}
+
+async function listed(response: Response): Promise<ListResponse> {
+  expect(response.status).toBe(200);
+  return (await response.json()) as ListResponse;
+}
+
+const docRow = (docId: string) =>
+  env.DB.prepare("SELECT * FROM docs WHERE id = ?").bind(docId).first<DocRow>();
+
+const objectKeys = async (docId: string) =>
+  (await env.DOCS.list({ prefix: docObjectPrefix(docId) })).objects.map((o) => o.key);
+
+const allObjectKeys = async () => (await env.DOCS.list()).objects.map((o) => o.key);
+
+/**
+ * A doc row without going through push, so a test can control `created_at` to
+ * the millisecond — which is what the cursor's tie-break is about.
+ */
+async function seedDoc(
+  publisher: string,
+  id: string,
+  createdAt: number,
+  options: { versions?: number } = {},
+): Promise<string> {
+  const versions = options.versions ?? 1;
+  await env.DB.prepare(
+    `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(id, publisher, `seeded ${id}`, versions, createdAt, createdAt)
+    .run();
+
+  for (let n = 1; n <= versions; n++) {
+    await env.DB.prepare("INSERT INTO versions (doc_id, n, size, created_at) VALUES (?, ?, 1, ?)")
+      .bind(id, n, createdAt)
+      .run();
+  }
+  return id;
+}
+
+/** Valid doc ids that sort predictably, so a paging test can name what it expects. */
+const seededId = (i: number) => String(i).padStart(26, "0");
+
+/** Every docId the list yields when walked to the end, in order. */
+async function walk(key: string, limit: number): Promise<string[]> {
+  const ids: string[] = [];
+  let query = `?limit=${limit}`;
+
+  for (let requests = 0; requests <= 100; requests++) {
+    const body = await listed(await list(key, query));
+    ids.push(...body.docs.map((doc) => doc.docId));
+    if (body.cursor === undefined) return ids;
+    query = `?limit=${limit}&cursor=${encodeURIComponent(body.cursor)}`;
+  }
+  throw new Error("the list never ran out of pages");
+}
+
+describe("DELETE /api/v1/docs/{docId}", () => {
+  it("204s a doc I own and turns its public url into a 410", async () => {
+    const created = await publish(KEY_A, "A note");
+    expect((await read(`/d/${created.docId}`)).status).toBe(200);
+
+    const response = await del(KEY_A, created.docId);
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+
+    // 410, not 404: a reader holding the link learns it was withdrawn rather
+    // than concluding they mistyped it. That is what the kept row buys.
+    const gone = await read(`/d/${created.docId}`);
+    expect(gone.status).toBe(410);
+    await expect(gone.json()).resolves.toEqual({
+      error: { code: "gone", message: expect.any(String) },
+    });
+  });
+
+  it("410s the doc's pinned versions too", async () => {
+    const created = await publish(KEY_A, "A note");
+    await push(KEY_A, { html: page("<p>second draft</p>") }, created.docId);
+
+    expect((await del(KEY_A, created.docId)).status).toBe(204);
+
+    for (const path of [`/d/${created.docId}/v1`, `/d/${created.docId}/v2`]) {
+      expect({ path, status: (await read(path)).status }).toEqual({ path, status: 410 });
+    }
+  });
+
+  it("destroys the bytes of every version, not just the latest", async () => {
+    const created = await publish(KEY_A, "A note");
+    await push(KEY_A, { html: page("<p>second draft</p>") }, created.docId);
+    await push(KEY_A, { html: page("<p>third draft</p>") }, created.docId);
+    expect(await objectKeys(created.docId)).toHaveLength(3);
+
+    expect((await del(KEY_A, created.docId)).status).toBe(204);
+
+    // The content is the part that actually had to disappear. Hiding the row
+    // while leaving three copies of the doc readable by key would not be a delete.
+    expect(await objectKeys(created.docId)).toEqual([]);
+    expect(await env.DOCS.head(versionObjectKey(created.docId, 1))).toBeNull();
+    // The row stays, so the serving path can still tell 410 from 404.
+    expect(await docRow(created.docId)).toMatchObject({ deleted_at: expect.any(Number) });
+  });
+
+  it("clears a doc holding more objects than one R2 listing returns", async () => {
+    const docId = await seedDoc(publisherA, seededId(1), Date.now());
+    // 100 pushes a day compounds: a long-lived doc outgrows R2's 1000-key
+    // listing page, and a delete that read only the first page would leave the
+    // rest of the doc sitting in the bucket forever.
+    await Promise.all(
+      Array.from({ length: 1001 }, (_, i) => env.DOCS.put(versionObjectKey(docId, i + 1), "x")),
+    );
+
+    expect((await del(KEY_A, docId)).status).toBe(204);
+
+    expect(await objectKeys(docId)).toEqual([]);
+  });
+
+  it("touches no other doc's bytes", async () => {
+    const kept = await publish(KEY_A, "Kept");
+    const dropped = await publish(KEY_A, "Dropped");
+
+    expect((await del(KEY_A, dropped.docId)).status).toBe(204);
+
+    expect(await allObjectKeys()).toEqual([versionObjectKey(kept.docId, 1)]);
+    expect((await read(`/d/${kept.docId}`)).status).toBe(200);
+  });
+
+  it("404s another publisher's doc and leaves it completely untouched", async () => {
+    const created = await publish(KEY_A, "Private");
+
+    const response = await del(KEY_B, created.docId);
+
+    // 404, never 403: a 403 would confirm the id is real.
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "not_found", message: expect.any(String) },
+    });
+
+    expect(await docRow(created.docId)).toMatchObject({
+      publisher: publisherA,
+      deleted_at: null,
+    });
+    expect(await objectKeys(created.docId)).toEqual([versionObjectKey(created.docId, 1)]);
+    expect((await read(`/d/${created.docId}`)).status).toBe(200);
+  });
+
+  it("404s a second delete, and the doc stays deleted", async () => {
+    const created = await publish(KEY_A, "A note");
+    expect((await del(KEY_A, created.docId)).status).toBe(204);
+    const deletedAt = (await docRow(created.docId))?.deleted_at;
+
+    const again = await del(KEY_A, created.docId);
+
+    // Not 204 twice: an already-deleted doc has to be indistinguishable from
+    // one that never existed. What repeats safely is the outcome — the doc is
+    // still deleted, at the same moment, with no bytes.
+    expect(again.status).toBe(404);
+    expect((await docRow(created.docId))?.deleted_at).toBe(deletedAt);
+    expect(await objectKeys(created.docId)).toEqual([]);
+    expect((await read(`/d/${created.docId}`)).status).toBe(410);
+  });
+
+  it("404s a doc that never existed", async () => {
+    expect((await del(KEY_A, UNKNOWN_DOC_ID)).status).toBe(404);
+  });
+
+  it("still 204s when R2 fails after the row is already marked", async () => {
+    const created = await publish(KEY_A, "A note");
+    const brokenDocs = {
+      list: () => {
+        throw new Error("R2 unavailable");
+      },
+    } as unknown as R2Bucket;
+
+    const response = await send("DELETE", `/api/v1/docs/${created.docId}`, KEY_A, undefined, {
+      DOCS: brokenDocs,
+    });
+
+    // The row is marked before R2 is touched, so by here the doc is withdrawn
+    // from every reader whatever the bucket did. A 500 would tell the publisher
+    // their unshare failed, and the retry it invites answers 404 — leaving them
+    // certain the doc is still up when it is not.
+    expect(response.status).toBe(204);
+    expect((await read(`/d/${created.docId}`)).status).toBe(410);
+    // What the failure actually costs: objects nothing can reach any more.
+    expect(await objectKeys(created.docId)).toHaveLength(1);
+  });
+
+  it("404s an id that could never be a doc id", async () => {
+    for (const id of [
+      "not-a-doc-id",
+      "0123456789abcdefghjkmnpqrsTOOLONG",
+      "ilou00000000000000000000000",
+      "0123456789ABCDEFGHJKMNPQRS",
+    ]) {
+      const response = await del(KEY_A, id);
+      expect({ id, status: response.status }).toEqual({ id, status: 404 });
+    }
+  });
+
+  it("401s an unauthenticated delete before it reaches a handler", async () => {
+    const created = await publish(KEY_A, "A note");
+
+    const response = await del(null, created.docId);
+
+    expect(response.status).toBe(401);
+    expect(await docRow(created.docId)).toMatchObject({ deleted_at: null });
+    expect(await objectKeys(created.docId)).toHaveLength(1);
+  });
+
+  it("drops the doc out of its publisher's list", async () => {
+    const kept = await publish(KEY_A, "Kept");
+    const dropped = await publish(KEY_A, "Dropped");
+
+    expect((await del(KEY_A, dropped.docId)).status).toBe(204);
+
+    const body = await listed(await list(KEY_A));
+    expect(body.docs.map((doc) => doc.docId)).toEqual([kept.docId]);
+  });
+});
+
+describe("GET /api/v1/docs", () => {
+  it("lists only the caller's own docs", async () => {
+    const mine = [await publish(KEY_A, "Mine one"), await publish(KEY_A, "Mine two")];
+    const theirs = await publish(KEY_B, "Theirs");
+
+    const forA = await listed(await list(KEY_A));
+    const forB = await listed(await list(KEY_B));
+
+    expect(new Set(forA.docs.map((doc) => doc.docId))).toEqual(
+      new Set(mine.map((doc) => doc.docId)),
+    );
+    expect(forB.docs.map((doc) => doc.docId)).toEqual([theirs.docId]);
+    // Not merely absent from the page: another publisher's doc is not listable
+    // at all, whatever the caller does with limit.
+    expect(forB.docs.map((doc) => doc.title)).toEqual(["Theirs"]);
+  });
+
+  it("reports each doc's id, title, public url, version and update time", async () => {
+    const created = await publish(KEY_A, "A note");
+    const updated = await push(
+      KEY_A,
+      { title: "A note, revised", html: page("<p>second draft</p>") },
+      created.docId,
+    );
+    const row = await docRow(created.docId);
+
+    const body = await listed(await list(KEY_A));
+
+    expect(body.docs).toEqual([
+      {
+        docId: created.docId,
+        title: "A note, revised",
+        // The same url the push handed back, which is the one the publisher
+        // pasted somewhere and the only one they can match a list entry against.
+        url: created.url,
+        version: updated.version,
+        updatedAt: row?.updated_at,
+      },
+    ]);
+  });
+
+  it("points list urls at the serving host once one is configured (D3)", async () => {
+    const created = await publish(KEY_A, "A note");
+
+    const response = await send("GET", "/api/v1/docs", KEY_A, undefined, {
+      SERVING_HOST: "updoc.page",
+    });
+
+    expect((await listed(response)).docs[0]?.url).toBe(`https://updoc.page/d/${created.docId}`);
+  });
+
+  it("orders newest first", async () => {
+    const ids = [3, 1, 2].map((i) => seededId(i));
+    await seedDoc(publisherA, ids[0]!, 3_000);
+    await seedDoc(publisherA, ids[1]!, 1_000);
+    await seedDoc(publisherA, ids[2]!, 2_000);
+
+    const body = await listed(await list(KEY_A));
+
+    expect(body.docs.map((doc) => doc.docId)).toEqual([ids[0], ids[2], ids[1]]);
+  });
+
+  it("returns an empty list, and no cursor, for a publisher with no docs", async () => {
+    await publish(KEY_B, "Theirs");
+
+    expect(await listed(await list(KEY_A))).toEqual({ docs: [] });
+  });
+
+  it("lists a doc whose first push never wrote bytes, so it can be deleted", async () => {
+    // The crash artifact push.ts documents: a row with no versions and no
+    // object, whose id was never returned to anyone. It still counts against
+    // the 500-doc ceiling, so hiding it would make it unclearable.
+    const stranded = await seedDoc(publisherA, seededId(1), Date.now(), { versions: 0 });
+
+    const body = await listed(await list(KEY_A));
+
+    expect(body.docs).toMatchObject([{ docId: stranded, version: null }]);
+    expect((await del(KEY_A, stranded)).status).toBe(204);
+  });
+
+  it("defaults to 50 docs a page", async () => {
+    for (let i = 1; i <= 51; i++) await seedDoc(publisherA, seededId(i), i);
+
+    const body = await listed(await list(KEY_A));
+
+    expect(body.docs).toHaveLength(50);
+    expect(body.cursor).toEqual(expect.any(String));
+  });
+
+  it("honours a limit, and omits the cursor on the last page", async () => {
+    for (let i = 1; i <= 3; i++) await seedDoc(publisherA, seededId(i), i);
+
+    const first = await listed(await list(KEY_A, "?limit=2"));
+    expect(first.docs).toHaveLength(2);
+    expect(first.cursor).toEqual(expect.any(String));
+
+    const second = await listed(
+      await list(KEY_A, `?limit=2&cursor=${encodeURIComponent(first.cursor!)}`),
+    );
+    expect(second.docs).toHaveLength(1);
+    // No trailing empty page: a cursor on the last full page would cost every
+    // client one more round trip to discover the end.
+    expect(second.cursor).toBeUndefined();
+  });
+
+  it("400s a limit that is not a whole number in range", async () => {
+    for (const limit of ["0", "-1", "101", "1000", "abc", "10.5", "1e2", "", " 10", "+1"]) {
+      const response = await list(KEY_A, `?limit=${encodeURIComponent(limit)}`);
+      expect({ limit, status: response.status }).toEqual({ limit, status: 400 });
+      await expect(response.json()).resolves.toEqual({
+        error: { code: "bad_request", message: expect.any(String) },
+      });
+    }
+  });
+
+  it("accepts the boundaries of the limit range", async () => {
+    await publish(KEY_A, "A note");
+
+    for (const limit of ["1", "100"]) {
+      expect((await list(KEY_A, `?limit=${limit}`)).status).toBe(200);
+    }
+  });
+
+  it("400s a cursor it did not issue", async () => {
+    await publish(KEY_A, "A note");
+
+    for (const cursor of [
+      "",
+      "not-base64!!",
+      // Well-formed base64 over payloads that are not resume points.
+      btoa("nonsense"),
+      btoa(`${Date.now()}.not-a-doc-id`),
+      btoa(`not-a-number.${UNKNOWN_DOC_ID}`),
+      btoa(`${Number.MAX_SAFE_INTEGER}0.${UNKNOWN_DOC_ID}`),
+    ]) {
+      const response = await list(KEY_A, `?cursor=${encodeURIComponent(cursor)}`);
+      expect({ cursor, status: response.status }).toEqual({ cursor, status: 400 });
+    }
+  });
+
+  it("401s an unauthenticated list", async () => {
+    await publish(KEY_A, "A note");
+
+    expect((await list(null)).status).toBe(401);
+  });
+});
+
+describe("paging through the list", () => {
+  it("yields every doc exactly once, with no duplicates and no gaps", async () => {
+    const expected: string[] = [];
+    for (let i = 1; i <= 7; i++) {
+      expected.push(await seedDoc(publisherA, seededId(i), 1_000 + i));
+    }
+    expected.reverse();
+
+    for (const limit of [1, 2, 3, 7, 100]) {
+      const walked = await walk(KEY_A, limit);
+      expect({ limit, walked }).toEqual({ limit, walked: expected });
+    }
+  });
+
+  it("keeps the order total when docs share a created_at", async () => {
+    // Milliseconds collide — a client pushing a folder does it every time — so
+    // `created_at` alone is not a cursor. Without the id tie-break these five
+    // docs would repeat or vanish across page boundaries.
+    const ids: string[] = [];
+    for (let i = 1; i <= 5; i++) ids.push(await seedDoc(publisherA, seededId(i), 42));
+    ids.reverse();
+
+    expect(await walk(KEY_A, 2)).toEqual(ids);
+  });
+
+  it("never repeats a doc when a newer one is pushed mid-walk", async () => {
+    for (let i = 1; i <= 4; i++) await seedDoc(publisherA, seededId(i), 1_000 + i);
+
+    const first = await listed(await list(KEY_A, "?limit=2"));
+    // OFFSET paging renumbers here and page 2 would re-serve a doc from page 1.
+    await publish(KEY_A, "Pushed mid-walk");
+    const second = await listed(
+      await list(KEY_A, `?limit=2&cursor=${encodeURIComponent(first.cursor!)}`),
+    );
+
+    const seen = [...first.docs, ...second.docs].map((doc) => doc.docId);
+    expect(new Set(seen).size).toBe(seen.length);
+    expect(seen).toEqual([seededId(4), seededId(3), seededId(2), seededId(1)]);
+  });
+
+  it("skips a doc deleted mid-walk and keeps the rest whole", async () => {
+    for (let i = 1; i <= 6; i++) await seedDoc(publisherA, seededId(i), 1_000 + i);
+
+    // Page one takes 6 and 5.
+    const first = await listed(await list(KEY_A, "?limit=2"));
+    expect(first.docs.map((doc) => doc.docId)).toEqual([seededId(6), seededId(5)]);
+
+    // One doc already read and one still ahead of the cursor. Neither may
+    // disturb the walk: the resume point is a position in the ordering, not an
+    // offset, so removing rows on either side of it cannot shift anything.
+    expect((await del(KEY_A, seededId(6))).status).toBe(204);
+    expect((await del(KEY_A, seededId(3))).status).toBe(204);
+
+    const rest: string[] = [];
+    let cursor = first.cursor;
+    while (cursor !== undefined) {
+      const next = await listed(await list(KEY_A, `?limit=2&cursor=${encodeURIComponent(cursor)}`));
+      rest.push(...next.docs.map((doc) => doc.docId));
+      cursor = next.cursor;
+    }
+
+    // 3 is gone because it was deleted before the page holding it was read; 4,
+    // 2 and 1 each appear exactly once, and nothing repeats across the boundary
+    // the deletes straddled.
+    expect(rest).toEqual([seededId(4), seededId(2), seededId(1)]);
+  });
+
+  it("stops walking a publisher's page at their own docs", async () => {
+    for (let i = 1; i <= 4; i++) await seedDoc(publisherA, seededId(i), 1_000 + i);
+    for (let i = 5; i <= 8; i++) await seedDoc(publisherB, seededId(i), 1_000 + i);
+
+    // B's docs are newer, so a scan that ignored the publisher predicate on the
+    // resume step would walk straight into them.
+    expect(await walk(KEY_A, 2)).toEqual([4, 3, 2, 1].map((i) => seededId(i)));
+    expect(await walk(KEY_B, 3)).toEqual([8, 7, 6, 5].map((i) => seededId(i)));
+  });
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -634,42 +634,79 @@ describe("races the review found", () => {
     expect((await versionRows(created.docId)).map((row) => row.n)).toEqual([1]);
   });
 
-  it("ignores a metadata commit from a version that is no longer newest", async () => {
+  /**
+   * Overlapping pushes to one doc reserve their version numbers in order but can
+   * store, and therefore commit, in any order. These three cover what that must
+   * never do to the doc's metadata. They seed the `versions` rows directly and
+   * call the commit in the adverse order, because the whole point is the
+   * interleaving a client cannot be made to produce on demand.
+   */
+  const seedVersion = (docId: string, n: number, title: string | null) =>
+    env.DB.prepare(
+      "INSERT INTO versions (doc_id, n, size, title, created_at) VALUES (?, ?, 1, ?, ?)",
+    )
+      .bind(docId, n, title, Date.now())
+      .run();
+
+  it("keeps the newest version's title when an older commit lands after it", async () => {
     const created = await pushedOk(
       await post(KEY_A, { title: "first", html: page("<p>v1</p>") }),
       201,
     );
-    await pushedOk(await put(KEY_A, created.docId, { title: "second", html: page("<p>v2</p>") }), 200);
+    await pushedOk(
+      await put(KEY_A, created.docId, { title: "second", html: page("<p>v2</p>") }),
+      200,
+    );
+    const settled = await docRow(created.docId);
 
-    // The slow half of two overlapping pushes: version 1 finishing its commit
-    // after version 2 already landed. It must not leave the row advertising
-    // version 2 with version 1's title.
-    await commitVersionMetadata(env.DB, created.docId, 1, "stale", Date.now() + 1000);
+    // Version 1's commit arriving late must not drag the doc back to its title.
+    await commitVersionMetadata(env.DB, created.docId, 1, Date.now() + 1000);
 
-    expect(await docRow(created.docId)).toMatchObject({ title: "second", latest_version: 2 });
+    const after = await docRow(created.docId);
+    expect(after).toMatchObject({ title: "second", latest_version: 2 });
+    // Nor move the timestamp, which describes what the shared link serves.
+    expect(after!.updated_at).toBe(settled!.updated_at);
   });
 
-  it("commits metadata for a version that landed even when a later one burned a number", async () => {
+  it("moves the timestamp for a version that landed even when a later one burned a number", async () => {
     const created = await pushedOk(
       await post(KEY_A, { title: "first", html: page("<p>v1</p>") }),
       201,
     );
-    // Version 2 lands: its object and row both exist.
-    await pushedOk(await put(KEY_A, created.docId, { title: "second", html: page("<p>v2</p>") }), 200);
+    await pushedOk(
+      await put(KEY_A, created.docId, { title: "second", html: page("<p>v2</p>") }),
+      200,
+    );
 
-    // Version 3 reserves a number and then dies before storing anything, which
-    // is all `reserveNextVersion` does on its own. The counter is now ahead of
-    // what exists.
+    // Version 3 reserves a number and dies before storing anything, which is all
+    // `reserveNextVersion` does on its own: the counter is now ahead of reality.
     await env.DB.prepare("UPDATE docs SET latest_version = 3 WHERE id = ?")
       .bind(created.docId)
       .run();
 
-    // Version 2's commit arrives. Comparing against the counter would reject it
-    // on account of a version that never stored anything, leaving the listing
-    // describing v1 while the shared link serves v2.
-    await commitVersionMetadata(env.DB, created.docId, 2, "landed", Date.now() + 1000);
+    const landed = Date.now() + 1000;
+    await commitVersionMetadata(env.DB, created.docId, 2, landed);
 
-    expect(await docRow(created.docId)).toMatchObject({ title: "landed", latest_version: 3 });
+    // Testing against the counter would let the dead reservation veto this.
+    expect(await docRow(created.docId)).toMatchObject({ updated_at: landed, title: "second" });
+  });
+
+  it("does not lose an explicit title to a later push that omitted one", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "first", html: page("<p>v1</p>") }),
+      201,
+    );
+
+    // Two pushes in flight: 2 renames the doc, 3 only replaces the content.
+    await seedVersion(created.docId, 2, "renamed");
+    await seedVersion(created.docId, 3, null);
+
+    // 3 stores first and commits; its omitted title must not resurrect v1's.
+    await commitVersionMetadata(env.DB, created.docId, 3, Date.now() + 1000);
+    // 2 commits second, and its rename has to survive being late.
+    await commitVersionMetadata(env.DB, created.docId, 2, Date.now() + 2000);
+
+    expect(await docRow(created.docId)).toMatchObject({ title: "renamed" });
   });
 
   it("resets a blank title on update, and keeps the current one when it is absent", async () => {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -4,7 +4,7 @@ import type { Env } from "../src/config.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../src/config.js";
 import type { DocRow, PushQuotaRow, VersionRow } from "../src/db.js";
 import { isDocId } from "../src/ids.js";
-import { utcDay } from "../src/quota.js";
+import { MAX_REQUEST_BYTES, utcDay, utf8Length } from "../src/quota.js";
 import { NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
@@ -631,6 +631,49 @@ describe("races the review found", () => {
     expect(racing.status).toBe(404);
     expect(await allObjects()).toHaveLength(0);
     expect((await versionRows(created.docId)).map((row) => row.n)).toEqual([1]);
+  });
+
+  it("gives back the push when the version reservation loses to a delete", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>v1</p>") }), 201);
+    const spentAfterCreate = (await quotaRows())[0]?.pushes;
+
+    // The delete lands after ownsLiveDoc has already passed, so the push is paid
+    // for by the time reserveNextVersion refuses it.
+    await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?")
+      .bind(Date.now(), created.docId)
+      .run();
+
+    const response = await put(KEY_A, created.docId, { html: page("<p>v2</p>") });
+
+    expect(response.status).toBe(404);
+    // A rejected push costs nothing — the same promise the ownership check makes.
+    expect((await quotaRows())[0]?.pushes).toBe(spentAfterCreate);
+  });
+
+  it("budgets the request cap for worst-case JSON escaping, not typical", async () => {
+    // The bug this pins: a cap of doc-ceiling + 1MiB is a second, stricter and
+    // undocumented limit, because every `"` and `\\` doubles inside a JSON
+    // string. A document at the published ceiling made entirely of quotes
+    // serializes to twice its size, and must still be accepted.
+    expect(MAX_REQUEST_BYTES).toBeGreaterThanOrEqual(2 * MAX_DOC_BYTES);
+
+    // Asserted on the constants rather than by pushing a 10MB body: the failure
+    // is a threshold relationship, and allocating tens of megabytes per run to
+    // rediscover it would buy nothing.
+  });
+
+  it("stores quote-dense HTML unaltered", async () => {
+    const attributes = Array.from(
+      { length: 20_000 },
+      (_, i) => `<span class="a${i}" data-k="v" title="q">x</span>`,
+    ).join("");
+    const html = page(attributes);
+
+    // Escaping inflates the envelope well past the document's own size.
+    expect(utf8Length(JSON.stringify({ html }))).toBeGreaterThan(utf8Length(html) * 1.1);
+
+    const created = await pushedOk(await post(KEY_A, { title: "quoted", html }), 201);
+    expect(await stored(created.docId, 1)).toContain('data-k="v"');
   });
 
   /**

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -565,3 +565,113 @@ describe("the push routes themselves", () => {
     expect(await docRow(created.docId)).toMatchObject({ latest_version: 1 });
   });
 });
+
+describe("races the review found", () => {
+  /**
+   * A delete that lands between the version reservation and the R2 write has
+   * already scanned the prefix, so it cannot see the object the push is about
+   * to add. Unshare has to mean the bytes are gone, so the push cleans up after
+   * itself rather than leaving content behind a doc that reports 410.
+   */
+  it("removes the version it just wrote when a delete beat it to the doc", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>v1</p>") }), 201);
+
+    // The race needs the delete to land *between* the version reservation and
+    // the R2 write, which is the one ordering the handler cannot see coming. A
+    // DB that soft-deletes the doc at the moment the version row is inserted
+    // puts it exactly there, deterministically.
+    let raced = false;
+    const racingDb = new Proxy(env.DB, {
+      get(target, prop, receiver) {
+        if (prop !== "prepare") return Reflect.get(target, prop, receiver);
+        return (sql: string) => {
+          const statement = target.prepare(sql);
+          if (!sql.includes("INSERT INTO versions")) return statement;
+          return new Proxy(statement, {
+            get(stmtTarget, stmtProp, stmtReceiver) {
+              if (stmtProp !== "bind") return Reflect.get(stmtTarget, stmtProp, stmtReceiver);
+              return (...args: unknown[]) => {
+                const bound = stmtTarget.bind(...args);
+                return new Proxy(bound, {
+                  get(boundTarget, boundProp, boundReceiver) {
+                    if (boundProp !== "run") {
+                      return Reflect.get(boundTarget, boundProp, boundReceiver);
+                    }
+                    return async () => {
+                      const result = await boundTarget.run();
+                      if (!raced) {
+                        raced = true;
+                        // The concurrent DELETE: mark it gone, then scan the
+                        // prefix — which cannot yet see the object just written.
+                        await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?")
+                          .bind(Date.now(), created.docId)
+                          .run();
+                        for (const object of (await env.DOCS.list()).objects) {
+                          await env.DOCS.delete(object.key);
+                        }
+                      }
+                      return result;
+                    };
+                  },
+                });
+              };
+            },
+          });
+        };
+      },
+    }) as D1Database;
+
+    const racing = await put(KEY_A, created.docId, { html: page("<p>v2</p>") }, { DB: racingDb });
+
+    expect(raced).toBe(true);
+    // The push loses: it reports the doc gone rather than handing back a url
+    // that serves 410, and the bucket is empty because it undid its own write.
+    // Version 1 keeps its row — the stand-in delete above only soft-deleted the
+    // doc and cleared the bucket, so a row for 2 could only come from the push.
+    expect(racing.status).toBe(404);
+    expect(await allObjects()).toHaveLength(0);
+    expect((await versionRows(created.docId)).map((row) => row.n)).toEqual([1]);
+  });
+
+  /**
+   * The ceiling is documented as a hard number, so it has to hold when a
+   * publisher at the edge pushes concurrently rather than one at a time.
+   */
+  it("holds the doc ceiling when creates arrive together", async () => {
+    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER - 1);
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () => post(KEY_A, { title: "t", html: page("<p>x</p>") })),
+    );
+
+    const created = responses.filter((r) => r.status === 201);
+    const refused = responses.filter((r) => r.status === 429);
+
+    expect(created).toHaveLength(1);
+    expect(refused).toHaveLength(7);
+
+    const { n } = (await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM docs WHERE publisher = ? AND deleted_at IS NULL",
+    )
+      .bind(publisherA)
+      .first<{ n: number }>()) ?? { n: -1 };
+    expect(n).toBe(MAX_DOCS_PER_PUBLISHER);
+  });
+
+  it("does not spend a doc slot on a push refused by the daily quota", async () => {
+    await env.DB.prepare(
+      "INSERT INTO push_quota (publisher, day, pushes) VALUES (?, ?, ?)",
+    )
+      .bind(publisherA, utcDay(Date.now()), MAX_PUSHES_PER_DAY)
+      .run();
+
+    const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") });
+
+    expect(response.status).toBe(429);
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM docs WHERE publisher = ?")
+      .bind(publisherA)
+      .first<{ n: number }>()) ?? { n: -1 };
+    expect(n).toBe(0);
+    expect(await allObjects()).toHaveLength(0);
+  });
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -2,6 +2,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../src/config.js";
+import { commitVersionMetadata } from "../src/db.js";
 import type { DocRow, PushQuotaRow, VersionRow } from "../src/db.js";
 import { isDocId } from "../src/ids.js";
 import { MAX_REQUEST_BYTES, utcDay, utf8Length } from "../src/quota.js";
@@ -631,6 +632,36 @@ describe("races the review found", () => {
     expect(racing.status).toBe(404);
     expect(await allObjects()).toHaveLength(0);
     expect((await versionRows(created.docId)).map((row) => row.n)).toEqual([1]);
+  });
+
+  it("ignores a metadata commit from a version that is no longer newest", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "first", html: page("<p>v1</p>") }),
+      201,
+    );
+    await pushedOk(await put(KEY_A, created.docId, { title: "second", html: page("<p>v2</p>") }), 200);
+
+    // The slow half of two overlapping pushes: version 1 finishing its commit
+    // after version 2 already landed. It must not leave the row advertising
+    // version 2 with version 1's title.
+    await commitVersionMetadata(env.DB, created.docId, 1, "stale", Date.now() + 1000);
+
+    expect(await docRow(created.docId)).toMatchObject({ title: "second", latest_version: 2 });
+  });
+
+  it("resets a blank title on update, and keeps the current one when it is absent", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "named", html: page("<p>v1</p>") }),
+      201,
+    );
+
+    await pushedOk(await put(KEY_A, created.docId, { html: page("<p>v2</p>") }), 200);
+    expect(await docRow(created.docId)).toMatchObject({ title: "named" });
+
+    // Present but blank is not omission: it is a title of nothing, and means the
+    // same thing here as it does on create.
+    await pushedOk(await put(KEY_A, created.docId, { title: "   ", html: page("<p>v3</p>") }), 200);
+    expect(await docRow(created.docId)).toMatchObject({ title: "Untitled" });
   });
 
   it("leaves listing metadata on the last version that actually landed", async () => {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -1,0 +1,567 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../src/config.js";
+import type { DocRow, PushQuotaRow, VersionRow } from "../src/db.js";
+import { isDocId } from "../src/ids.js";
+import { utcDay } from "../src/quota.js";
+import { NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
+import { versionObjectKey } from "../src/storage.js";
+import worker from "../src/index.js";
+
+/** v0 runs both surfaces on one workers.dev subdomain. */
+const API_ORIGIN = "https://updoc.workers.dev";
+
+const KEY_A = "cplus_live_a1b2c3d4e5f60718";
+const KEY_B = "cplus_live_9988776655443322";
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Give a key a publisher row validated just now.
+ *
+ * This is what a real request leaves behind after auth (phase 2), and it is
+ * also what the `docs.publisher` foreign key needs. A fresh `validated_at`
+ * means the license cache is warm, so no test here ever needs the license
+ * server — these tests are about pushing, not about authenticating.
+ */
+async function seedPublisher(key: string): Promise<string> {
+  const id = await sha256Hex(key);
+  await env.DB.prepare(
+    "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at) VALUES (?, 'plus', ?)",
+  )
+    .bind(id, Date.now())
+    .run();
+  return id;
+}
+
+let publisherA = "";
+let publisherB = "";
+
+beforeEach(async () => {
+  publisherA = await seedPublisher(KEY_A);
+  publisherB = await seedPublisher(KEY_B);
+});
+
+interface PushResponse {
+  docId: string;
+  url: string;
+  version: number;
+}
+
+async function send(
+  method: string,
+  path: string,
+  key: string | null,
+  body?: unknown,
+  overrides: Partial<Env> = {},
+): Promise<Response> {
+  const headers = new Headers();
+  if (key !== null) headers.set("authorization", `Bearer ${key}`);
+
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    headers.set("content-type", "application/json");
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(
+    new Request(`${API_ORIGIN}${path}`, init),
+    { ...env, ...overrides },
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+const post = (key: string | null, body?: unknown, overrides?: Partial<Env>) =>
+  send("POST", "/api/v1/docs", key, body, overrides);
+
+const put = (key: string | null, docId: string, body?: unknown, overrides?: Partial<Env>) =>
+  send("PUT", `/api/v1/docs/${docId}`, key, body, overrides);
+
+const page = (body: string) =>
+  `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>A note</title>\n</head>\n<body>\n${body}\n</body>\n</html>\n`;
+
+async function stored(docId: string, n: number): Promise<string | null> {
+  const object = await env.DOCS.get(versionObjectKey(docId, n));
+  return object === null ? null : object.text();
+}
+
+const docRow = (docId: string) =>
+  env.DB.prepare("SELECT * FROM docs WHERE id = ?").bind(docId).first<DocRow>();
+
+const versionRows = async (docId: string) =>
+  (
+    await env.DB.prepare("SELECT * FROM versions WHERE doc_id = ? ORDER BY n")
+      .bind(docId)
+      .all<VersionRow>()
+  ).results;
+
+const quotaRows = async () =>
+  (await env.DB.prepare("SELECT * FROM push_quota").all<PushQuotaRow>()).results;
+
+const allObjects = async () => (await env.DOCS.list()).objects;
+
+async function pushedOk(response: Response, status: number): Promise<PushResponse> {
+  expect(response.status).toBe(status);
+  return (await response.json()) as PushResponse;
+}
+
+/** Fill a publisher's shelf without pushing 500 times through the handler. */
+async function seedDocs(publisher: string, live: number, deleted = 0): Promise<void> {
+  const now = Date.now();
+  await env.DB.prepare(
+    `WITH RECURSIVE seq(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < ?)
+     INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at, deleted_at)
+     SELECT printf('%026d', i), ?, 'seeded', 1, ?, ?, CASE WHEN i > ? THEN ? END
+       FROM seq`,
+  )
+    .bind(live + deleted, publisher, now, now, live, now)
+    .run();
+}
+
+describe("POST /api/v1/docs", () => {
+  it("publishes a 200KB doc and stores the bytes readers will get", async () => {
+    const article = `<p>${"content ".repeat(26_000)}</p>`;
+    expect(article.length).toBeGreaterThan(200 * 1024);
+
+    const body = await pushedOk(await post(KEY_A, { title: "A note", html: page(article) }), 201);
+
+    expect(isDocId(body.docId)).toBe(true);
+    expect(body).toEqual({
+      docId: body.docId,
+      url: `${API_ORIGIN}/d/${body.docId}`,
+      version: 1,
+    });
+
+    // The stored object is the served object (D11), so every claim about what a
+    // reader sees is a claim about these bytes.
+    const object = await env.DOCS.get(versionObjectKey(body.docId, 1));
+    expect(object).not.toBeNull();
+    const html = await object!.text();
+
+    expect(html.slice(0, html.indexOf("</head>"))).toContain(NOINDEX_META);
+    expect(html).toContain(`${UPDOC_FOOTER}</body>`);
+    expect(html).toContain(article);
+    expect(object!.httpMetadata?.contentType).toBe("text/html; charset=utf-8");
+
+    // D1 is a pointer index: it has to agree with what R2 actually holds.
+    expect(await docRow(body.docId)).toMatchObject({
+      publisher: publisherA,
+      title: "A note",
+      latest_version: 1,
+      deleted_at: null,
+    });
+    expect(await versionRows(body.docId)).toMatchObject([{ n: 1, size: object!.size }]);
+  });
+
+  it("keeps uploaded scripts intact (D6)", async () => {
+    const interactive = '<script>window.__updoc = "runs";</script><canvas id="figure"></canvas>';
+
+    const body = await pushedOk(
+      await post(KEY_A, { title: "Figure", html: page(interactive) }),
+      201,
+    );
+
+    expect(await stored(body.docId, 1)).toContain(interactive);
+  });
+
+  it("writes one object at the documented key and nothing else", async () => {
+    const body = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+
+    // Spelled out rather than built with `versionObjectKey`, which is what every
+    // other test here reads through: the key layout is a contract phase 4 and
+    // the delete path both depend on, and a helper compared against itself
+    // would agree with any change to it.
+    expect((await allObjects()).map((o) => o.key)).toEqual([`docs/${body.docId}/v1.html`]);
+  });
+
+  it("gives every doc its own id", async () => {
+    const first = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>1</p>") }), 201);
+    const second = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>2</p>") }), 201);
+
+    expect(second.docId).not.toBe(first.docId);
+    expect(second.version).toBe(1);
+  });
+
+  it("publishes without a title rather than refusing the share", async () => {
+    const body = await pushedOk(await post(KEY_A, { html: page("<p>x</p>") }), 201);
+
+    expect((await docRow(body.docId))?.title).toBe("Untitled");
+  });
+
+  it("points the url at the serving host once one is configured (D3)", async () => {
+    const body = await pushedOk(
+      await post(KEY_A, { title: "t", html: page("<p>x</p>") }, { SERVING_HOST: "updoc.page" }),
+      201,
+    );
+
+    expect(body.url).toBe(`https://updoc.page/d/${body.docId}`);
+  });
+});
+
+describe("PUT /api/v1/docs/{docId}", () => {
+  it("mints version 2 at the same url and leaves version 1 untouched", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "A note", html: page("<p>first draft</p>") }),
+      201,
+    );
+    const v1 = await stored(created.docId, 1);
+
+    const updated = await pushedOk(
+      await put(KEY_A, created.docId, { html: page("<p>second draft</p>") }),
+      200,
+    );
+
+    expect(updated).toEqual({ docId: created.docId, url: created.url, version: 2 });
+
+    // Immutability is the point of the version: v1 must still be byte-identical.
+    expect(await stored(created.docId, 1)).toBe(v1);
+    expect(await stored(created.docId, 2)).toContain("<p>second draft</p>");
+    expect(await stored(created.docId, 2)).toContain(NOINDEX_META);
+
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 2, title: "A note" });
+    expect(await versionRows(created.docId)).toMatchObject([{ n: 1 }, { n: 2 }]);
+  });
+
+  it("renames the doc when the push carries a title", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "Draft", html: page("<p>x</p>") }),
+      201,
+    );
+
+    await pushedOk(
+      await put(KEY_A, created.docId, { title: "Final", html: page("<p>y</p>") }),
+      200,
+    );
+
+    expect((await docRow(created.docId))?.title).toBe("Final");
+  });
+
+  it("404s another publisher's doc rather than admitting it exists", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "Private", html: page("<p>x</p>") }),
+      201,
+    );
+
+    const response = await put(KEY_B, created.docId, { html: page("<p>hijacked</p>") });
+
+    // 404, never 403: a 403 would confirm the id is real.
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "not_found", message: expect.any(String) },
+    });
+
+    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+    expect(await stored(created.docId, 1)).toContain("<p>x</p>");
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1, publisher: publisherA });
+    // And it cost the caller nothing: a push that never happened is not a push.
+    expect(await quotaRows()).toMatchObject([{ publisher: publisherA, pushes: 1 }]);
+  });
+
+  it("404s a doc that does not exist", async () => {
+    const response = await put(KEY_A, "0123456789abcdefghjkmnpqrs", { html: page("<p>x</p>") });
+
+    expect(response.status).toBe(404);
+    expect(await allObjects()).toHaveLength(0);
+  });
+
+  it("404s an id that could never be a doc id, without touching D1", async () => {
+    const impossible = [
+      "not-a-doc-id",
+      "0123456789abcdefghjkmnpqrsTOOLONG",
+      "ilou00000000000000000000000",
+    ];
+
+    for (const id of impossible) {
+      const response = await put(KEY_A, id, { html: page("<p>x</p>") });
+      expect(response.status).toBe(404);
+    }
+    expect(await quotaRows()).toHaveLength(0);
+  });
+
+  it("gives concurrent pushes different version numbers (D7)", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+
+    const [first, second] = await Promise.all([
+      put(KEY_A, created.docId, { html: page("<p>racer one</p>") }),
+      put(KEY_A, created.docId, { html: page("<p>racer two</p>") }),
+    ]);
+
+    const versions = [
+      (await pushedOk(first, 200)).version,
+      (await pushedOk(second, 200)).version,
+    ].sort();
+
+    // Sharing a number would mean sharing an R2 key, and one racer silently
+    // overwriting the other's immutable bytes.
+    expect(versions).toEqual([2, 3]);
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 3 });
+    expect(await versionRows(created.docId)).toMatchObject([{ n: 1 }, { n: 2 }, { n: 3 }]);
+
+    const bodies = [await stored(created.docId, 2), await stored(created.docId, 3)];
+    expect(bodies.filter((html) => html?.includes("racer one"))).toHaveLength(1);
+    expect(bodies.filter((html) => html?.includes("racer two"))).toHaveLength(1);
+  });
+
+  it("404s a deleted doc", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+    await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?")
+      .bind(Date.now(), created.docId)
+      .run();
+
+    const response = await put(KEY_A, created.docId, { html: page("<p>y</p>") });
+
+    expect(response.status).toBe(404);
+    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+  });
+});
+
+describe("the 10MB body ceiling", () => {
+  it("413s an html field over the ceiling and writes nothing", async () => {
+    const oversized = "a".repeat(MAX_DOC_BYTES + 1);
+
+    const response = await post(KEY_A, { title: "big", html: oversized });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "too_large", message: expect.any(String) },
+    });
+
+    expect(await allObjects()).toHaveLength(0);
+    expect(
+      await env.DB.prepare("SELECT COUNT(*) AS n FROM docs").first<{ n: number }>(),
+    ).toMatchObject({ n: 0 });
+    // Rejected before it could cost a push, so a retry with a smaller doc works.
+    expect(await quotaRows()).toHaveLength(0);
+  });
+
+  it("413s a request too large to be a legal doc at all, without buffering it", async () => {
+    const response = await post(KEY_A, { title: "huge", html: "a".repeat(MAX_DOC_BYTES * 2) });
+
+    expect(response.status).toBe(413);
+    expect(await allObjects()).toHaveLength(0);
+  });
+
+  it("413s an oversized update without minting a version", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+
+    const response = await put(KEY_A, created.docId, { html: "a".repeat(MAX_DOC_BYTES + 1) });
+
+    expect(response.status).toBe(413);
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1 });
+    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+  });
+});
+
+describe("the daily push quota", () => {
+  const spend = (publisher: string, pushes: number, day = utcDay(Date.now())) =>
+    env.DB.prepare("INSERT INTO push_quota (publisher, day, pushes) VALUES (?, ?, ?)")
+      .bind(publisher, day, pushes)
+      .run();
+
+  it("429s a publisher who has used today's pushes", async () => {
+    await spend(publisherA, MAX_PUSHES_PER_DAY);
+
+    const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") });
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "quota_exceeded", message: expect.any(String) },
+    });
+    expect(await allObjects()).toHaveLength(0);
+  });
+
+  it("429s the update path too, and only after the last push is spent", async () => {
+    await spend(publisherA, MAX_PUSHES_PER_DAY - 1);
+
+    // The last push of the day: creating the doc.
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+
+    const response = await put(KEY_A, created.docId, { html: page("<p>y</p>") });
+
+    expect(response.status).toBe(429);
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1 });
+    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+  });
+
+  it("counts each publisher separately", async () => {
+    await spend(publisherA, MAX_PUSHES_PER_DAY);
+
+    expect((await post(KEY_A, { title: "t", html: page("<p>x</p>") })).status).toBe(429);
+    expect((await post(KEY_B, { title: "t", html: page("<p>x</p>") })).status).toBe(201);
+  });
+
+  it("rolls over at the UTC day boundary", async () => {
+    await spend(publisherA, MAX_PUSHES_PER_DAY, utcDay(Date.now() - 24 * 60 * 60 * 1000));
+
+    expect((await post(KEY_A, { title: "t", html: page("<p>x</p>") })).status).toBe(201);
+  });
+
+  it("counts one push per request", async () => {
+    await post(KEY_A, { title: "t", html: page("<p>x</p>") });
+    await post(KEY_A, { title: "t", html: page("<p>y</p>") });
+
+    expect(await quotaRows()).toMatchObject([
+      { publisher: publisherA, day: utcDay(Date.now()), pushes: 2 },
+    ]);
+  });
+
+  it("loses no increments when pushes land at once", async () => {
+    const concurrent = 5;
+
+    const responses = await Promise.all(
+      Array.from({ length: concurrent }, (_, i) =>
+        post(KEY_A, { title: "t", html: page(`<p>${i}</p>`) }),
+      ),
+    );
+
+    expect(responses.map((r) => r.status)).toEqual(Array(concurrent).fill(201));
+    // Read-then-increment would let two pushes see the same count and one
+    // increment vanish, which is the hole a claim-in-one-statement upsert closes.
+    expect(await quotaRows()).toMatchObject([{ publisher: publisherA, pushes: concurrent }]);
+  });
+
+  it("gives the last push of the day to exactly one of two racing pushes", async () => {
+    await spend(publisherA, MAX_PUSHES_PER_DAY - 1);
+
+    const statuses = (
+      await Promise.all([
+        post(KEY_A, { title: "t", html: page("<p>a</p>") }),
+        post(KEY_A, { title: "t", html: page("<p>b</p>") }),
+      ])
+    )
+      .map((response) => response.status)
+      .sort();
+
+    expect(statuses).toEqual([201, 429]);
+    expect(await quotaRows()).toMatchObject([{ pushes: MAX_PUSHES_PER_DAY }]);
+  });
+});
+
+describe("a push whose write fails partway", () => {
+  /** An R2 binding that refuses to store anything. */
+  const brokenR2 = {
+    put: () => Promise.reject(new Error("R2 unavailable")),
+  } as unknown as R2Bucket;
+
+  it("answers in the error contract rather than escaping the worker", async () => {
+    const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") }, { DOCS: brokenR2 });
+
+    // An uncaught throw would be workerd's plain-text 500 — the one reply
+    // Copilot cannot parse, since it reads `error.code` on every failure.
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "internal", message: expect.any(String) },
+    });
+  });
+
+  it("never records a version whose bytes were not stored", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+
+    const response = await put(KEY_A, created.docId, { html: page("<p>y</p>") }, { DOCS: brokenR2 });
+
+    expect(response.status).toBe(500);
+    // The reservation stands and version 2 is burned — the accepted trade. What
+    // must not happen is a `versions` row for it: that row is what the serving
+    // path follows to an object, and here there is no object to follow to.
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 2 });
+    expect(await versionRows(created.docId)).toMatchObject([{ n: 1 }]);
+    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+    expect(await stored(created.docId, 1)).toContain("<p>x</p>");
+  });
+});
+
+describe("the live-doc quota", () => {
+  it("429s a publisher already holding the maximum", async () => {
+    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER);
+
+    const response = await post(KEY_A, { title: "one more", html: page("<p>x</p>") });
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "quota_exceeded", message: expect.any(String) },
+    });
+    expect(await allObjects()).toHaveLength(0);
+    // Refused before the daily counter, so being full does not also burn a push.
+    expect(await quotaRows()).toHaveLength(0);
+  });
+
+  it("does not count deleted docs, so deleting one makes room", async () => {
+    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER - 1, 5);
+
+    expect((await post(KEY_A, { title: "one more", html: page("<p>x</p>") })).status).toBe(201);
+  });
+
+  it("does not limit updates to docs the publisher already holds", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER);
+
+    expect((await put(KEY_A, created.docId, { html: page("<p>y</p>") })).status).toBe(200);
+  });
+
+  it("counts each publisher's docs separately", async () => {
+    await seedDocs(publisherB, MAX_DOCS_PER_PUBLISHER);
+
+    expect((await post(KEY_A, { title: "t", html: page("<p>x</p>") })).status).toBe(201);
+  });
+});
+
+describe("malformed pushes", () => {
+  const cases: [string, unknown][] = [
+    ["a body that is not JSON", "<html>not json</html>"],
+    ["a JSON array", ["html"]],
+    ["a JSON string", '"just a string"'],
+    ["no html field", { title: "t" }],
+    ["an empty html field", { title: "t", html: "" }],
+    ["a non-string html field", { title: "t", html: 42 }],
+    ["a non-string title", { title: 42, html: "<p>x</p>" }],
+  ];
+
+  for (const [label, body] of cases) {
+    it(`400s ${label}`, async () => {
+      const response = await post(KEY_A, body);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: { code: "bad_request", message: expect.any(String) },
+      });
+      expect(await allObjects()).toHaveLength(0);
+      expect(await quotaRows()).toHaveLength(0);
+    });
+  }
+
+  it("400s a push with no body at all", async () => {
+    expect((await post(KEY_A)).status).toBe(400);
+  });
+});
+
+describe("the push routes themselves", () => {
+  it("401s an unauthenticated push before it reaches a handler", async () => {
+    const response = await post(null, { title: "t", html: page("<p>x</p>") });
+
+    expect(response.status).toBe(401);
+    expect(await allObjects()).toHaveLength(0);
+  });
+
+  it("404s methods and shapes no route claims", async () => {
+    const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
+
+    for (const [method, path] of [
+      ["POST", `/api/v1/docs/${created.docId}`],
+      ["PUT", "/api/v1/docs"],
+      ["PATCH", `/api/v1/docs/${created.docId}`],
+      ["PUT", `/api/v1/docs/${created.docId}/v2`],
+    ] as const) {
+      const response = await send(method, path, KEY_A, { html: page("<p>x</p>") });
+      expect({ method, path, status: response.status }).toEqual({ method, path, status: 404 });
+    }
+
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1 });
+  });
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -649,6 +649,29 @@ describe("races the review found", () => {
     expect(await docRow(created.docId)).toMatchObject({ title: "second", latest_version: 2 });
   });
 
+  it("commits metadata for a version that landed even when a later one burned a number", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "first", html: page("<p>v1</p>") }),
+      201,
+    );
+    // Version 2 lands: its object and row both exist.
+    await pushedOk(await put(KEY_A, created.docId, { title: "second", html: page("<p>v2</p>") }), 200);
+
+    // Version 3 reserves a number and then dies before storing anything, which
+    // is all `reserveNextVersion` does on its own. The counter is now ahead of
+    // what exists.
+    await env.DB.prepare("UPDATE docs SET latest_version = 3 WHERE id = ?")
+      .bind(created.docId)
+      .run();
+
+    // Version 2's commit arrives. Comparing against the counter would reject it
+    // on account of a version that never stored anything, leaving the listing
+    // describing v1 while the shared link serves v2.
+    await commitVersionMetadata(env.DB, created.docId, 2, "landed", Date.now() + 1000);
+
+    expect(await docRow(created.docId)).toMatchObject({ title: "landed", latest_version: 3 });
+  });
+
   it("resets a blank title on update, and keeps the current one when it is absent", async () => {
     const created = await pushedOk(
       await post(KEY_A, { title: "named", html: page("<p>v1</p>") }),

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -756,6 +756,59 @@ describe("races the review found", () => {
     expect(await stored(created.docId, 2)).toBeNull();
   });
 
+  it("does not report a create that was deleted before its first version landed", async () => {
+    const spentBefore = (await quotaRows())[0]?.pushes ?? 0;
+
+    // The row is visible to this publisher's own list as soon as it is inserted,
+    // so a delete can land while version 1 is still being written. Proxying D1
+    // puts the delete exactly there: at the version-row insert.
+    let raced = false;
+    const racingDb = new Proxy(env.DB, {
+      get(target, prop, receiver) {
+        if (prop !== "prepare") return Reflect.get(target, prop, receiver);
+        return (sql: string) => {
+          const statement = target.prepare(sql);
+          if (!sql.includes("INSERT INTO versions")) return statement;
+          return new Proxy(statement, {
+            get(st, stProp, stRec) {
+              if (stProp !== "bind") return Reflect.get(st, stProp, stRec);
+              return (...args: unknown[]) => {
+                const bound = st.bind(...args);
+                return new Proxy(bound, {
+                  get(bt, bProp, bRec) {
+                    if (bProp !== "run") return Reflect.get(bt, bProp, bRec);
+                    return async () => {
+                      const result = await bt.run();
+                      if (!raced) {
+                        raced = true;
+                        const docId = String(args[0]);
+                        await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?")
+                          .bind(Date.now(), docId)
+                          .run();
+                        for (const object of (await env.DOCS.list()).objects) {
+                          await env.DOCS.delete(object.key);
+                        }
+                      }
+                      return result;
+                    };
+                  },
+                });
+              };
+            },
+          });
+        };
+      },
+    }) as D1Database;
+
+    const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") }, { DB: racingDb });
+
+    expect(raced).toBe(true);
+    // Not a 201 pointing at a url that serves 410, and not a spent push.
+    expect(response.status).toBe(404);
+    expect(await allObjects()).toHaveLength(0);
+    expect((await quotaRows())[0]?.pushes ?? 0).toBe(spentBefore);
+  });
+
   it("gives back the push when the version reservation loses to a delete", async () => {
     const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>v1</p>") }), 201);
     const spentAfterCreate = (await quotaRows())[0]?.pushes;

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -633,6 +633,38 @@ describe("races the review found", () => {
     expect((await versionRows(created.docId)).map((row) => row.n)).toEqual([1]);
   });
 
+  it("leaves listing metadata on the last version that actually landed", async () => {
+    const created = await pushedOk(
+      await post(KEY_A, { title: "first", html: page("<p>v1</p>") }),
+      201,
+    );
+    const before = await docRow(created.docId);
+
+    // An R2 that refuses the write: the version is already reserved, so this is
+    // the window where title and updated_at must not have moved yet.
+    const failingDocs = new Proxy(env.DOCS, {
+      get(target, prop, receiver) {
+        if (prop !== "put") return Reflect.get(target, prop, receiver);
+        return () => Promise.reject(new Error("R2 is down"));
+      },
+    }) as R2Bucket;
+
+    const response = await put(
+      KEY_A,
+      created.docId,
+      { title: "second", html: page("<p>v2</p>") },
+      { DOCS: failingDocs },
+    );
+    expect(response.status).toBe(500);
+
+    const after = await docRow(created.docId);
+    // The version number is burned — that trade is deliberate. The metadata is
+    // not: it still describes v1, which is what the public url is still serving.
+    expect(after).toMatchObject({ title: "first", updated_at: before!.updated_at });
+    expect(after!.latest_version).toBe(2);
+    expect(await stored(created.docId, 2)).toBeNull();
+  });
+
   it("gives back the push when the version reservation loses to a delete", async () => {
     const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>v1</p>") }), 201);
     const spentAfterCreate = (await quotaRows())[0]?.pushes;
@@ -656,6 +688,9 @@ describe("races the review found", () => {
     // string. A document at the published ceiling made entirely of quotes
     // serializes to twice its size, and must still be accepted.
     expect(MAX_REQUEST_BYTES).toBeGreaterThanOrEqual(2 * MAX_DOC_BYTES);
+    // Deliberately not 6x for `\uXXXX` control-character escapes: those are not
+    // valid in HTML text, and budgeting for them would hold ~60MB against a
+    // 128MB isolate to accept a document nobody writes.
 
     // Asserted on the constants rather than by pushing a 10MB body: the failure
     // is a threshold relationship, and allocating tens of megabytes per run to

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { bakeServedHtml, NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
+
+const bake = async (html: string): Promise<string> =>
+  new TextDecoder().decode(await bakeServedHtml(html));
+
+/** A document shaped like the ones Obsidian renders. */
+const page = (body: string) =>
+  `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>A note</title>\n</head>\n<body>\n${body}\n</body>\n</html>\n`;
+
+/** Everything between the head tags, so "in the head" can be asserted literally. */
+const headOf = (html: string) => html.slice(html.indexOf("<head>"), html.indexOf("</head>"));
+
+const occurrences = (haystack: string, needle: string) => haystack.split(needle).length - 1;
+
+describe("bakeServedHtml — what gets injected", () => {
+  // Every other test here compares against the exported constants, which says
+  // only that the constant landed. These pin what the constants must say: D9
+  // promises readers a page that asks not to be indexed and admits where it
+  // came from, and both claims are about literal bytes, not about a symbol.
+  it("asks robots not to index or follow", () => {
+    expect(NOINDEX_META).toBe('<meta name="robots" content="noindex,nofollow">');
+  });
+
+  it("names updoc in text a reader can see", async () => {
+    const baked = await bake(page("<p>hello</p>"));
+
+    expect(baked).toContain(">Shared with updoc<");
+  });
+});
+
+describe("bakeServedHtml — where the injections land", () => {
+  it("puts the robots meta inside the head and the footer just before </body>", async () => {
+    const baked = await bake(page("<p>hello</p>"));
+
+    expect(headOf(baked)).toContain(NOINDEX_META);
+    expect(baked).toContain(`${UPDOC_FOOTER}</body>`);
+  });
+
+  it("injects each exactly once, however many candidate tags the page has", async () => {
+    const baked = await bake(page("<div><p>one</p></div><div><p>two</p></div>"));
+
+    expect(occurrences(baked, NOINDEX_META)).toBe(1);
+    expect(occurrences(baked, UPDOC_FOOTER)).toBe(1);
+  });
+
+  it("keeps the document's own head content, including its own meta tags", async () => {
+    const baked = await bake(page("<p>hello</p>"));
+
+    expect(baked).toContain('<meta charset="utf-8">');
+    expect(baked).toContain("<title>A note</title>");
+  });
+});
+
+describe("bakeServedHtml — documents missing the tags to hang them on", () => {
+  it("still footers a document whose body is never closed", async () => {
+    // `append()` on an element with no end tag silently does nothing, which is
+    // why the footer is injected via the end tag rather than by appending.
+    const baked = await bake(
+      "<!doctype html>\n<html>\n<head><title>t</title></head>\n<body>\n<p>hi</p>",
+    );
+
+    expect(headOf(baked)).toContain(NOINDEX_META);
+    expect(baked).toContain(UPDOC_FOOTER);
+    expect(baked).toContain("<p>hi</p>");
+  });
+
+  it("still injects into a document with no head", async () => {
+    const baked = await bake("<!doctype html>\n<html>\n<body>\n<p>hi</p>\n</body>\n</html>");
+
+    expect(baked).toContain(NOINDEX_META);
+    expect(baked).toContain(`${UPDOC_FOOTER}</body>`);
+    // The doctype has to stay first: a meta ahead of it would put the page into
+    // quirks mode, which is a real change to how the document renders.
+    expect(baked.startsWith("<!doctype html>")).toBe(true);
+  });
+
+  it("still injects into a bare fragment", async () => {
+    const baked = await bake("<p>just a fragment</p>");
+
+    expect(baked).toContain("<p>just a fragment</p>");
+    expect(baked).toContain(NOINDEX_META);
+    expect(baked).toContain(UPDOC_FOOTER);
+  });
+});
+
+describe("bakeServedHtml — the document's own content", () => {
+  it("leaves scripts, handlers and iframes exactly as uploaded (D6)", async () => {
+    const interactive =
+      '<script>const a = 1 < 2 && 3 > 2; document.title = "x";</script>' +
+      '<button onclick="alert(1)">go</button>' +
+      '<iframe src="https://example.com/figure"></iframe>' +
+      "<script src=\"https://cdn.example.com/plot.js\"></script>";
+
+    const baked = await bake(page(interactive));
+
+    expect(baked).toContain(interactive);
+  });
+
+  it("does not inject into markup that only looks like a tag", async () => {
+    // The whole reason this is a parser and not a regex: neither of these is a
+    // head or a body, and a string replace would have injected into both.
+    const decoys =
+      '<script>document.write("<head></head><body></body>");</script>' +
+      "<!-- <head> a commented-out head </head> -->" +
+      "<pre>&lt;body&gt;</pre>";
+
+    const baked = await bake(page(decoys));
+
+    expect(baked).toContain(decoys);
+    expect(occurrences(baked, NOINDEX_META)).toBe(1);
+    expect(occurrences(baked, UPDOC_FOOTER)).toBe(1);
+  });
+
+  it("preserves non-ASCII content byte for byte", async () => {
+    const body = "<p>callout — “quoted”, 日本語, 🌍</p>";
+
+    const baked = await bake(page(body));
+
+    expect(baked).toContain(body);
+  });
+
+  it("returns the bytes that will be stored, not characters", async () => {
+    const bytes = await bakeServedHtml(page("<p>日本語</p>"));
+    const text = new TextDecoder().decode(bytes);
+
+    // Three characters, nine bytes. A length in characters would under-report
+    // the object, and the version row's `size` would disagree with what R2 holds.
+    expect(bytes.byteLength).toBe(text.length + 6);
+  });
+});

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import worker, { resolveSurface } from "../src/index.js";
+
+/** Phase 1 routing never touches a binding, so the storage bindings stay unset. */
+const env = (vars: Partial<Env> = {}): Env =>
+  ({ SERVING_HOST: "", API_HOST: "", ...vars }) as Env;
+
+const ctx = {} as ExecutionContext;
+
+const get = (url: string, vars: Partial<Env> = {}) =>
+  worker.fetch(new Request(url), env(vars), ctx);
+
+const WORKERS_DEV = "updoc.workers.dev";
+const TWO_DOMAIN = { servingHost: "updoc.page", apiHost: "api.updoc.md" };
+
+describe("resolveSurface — workers.dev, no hosts configured", () => {
+  const unset = {};
+
+  it("routes /api/v1 paths to the API surface", () => {
+    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs", unset)).toBe("api");
+    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs/abc", unset)).toBe("api");
+    expect(resolveSurface(WORKERS_DEV, "/api/v1", unset)).toBe("api");
+  });
+
+  it("routes /d paths to the serving surface", () => {
+    expect(resolveSurface(WORKERS_DEV, "/d/abc", unset)).toBe("serving");
+    expect(resolveSurface(WORKERS_DEV, "/d/abc/v2", unset)).toBe("serving");
+  });
+
+  it("does not treat a prefix lookalike as a match", () => {
+    expect(resolveSurface(WORKERS_DEV, "/api/v11/docs", unset)).toBe("unknown");
+    expect(resolveSurface(WORKERS_DEV, "/docs", unset)).toBe("unknown");
+    expect(resolveSurface(WORKERS_DEV, "/", unset)).toBe("unknown");
+  });
+
+  it("ignores empty host vars the same as absent ones", () => {
+    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs", { servingHost: "", apiHost: "" })).toBe(
+      "api",
+    );
+  });
+});
+
+describe("resolveSurface — two configured domains", () => {
+  it("routes by host, not path", () => {
+    expect(resolveSurface("updoc.page", "/d/abc", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("api.updoc.md", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+  });
+
+  it("keeps /api/v1 off the serving host", () => {
+    expect(resolveSurface("updoc.page", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("updoc.page", "/api/v1/docs/abc", TWO_DOMAIN)).toBe("serving");
+  });
+
+  it("keeps doc serving off the API host", () => {
+    expect(resolveSurface("api.updoc.md", "/d/abc", TWO_DOMAIN)).toBe("api");
+  });
+
+  it("matches the host case-insensitively and ignores the root dot", () => {
+    // Both forms reach `/api/v1` if the match fails, so each asserts the
+    // security property rather than just a normalisation detail.
+    expect(resolveSurface("UPDOC.PAGE", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("updoc.page.", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("updoc.page", "/api/v1/docs", { servingHost: "UPDOC.Page." })).toBe(
+      "serving",
+    );
+  });
+
+  it("does not match a subdomain or suffix of a configured host", () => {
+    // A path with no prefix to fall back on, so "unknown" can only mean the
+    // host itself did not match.
+    expect(resolveSurface("evil.updoc.page", "/nope", TWO_DOMAIN)).toBe("unknown");
+    expect(resolveSurface("updoc.page.evil.com", "/nope", TWO_DOMAIN)).toBe("unknown");
+    expect(resolveSurface("notupdoc.page", "/nope", TWO_DOMAIN)).toBe("unknown");
+    // And a lookalike host still gets no serving treatment for an API path.
+    expect(resolveSurface("evil.updoc.page", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+  });
+
+  it("falls back to path prefixes on an unrecognised host", () => {
+    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+    expect(resolveSurface(WORKERS_DEV, "/d/abc", TWO_DOMAIN)).toBe("serving");
+  });
+
+  it("routes by host when only the serving host is configured", () => {
+    expect(resolveSurface("updoc.page", "/api/v1/docs", { servingHost: "updoc.page" })).toBe(
+      "serving",
+    );
+  });
+});
+
+describe("worker dispatch", () => {
+  it("serves the health check on any host", async () => {
+    for (const host of [WORKERS_DEV, "updoc.page", "api.updoc.md"]) {
+      const res = await get(`https://${host}/health`, {
+        SERVING_HOST: "updoc.page",
+        API_HOST: "api.updoc.md",
+      });
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ ok: true });
+    }
+  });
+
+  it("answers unknown paths with the error contract", async () => {
+    const res = await get(`https://${WORKERS_DEV}/nope`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "not_found", message: expect.stringContaining("/nope") },
+    });
+  });
+
+  it("hands /api/v1 to the API surface on workers.dev", async () => {
+    const res = await get(`https://${WORKERS_DEV}/api/v1/docs`);
+    expect(res.status).toBe(404);
+    // The serving surface stamps every response it produces; the API does not.
+    expect(res.headers.get("x-robots-tag")).toBeNull();
+  });
+
+  it("hands /d to the serving surface on workers.dev", async () => {
+    const res = await get(`https://${WORKERS_DEV}/d/abc`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+  });
+
+  it("never reaches the API surface on the serving host", async () => {
+    // Including the trailing-root-dot form, which `new URL()` preserves in
+    // `hostname` and which would otherwise miss the host match and fall
+    // through to the /api/v1 path prefix.
+    for (const host of ["updoc.page", "updoc.page.", "UPDOC.PAGE"]) {
+      const res = await get(`https://${host}/api/v1/docs`, {
+        SERVING_HOST: "updoc.page",
+        API_HOST: "api.updoc.md",
+      });
+      expect(res.status).toBe(404);
+      // Two independent signals that the serving surface answered: only it
+      // stamps the robots header, and only it phrases the miss as a doc.
+      expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+      await expect(res.json()).resolves.toEqual({
+        error: { code: "not_found", message: expect.stringContaining("No doc at") },
+      });
+    }
+  });
+
+  it("never sets a cookie on the serving surface", async () => {
+    const res = await get("https://updoc.page/d/abc", { SERVING_HOST: "updoc.page" });
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -110,8 +110,10 @@ describe("worker dispatch", () => {
   });
 
   it("hands /api/v1 to the API surface on workers.dev", async () => {
+    // The API surface authenticates before it routes (phase 2), so an
+    // unauthenticated request stops at 401 rather than reaching a handler.
     const res = await get(`https://${WORKERS_DEV}/api/v1/docs`);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(401);
     // The serving surface stamps every response it produces; the API does not.
     expect(res.headers.get("x-robots-tag")).toBeNull();
   });

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -1,0 +1,505 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import { NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
+import { versionObjectKey } from "../src/storage.js";
+import worker from "../src/index.js";
+
+/** v0 runs both surfaces on one workers.dev subdomain. */
+const ORIGIN = "https://updoc.workers.dev";
+
+const KEY = "cplus_live_a1b2c3d4e5f60718";
+
+/** A doc id of the right shape that no push ever minted. */
+const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrs";
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * A publisher row with a fresh validation, which is what a real request leaves
+ * behind after auth and what `docs.publisher` needs as a foreign key. Reading is
+ * unauthenticated, so this exists only so the pushes that set up each test can
+ * run without a license server.
+ */
+let publisher = "";
+
+beforeEach(async () => {
+  publisher = await sha256Hex(KEY);
+  await env.DB.prepare(
+    "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at) VALUES (?, 'plus', ?)",
+  )
+    .bind(publisher, Date.now())
+    .run();
+});
+
+/** Statuses whose responses may not carry a body, per the Response constructor. */
+const BODILESS = new Set([204, 205, 304]);
+
+async function send(
+  method: string,
+  path: string,
+  init: RequestInit = {},
+  overrides: Partial<Env> = {},
+): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(
+    new Request(`${ORIGIN}${path}`, { method, ...init }),
+    { ...env, ...overrides },
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+
+  // A served page is an R2 stream, and a test that only looks at the headers
+  // would leave it open past its own end — which the pool's per-test storage
+  // isolation fails on. Buffering here lets every test read the body, or not,
+  // without each one having to remember to drain it.
+  const body = await response.arrayBuffer();
+  return new Response(BODILESS.has(response.status) ? null : body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+const get = (path: string, init?: RequestInit, overrides?: Partial<Env>) =>
+  send("GET", path, init, overrides);
+
+const page = (body: string) =>
+  `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>A note</title>\n</head>\n<body>\n${body}\n</body>\n</html>\n`;
+
+/**
+ * Publish through the real push handler rather than seeding R2 by hand: the
+ * claim under test is that a reader gets the bytes a push produced, so the
+ * pushes have to be real ones.
+ */
+async function push(body: unknown, docId?: string): Promise<string> {
+  const response = await send(
+    docId === undefined ? "POST" : "PUT",
+    docId === undefined ? "/api/v1/docs" : `/api/v1/docs/${docId}`,
+    {
+      headers: { authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  expect(response.status).toBe(docId === undefined ? 201 : 200);
+  return ((await response.json()) as { docId: string }).docId;
+}
+
+/** The exact bytes push stored, which every served response is compared to. */
+async function stored(docId: string, n: number): Promise<string> {
+  const object = await env.DOCS.get(versionObjectKey(docId, n));
+  expect(object).not.toBeNull();
+  return object!.text();
+}
+
+const softDelete = (docId: string) =>
+  env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?").bind(Date.now(), docId).run();
+
+/** A doc at version 2, so latest and pinned can never be confused. */
+async function twoVersionDoc(): Promise<string> {
+  const docId = await push({ title: "A note", html: page("<p>first draft</p>") });
+  await push({ html: page("<p>second draft</p>") }, docId);
+  return docId;
+}
+
+describe("GET /d/{docId}", () => {
+  it("serves the latest version's stored bytes with a 60s TTL and no cookie", async () => {
+    const docId = await twoVersionDoc();
+
+    const response = await get(`/d/${docId}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+
+    // Byte-for-byte: serving is a passthrough (D11), so the reader's page and
+    // the stored object are the same thing, footer and robots meta included.
+    const html = await response.text();
+    expect(html).toBe(await stored(docId, 2));
+    expect(html).toContain("<p>second draft</p>");
+    expect(html).not.toContain("<p>first draft</p>");
+    expect(html).toContain(NOINDEX_META);
+    expect(html).toContain(UPDOC_FOOTER);
+  });
+
+  it("serves version 1 at the same url before there is a version 2", async () => {
+    const docId = await push({ title: "A note", html: page("<p>only draft</p>") });
+
+    const response = await get(`/d/${docId}`);
+
+    expect(response.status).toBe(200);
+    // The TTL follows the url, not the version number: this url will change
+    // what it serves the moment the author pushes again.
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(await stored(docId, 1));
+  });
+
+  it("serves the newest version that has bytes, not the burned reservation", async () => {
+    const docId = await twoVersionDoc();
+    // What a push that dies between reserving a version and writing its object
+    // leaves behind (see `docs.latest_version`). Serving the counter would 404
+    // a perfectly healthy doc.
+    await env.DB.prepare("UPDATE docs SET latest_version = 7 WHERE id = ?").bind(docId).run();
+
+    const response = await get(`/d/${docId}`);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(await stored(docId, 2));
+  });
+
+  it("serves the same page with a trailing slash", async () => {
+    const docId = await twoVersionDoc();
+
+    const response = await get(`/d/${docId}/`);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(await stored(docId, 2));
+  });
+});
+
+describe("GET /d/{docId}/v{n}", () => {
+  it("still serves version 1 immutably after version 2 lands", async () => {
+    const docId = await twoVersionDoc();
+
+    const response = await get(`/d/${docId}/v1`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("set-cookie")).toBeNull();
+
+    const html = await response.text();
+    expect(html).toBe(await stored(docId, 1));
+    expect(html).toContain("<p>first draft</p>");
+    expect(html).not.toContain("<p>second draft</p>");
+  });
+
+  it("serves the newest version at its own pinned url too", async () => {
+    const docId = await twoVersionDoc();
+
+    const response = await get(`/d/${docId}/v2`);
+
+    expect(response.status).toBe(200);
+    // Immutable because the url names a version, not because the version is
+    // old: /v2 will never mean anything else, even once /v3 exists.
+    expect(response.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(await response.text()).toBe(await stored(docId, 2));
+  });
+
+  it("404s a version above the ones that exist", async () => {
+    const docId = await twoVersionDoc();
+
+    for (const n of [3, 4, 99]) {
+      const response = await get(`/d/${docId}/v${n}`);
+      expect({ n, status: response.status }).toEqual({ n, status: 404 });
+    }
+  });
+
+  it("404s a version that was reserved but never written", async () => {
+    const docId = await twoVersionDoc();
+    await env.DB.prepare("UPDATE docs SET latest_version = 7 WHERE id = ?").bind(docId).run();
+
+    // Below the counter, but there are no bytes: a 500 or an empty page would
+    // be the alternative to checking `versions` rather than `latest_version`.
+    expect((await get(`/d/${docId}/v3`)).status).toBe(404);
+  });
+
+  it("404s a version segment that is not one canonical number", async () => {
+    const docId = await twoVersionDoc();
+
+    // One version, one url. Leading zeros and signs would each be a second
+    // spelling of /v1, and an immutably cached page should have exactly one.
+    for (const segment of ["v0", "v01", "v+1", "v1.0", "v-1", "v", "1", "version1", "V1", "v1x"]) {
+      const response = await get(`/d/${docId}/${segment}`);
+      expect({ segment, status: response.status }).toEqual({ segment, status: 404 });
+    }
+  });
+});
+
+describe("the headers on every served page", () => {
+  /** Latest, pinned, a miss and a deleted doc — every reply this surface makes. */
+  async function everyServingResponse(): Promise<Response[]> {
+    const live = await twoVersionDoc();
+    const deleted = await push({ title: "Gone", html: page("<p>x</p>") });
+    await softDelete(deleted);
+
+    return Promise.all([
+      get(`/d/${live}`),
+      get(`/d/${live}/v1`),
+      send("HEAD", `/d/${live}`),
+      get(`/d/${UNKNOWN_DOC_ID}`),
+      get("/d/not-a-doc-id"),
+      get(`/d/${deleted}`),
+    ]);
+  }
+
+  it("asks every crawler not to index or follow (D9)", async () => {
+    for (const response of await everyServingResponse()) {
+      expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    }
+  });
+
+  it("never sets a cookie, which is what makes running uploaded scripts safe", async () => {
+    for (const response of await everyServingResponse()) {
+      expect(response.headers.get("set-cookie")).toBeNull();
+    }
+  });
+
+  it("blocks form submission and framing on every response", async () => {
+    for (const response of await everyServingResponse()) {
+      const csp = response.headers.get("content-security-policy") ?? "";
+      const directives = csp.split(";").map((directive) => directive.trim());
+
+      // The two directives the whole D6 trade rests on: a doc may run scripts,
+      // but it may not post a form anywhere, and it may not be framed.
+      expect(directives).toContain("form-action 'none'");
+      expect(directives).toContain("frame-ancestors 'none'");
+      // And nothing may re-point the document's relative urls.
+      expect(directives).toContain("base-uri 'none'");
+      expect(directives).toContain("object-src 'none'");
+    }
+  });
+
+  it("still lets an uploaded doc run its scripts and load its assets (D6)", async () => {
+    const csp = (await get(`/d/${await twoVersionDoc()}`)).headers.get("content-security-policy");
+    const directive = (name: string) =>
+      (csp ?? "")
+        .split(";")
+        .map((d) => d.trim())
+        .find((d) => d.startsWith(`${name} `)) ?? "";
+
+    // Interactive figures and embedded simulations are the reason the client
+    // uploads HTML at all; a policy that broke them would be the wrong trade.
+    for (const name of ["script-src", "style-src"]) {
+      expect(directive(name)).toContain("'unsafe-inline'");
+      expect(directive(name)).toContain("https:");
+    }
+    expect(directive("script-src")).toContain("'unsafe-eval'");
+    for (const name of ["img-src", "font-src"]) {
+      expect(directive(name)).toContain("https:");
+      expect(directive(name)).toContain("data:");
+    }
+  });
+
+  it("keeps the whole policy on a failure no handler expected", async () => {
+    // R2 down mid-read, which is the one serving response that is not written
+    // by hand in serve.ts. A crawler that catches an outage on a doc url must
+    // still be told not to index it, so the 500 has to be a *serving* 500.
+    const brokenDocs = {
+      get: () => {
+        throw new Error("R2 unavailable");
+      },
+    } as unknown as R2Bucket;
+
+    const docId = await twoVersionDoc();
+    const response = await get(`/d/${docId}`, undefined, { DOCS: brokenDocs });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "internal", message: expect.any(String) },
+    });
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("keeps the doc url out of the Referer of everything the page touches", async () => {
+    // The id is the only access control there is, so leaking it in a header to
+    // every linked site would hand the doc away.
+    const response = await get(`/d/${await twoVersionDoc()}`);
+
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+});
+
+describe("a deleted doc", () => {
+  it("returns 410 gone rather than 404", async () => {
+    const docId = await twoVersionDoc();
+    await softDelete(docId);
+
+    const response = await get(`/d/${docId}`);
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "gone", message: expect.any(String) },
+    });
+    // A reader who bookmarked the link deserves to know it was withdrawn, not
+    // to wonder whether they mistyped it.
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns 410 for its pinned versions too, without leaking which existed", async () => {
+    const docId = await twoVersionDoc();
+    await softDelete(docId);
+
+    for (const path of [`/d/${docId}/v1`, `/d/${docId}/v2`, `/d/${docId}/v99`]) {
+      const response = await get(path);
+      expect({ path, status: response.status }).toEqual({ path, status: 410 });
+    }
+  });
+
+  it("returns 410 once the bytes are gone as well", async () => {
+    const docId = await twoVersionDoc();
+    await softDelete(docId);
+    // Phase 5's delete drops the R2 objects. The answer must not change to 404
+    // when it does.
+    await env.DOCS.delete([versionObjectKey(docId, 1), versionObjectKey(docId, 2)]);
+
+    expect((await get(`/d/${docId}`)).status).toBe(410);
+  });
+});
+
+describe("a doc that is not there", () => {
+  it("404s an id no push ever minted", async () => {
+    const response = await get(`/d/${UNKNOWN_DOC_ID}`);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "not_found", message: expect.stringContaining("No doc at") },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("404s a doc row with no version yet", async () => {
+    // The other half of a push that died mid-write: a `docs` row whose id was
+    // never returned to anyone, so nothing points at it and nothing has bytes.
+    await env.DB.prepare(
+      `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+       VALUES (?, ?, 'stranded', 1, ?, ?)`,
+    )
+      .bind(UNKNOWN_DOC_ID, publisher, Date.now(), Date.now())
+      .run();
+
+    expect((await get(`/d/${UNKNOWN_DOC_ID}`)).status).toBe(404);
+  });
+
+  it("404s an object D1 promises but R2 does not have", async () => {
+    const docId = await twoVersionDoc();
+    await env.DOCS.delete(versionObjectKey(docId, 2));
+
+    // R2 is the system of record, so its answer wins over the pointer index's
+    // — a missing object is a miss, not a 500.
+    expect((await get(`/d/${docId}`)).status).toBe(404);
+    expect((await get(`/d/${docId}/v1`)).status).toBe(200);
+  });
+
+  it("404s ids that could never be doc ids, without touching D1", async () => {
+    // A binding that fails on contact, so reaching D1 at all is a 500 rather
+    // than a passing test: junk and crawler noise must cost a regex, not a read.
+    const noDb = {
+      prepare: () => {
+        throw new Error("D1 must not be touched for a malformed id");
+      },
+    } as unknown as D1Database;
+
+    const impossible = [
+      "/d",
+      "/d/",
+      "/d/not-a-doc-id",
+      "/d/0123456789abcdefghjkmnpqrsTOOLONG",
+      "/d/ilou00000000000000000000000",
+      "/d/0123456789ABCDEFGHJKMNPQRS",
+      `/d/${UNKNOWN_DOC_ID}/v1/extra`,
+      `/d${UNKNOWN_DOC_ID}`,
+      `/dx/${UNKNOWN_DOC_ID}`,
+    ];
+
+    // Configured so that *every* path on this host is the serving surface,
+    // which is what the sacrificial domain looks like (D3). It is the only
+    // arrangement in which the prefix lookalikes below reach this handler at
+    // all — on workers.dev the router answers them as unknown paths — and it is
+    // the arrangement where mistaking `/dx{docId}` for a doc url would matter.
+    const servingHost = { SERVING_HOST: "updoc.workers.dev", DB: noDb };
+
+    for (const path of impossible) {
+      const response = await get(path, undefined, servingHost);
+      expect({ path, status: response.status }).toEqual({ path, status: 404 });
+      expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    }
+  });
+
+  it("404s methods the serving surface does not have", async () => {
+    const docId = await twoVersionDoc();
+
+    for (const method of ["POST", "PUT", "DELETE", "PATCH"]) {
+      const response = await send(method, `/d/${docId}`);
+      expect({ method, status: response.status }).toEqual({ method, status: 404 });
+    }
+    // And the doc is untouched by the attempt.
+    expect((await get(`/d/${docId}`)).status).toBe(200);
+  });
+});
+
+describe("HEAD and conditional requests", () => {
+  it("answers HEAD with the page's headers and no body", async () => {
+    const docId = await twoVersionDoc();
+    const html = await stored(docId, 2);
+
+    const response = await send("HEAD", `/d/${docId}`);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(response.headers.get("content-length")).toBe(
+      String(new TextEncoder().encode(html).byteLength),
+    );
+    expect(response.headers.get("content-security-policy")).toContain("form-action 'none'");
+  });
+
+  it("404s HEAD for a doc that is not there", async () => {
+    expect((await send("HEAD", `/d/${UNKNOWN_DOC_ID}`)).status).toBe(404);
+  });
+
+  it("410s HEAD for a deleted doc", async () => {
+    const docId = await twoVersionDoc();
+    await softDelete(docId);
+
+    expect((await send("HEAD", `/d/${docId}`)).status).toBe(410);
+  });
+
+  it("answers a matching If-None-Match with 304 and no body", async () => {
+    const docId = await twoVersionDoc();
+
+    const first = await get(`/d/${docId}`);
+    const etag = first.headers.get("etag");
+    expect(etag).not.toBeNull();
+    await first.text();
+
+    const second = await get(`/d/${docId}`, { headers: { "if-none-match": etag! } });
+
+    expect(second.status).toBe(304);
+    expect(await second.text()).toBe("");
+    // A 304 still has to carry the policy: it refreshes what the browser holds.
+    expect(second.headers.get("etag")).toBe(etag);
+    expect(second.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(second.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+  });
+
+  it("serves the body when the client holds a different version's etag", async () => {
+    const docId = await twoVersionDoc();
+
+    const stale = (await get(`/d/${docId}/v1`)).headers.get("etag");
+    const response = await get(`/d/${docId}`, { headers: { "if-none-match": stale! } });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(await stored(docId, 2));
+  });
+
+  it("gives each version its own etag", async () => {
+    const docId = await twoVersionDoc();
+
+    const v1 = (await get(`/d/${docId}/v1`)).headers.get("etag");
+    const v2 = (await get(`/d/${docId}/v2`)).headers.get("etag");
+    const latest = (await get(`/d/${docId}`)).headers.get("etag");
+
+    expect(v1).not.toBe(v2);
+    // The shared link's etag has to move with the version, or a 60s-stale
+    // reader would revalidate into the old page forever.
+    expect(latest).toBe(v2);
+  });
+});

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -480,6 +480,47 @@ describe("HEAD and conditional requests", () => {
     expect(second.headers.get("x-robots-tag")).toBe("noindex, nofollow");
   });
 
+  it("answers HEAD the same way GET does when the validator matches", async () => {
+    const docId = await twoVersionDoc();
+
+    const etag = (await send("HEAD", `/d/${docId}`)).headers.get("etag");
+    expect(etag).not.toBeNull();
+
+    const revalidated = await send("HEAD", `/d/${docId}`, {
+      headers: { "if-none-match": etag! },
+    });
+
+    // A validator cannot mean one thing to GET and another to HEAD: a cache
+    // revalidating with HEAD would otherwise be told the doc changed when it
+    // did not, and re-fetch every time.
+    expect(revalidated.status).toBe(304);
+    expect(revalidated.headers.get("etag")).toBe(etag);
+    expect(revalidated.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+
+    const viaGet = await get(`/d/${docId}`, { headers: { "if-none-match": etag! } });
+    expect(viaGet.status).toBe(304);
+  });
+
+  it("serves HEAD in full when the client holds another version's etag", async () => {
+    const docId = await twoVersionDoc();
+
+    const stale = (await send("HEAD", `/d/${docId}/v1`)).headers.get("etag");
+    const response = await send("HEAD", `/d/${docId}`, {
+      headers: { "if-none-match": stale! },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+  });
+
+  it("treats If-None-Match: * on HEAD as a match", async () => {
+    const docId = await twoVersionDoc();
+
+    const response = await send("HEAD", `/d/${docId}`, { headers: { "if-none-match": "*" } });
+
+    expect(response.status).toBe(304);
+  });
+
   it("serves the body when the client holds a different version's etag", async () => {
     const docId = await twoVersionDoc();
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,11 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll } from "vitest";
+
+/**
+ * Bring the test D1 up to the committed schema once, before the per-test
+ * storage isolation starts stacking. Everything a test writes afterwards is
+ * rolled back at the end of that test; the schema is not.
+ */
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
@@ -13,5 +13,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,40 @@
+import { defineWorkersConfig, readD1Migrations } from "@cloudflare/vitest-pool-workers/config";
+
+/**
+ * Tests run inside workerd, not Node.
+ *
+ * They have to: HTMLRewriter, R2 and D1 are runtime, not library, and a test
+ * double for any of them would be asserting our idea of Cloudflare rather than
+ * Cloudflare. Every test therefore gets the real bindings from `wrangler.jsonc`,
+ * backed by Miniflare, with storage isolated per test.
+ */
+export default defineWorkersConfig(async () => {
+  // The same files `wrangler d1 migrations apply` runs, so the schema under
+  // test is the schema that ships rather than a hand-maintained copy.
+  const migrations = await readD1Migrations(new URL("migrations", import.meta.url).pathname);
+
+  return {
+    test: {
+      setupFiles: ["./test/setup.ts"],
+      poolOptions: {
+        workers: {
+          wrangler: { configPath: "./wrangler.jsonc" },
+          miniflare: {
+            // Only the tests need it: `test/auth.test.ts` computes the expected
+            // key hash with node:crypto so it never reuses the implementation's
+            // own hashing to check the implementation.
+            compatibilityFlags: ["nodejs_compat"],
+
+            // The runtime bundled with the test pool is older than the
+            // deployed-worker compatibility date in wrangler.jsonc, and workerd
+            // refuses a date it does not know. Pinned to the newest date this
+            // binary supports rather than left to drift silently.
+            compatibilityDate: "2026-03-01",
+
+            bindings: { TEST_MIGRATIONS: migrations },
+          },
+        },
+      },
+    },
+  };
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,13 +5,31 @@
   "compatibility_date": "2026-07-24",
   "observability": {
     "enabled": true
-  }
+  },
 
-  // Bindings are added as the MVP lands. Planned shape (see docs/cost-at-scale.md §6):
-  //
-  // "r2_buckets":      [{ "binding": "DOCS", "bucket_name": "updoc-docs" }]
-  // "d1_databases":    [{ "binding": "DB", "database_name": "updoc", "database_id": "<id>" }]
-  // "durable_objects": { "bindings": [{ "name": "DOC", "class_name": "DocCoordinator" }] }
-  //
-  // Serving of user content goes on a sacrificial domain, never the brand domain.
+  // R2 is the system of record: every served byte lives here.
+  "r2_buckets": [{ "binding": "DOCS", "bucket_name": "updoc-docs" }],
+
+  // D1 holds pointer rows only (ids, sizes, timestamps) and is rebuildable
+  // from R2. `database_id` is a placeholder — the real id is created and
+  // filled in when the Cloudflare resources are provisioned at deploy time.
+  // Local work (`wrangler dev`, `wrangler d1 ... --local`) ignores it.
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "updoc",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "migrations"
+    }
+  ],
+
+  // Empty in v0: one workers.dev subdomain hosts both surfaces and the router
+  // falls back to path prefixes (/api/v1 vs /d). Filling these in splits the
+  // API onto the brand domain and doc serving onto the sacrificial domain
+  // without a code change — serving of user content never goes on the brand
+  // domain (see docs/cost-at-scale.md §6).
+  "vars": {
+    "SERVING_HOST": "",
+    "API_HOST": ""
+  }
 }


### PR DESCRIPTION
## Summary

**Why.** Sharing agent-written prose for review means either pasting it into a chat window or standing up hosting by hand. The wedge in `docs/positioning.md` is one push from Obsidian to a link a reviewer can open on their phone — nothing exists in this repo yet but a skeleton.

**What.** A Cloudflare Worker that takes rendered HTML over a license-key-authenticated API and serves it as a public, immutably versioned page. Push a note, get back a stable URL; push it again and the same URL shows the new version while every old version stays readable forever. Publishing needs a key, reading needs nothing. R2 is the system of record and D1 is a pointer index rebuildable from it.

```mermaid
sequenceDiagram
    participant C as Copilot
    participant A as API surface
    participant D as D1
    participant R as R2
    participant V as Reader
    C->>A: POST /api/v1/docs (Bearer license key)
    A->>D: validate key, reserve version, check quota
    A->>R: PUT docs/{id}/v{n}.html (noindex + footer baked in)
    A-->>C: 201 {docId, url, version}
    V->>A: GET /d/{docId}
    A-->>V: HTML + CSP, X-Robots-Tag noindex
```

Scope is the wedge only: no reader accounts, no permissions, no comments.

## Decisions

- **Publishers authenticate with their Copilot Plus license key**, validated against the existing license server. Everything downstream depends on a publisher id (the key's SHA-256), never on "license key", so free-tier identity slots in behind one function later.
- **The server issues the docId and Copilot stores it in the note's frontmatter.** Re-pushing a note versions the same URL, which is what makes the review loop work — a new link per push would break it.
- **HTML only; Copilot renders markdown locally.** A server-side markdown pipeline would silently drop callouts, wikilinks and dataview output.
- **Uploaded scripts run.** Interactive figures are the reason to serve HTML rather than sanitized markdown. The CSP blocks the phishing and clickjacking paths instead — `form-action`, `frame-ancestors`, `base-uri` and `object-src` are all `'none'` — and the origin is cookieless, which is what makes running strangers' scripts on a shared origin acceptable.
- **No Durable Objects.** The only thing needing atomicity in v0 is the version counter, which is one `UPDATE ... RETURNING`. DOs arrive with comments, when there is finally something to serialize.
- **Injection happens at push time**, so the stored object is the served object and serving is a pure passthrough.
- **v0 runs on workers.dev.** The router resolves surface by host first and path second, so splitting the brand and sacrificial domains later is config, not a refactor.

## Changes

- `d3a7530` Splits the worker into an API surface and a public serving surface, resolved host-first so `/api/v1` is unreachable on the serving host rather than merely unadvertised. Adds the D1 pointer index and 128-bit Crockford base32 doc ids. *Verify: a request on a configured `SERVING_HOST` never reaches the API, whatever path it asks for.*
- `6394bb5` Resolves a Bearer license key to a publisher id, cached an hour. The cache is the outage story: a publisher who has published before keeps working when the license server is unreachable; a key that never validated cannot. Only an explicit rejection denies — a bad `LICENSE_API_KEY` must not tell every paying publisher their key is bad. *Verify: a cached key makes no network call; an outage with no cached row returns 500, not 401.*
- `02b9c15` `POST`/`PUT` take HTML, enforce quotas, and store `docs/{docId}/v{n}.html`. The version is reserved atomically before the object is written, so objects are never overwritten and a version row always has bytes behind it. *Verify: a push over 10MB writes nothing; pushing to another publisher's doc answers 404, not 403.*
- `e51cbbb` `GET /d/{docId}` streams the latest version with a 60s TTL; `/v{n}` serves immutably. Every response from this surface — errors included — carries noindex and the CSP, and none can set a cookie. *Verify: a deleted doc answers 410, not 404; a pinned version URL keeps serving its own bytes after a newer push.*
- `07e9c1c` Adds unshare (soft-deletes the row, drops the R2 objects) and a keyset-paged my-docs list, plus the frozen HTTP contract in the README and a manual smoke script. *Verify: after a delete the public URL answers 410 and the objects are gone; the list shows only the caller's docs.*
- `c1ffa03` Closes three races review found. A delete landing between a version reservation and its R2 write finished its prefix scan before the object existed, so unshare reported success while leaving bytes behind; the push now compensates for itself and answers 404. The doc-count quota became a predicate on the insert rather than a read before it. HEAD now honors `If-None-Match` instead of contradicting GET. *Verify: 8 concurrent creates at 499 docs yield exactly one 201; HEAD with a matching etag returns 304.*
- `6f565a3` Deletes the now-superseded unguarded insert, so there is no second way to create a doc that skips the quota.
- `804f9d2` Refunds the daily push when a push loses a race to a concurrent delete, sizes the streaming request cap for worst-case JSON escaping so a document under the published 10MB limit cannot be refused, and corrects what the README claims delete does. *Verify: a PUT to a doc deleted mid-flight returns 404 without spending a push.*
- `ebbbfc5` Splits listing metadata off the version reservation, so a push whose storage fails no longer leaves "my docs" describing content the public url is not serving.
- `b1eb3c6` Makes the metadata commit conditional on its version still being newest, and stops a blank title on update from silently preserving the old one.
- `0e8c653` Compares metadata commits against the newest *stored* version rather than the reservation counter, which a failed push can burn. Also documents the manifest gap below.
- `5f02574` Moves titles onto the version rows they belong to, so a doc's title resolves by version number instead of by which concurrent push committed last.
- `919dcc6` Makes create answer honestly when the doc is deleted before its first version lands, instead of returning 201 for a url that serves 410.

## Notes / follow-ups

- **Do not deploy this yet.** D1 is currently the only record of doc ownership, titles and deletion tombstones — R2 holds version objects and nothing else — so the "D1 is a rebuildable pointer index" property this design rests on is not true today. Per-doc manifests are owed **before anything is provisioned**, because they are only useful if they exist from the first doc onward; backfilling them needs the D1 they insure against. Design and rationale are in `CLAUDE.md` under "Owed before anything is deployed", and the README's deploy section is gated on it. Until then D1 is a system of record with a 30-day Time Travel window, not a cache.
- **Nothing is deployed and no Cloudflare resources exist yet.** `wrangler.jsonc` holds a placeholder D1 id. The README documents the exact sequence — create the bucket and database, set both secrets, apply migrations, deploy, run `scripts/smoke.sh`.
- **workers.dev bypasses the Cloudflare edge cache**, so until a real domain is registered every read hits the worker and R2. Costs nothing at design-partner scale.
- **The script-allowing CSP is safe because publishing is gated to paying Plus holders.** That argument expires the day free-tier publishing lands, and should be revisited then.
- **Unshare withdraws the link, it does not revoke the content.** Pinned versions are served `immutable`, so a cache that already fetched one keeps serving it. A CDN purge on delete is owed when user content moves to a cached domain; it is recorded in `CLAUDE.md` with the rest of that migration.
- **Version storage grows without bound.** A retention policy is needed before agents push in a loop.
- The Obsidian right-click share is a separate PR in `obsidian-copilot`, written against the README contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq







