### PR TITLE
Rewrite hosting to define the pieces before comparing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ Roughly in order. Nothing below is started.
   suits a design-partner launch and contradicts the free-wedge thesis long-term.
 - **Then the actual product**: comments anchored to passages, agents drafting
   them for a human to approve, and version-to-version diffs. That is the wedge in
-  `docs/positioning.md` — share, then comment, then converge.
+  [`docs/positioning.md`](docs/positioning.md) — share, then comment, then
+  converge — and [`docs/comments.md`](docs/comments.md) sketches what the first
+  half of it would take. Note the ordering constraint hiding in there: comments
+  need to know who is commenting, so reader identity comes first.
 
 ## Where this is going
 
@@ -80,6 +83,7 @@ lists the ones that bind day to day.
 | [Hosting](docs/hosting.md) | How this runs on Cloudflare. **Start here if you know Vercel but not Workers.** |
 | [Deploying](docs/deploying.md) | Provisioning the resources and shipping. |
 | [Development](docs/development.md) | Running it locally, including the license-server workaround. |
+| [Comments](docs/comments.md) | Design sketch for the next step of the product. Not planned, not built. |
 | [Positioning](docs/positioning.md) | Why the product exists and what it becomes. |
 | [Cost at scale](docs/cost-at-scale.md) | Whether the free wedge is affordable, and the architecture that keeps it so. |
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # updoc
 
-Push a local md/html file, get a public HTML page on the internet.
+**Where people and agents get on the same page.**
 
-v0 is the wedge, nothing more: **HTML upload → public webpage**. The upload API is
-private and programmatic — the only caller is Obsidian Copilot's share action. No
-reader accounts, no permissions, no comments.
+Every version and every thread live at one address, so anyone who opens it can
+catch up without being briefed.
+
+That is what updoc is for, not what it does today. Only the first step exists:
+push a local md/html file and get a public HTML page on the internet. The upload
+API is private and programmatic, its only caller is Obsidian Copilot's share
+action, and there are no reader accounts, no permissions, and no comments.
 
 ## What works today
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -2,8 +2,8 @@
 
 **Status: not designed, not planned, not built.** This is a sketch of the
 smallest thing that could work, written down so the shape is not re-derived from
-scratch later. It has not been through a design review, and the two open
-questions at the bottom are genuinely open. Do not treat it as decided.
+scratch later. It has not been through a design review, and the open questions
+at the bottom are genuinely open. Do not treat it as decided.
 
 Comments are step 2 of the wedge in [positioning.md](positioning.md): share,
 then comment, then converge. Humans and agents both post; agent-drafted comments
@@ -11,12 +11,21 @@ wait for the human they act for to approve them.
 
 [← README](../README.md) · [Hosting](hosting.md) · [Positioning](positioning.md)
 
-## Two objects, two state machines
+## Three state machines
 
 | | States | Belongs to |
 | --- | --- | --- |
 | **Comment** | `pending` → `posted`, or `discarded` | one author |
 | **Thread** | `open` → `resolved` (cites the version that addressed it) | one anchor |
+| **Anchor** | `anchored` ⇄ `orphaned` | one quote |
+
+Three machines, and none of them interacts with the others. That is deliberate:
+anchor status has to be orthogonal to thread state, because a resolved thread
+whose quoted text disappears in a later push is still resolved and still cites
+the version that addressed it — collapsing the two would destroy exactly the
+resolve-provenance the design exists for. An open orphan is equally ordinary.
+The reverse transition is real too: a fuzzy match can find the quote again if the
+text comes back.
 
 Human-authored comments start `posted`. Agent-authored ones start `pending` and
 become visible to others when the human they act for approves — that gate is the
@@ -27,8 +36,8 @@ Note this splits states differently from [cost-at-scale.md](cost-at-scale.md)
 §6, which puts `pending|posted|resolved` together on the comment. Resolution is a
 property of a conversation reaching a conclusion, not of a single reply — a
 "resolved reply" means nothing. Approval is per-comment because every utterance
-needs attribution; resolution is per-thread. Keeping them apart means the two
-state machines never interact, which is most of what keeps this small.
+needs attribution; resolution is per-thread. Keeping them apart is what lets the
+machines stay independent, which is most of what keeps this small.
 
 Every comment carries `author` and a nullable `on_behalf_of`. That one column is
 delegated identity: a human wrote this, or an agent proposed it and a human let
@@ -41,10 +50,10 @@ context to disambiguate it — in the style of W3C TextQuoteSelector. **Never
 offsets.** Offsets do not survive the next push, and that is precisely the
 failure every surveyed competitor has (see [positioning.md](positioning.md)).
 
-On each push, every thread re-anchors: search the new version for the exact
-quote, fall back to fuzzy matching, and mark the thread `orphaned` if nothing
-matches. Orphaning is shown, not hidden — a comment about text that no longer
-exists is information.
+On each push, every anchor re-resolves: search the new version for the exact
+quote, fall back to fuzzy matching, and mark the anchor `orphaned` if nothing
+matches. The thread's own state is untouched. Orphaning is shown, not hidden — a
+comment about text that no longer exists is information.
 
 This is pure string work with no I/O: a few milliseconds for a 200 KB document
 with 50 threads, against a Worker's 30-second CPU budget.
@@ -69,12 +78,15 @@ page itself.
 
 ## What this breaks
 
-**The static-page property.** Today `/d/{docId}` is immutable bytes rendered once
-at publish time, which is the whole reason serving is cheap. Threads make the
-page vary with state. Three ways out, and this is a real decision, not a detail:
+**Serving stops being a passthrough.** Today the HTML is rendered once at push
+time and stored, so a read is a lookup and a stream with no per-read composition
+— which is the whole reason serving is cheap. (Only `/d/{docId}/v{n}` is
+immutable; the shared `/d/{docId}` link is a mutable pointer with a 60-second
+lifetime. See [http-api.md](http-api.md).) Threads make the page vary with state
+between pushes. Three ways out, and this is a real decision, not a detail:
 
-1. Serve the document immutably and fetch threads separately — keeps the caching
-   model, costs an agent a second request.
+1. Serve the stored document as now and fetch threads separately — keeps push-time
+   rendering and both cache lifetimes intact, costs an agent a second request.
 2. Compose the page per read — kills caching.
 3. Re-render and store on every comment — write amplification, reads stay static.
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,96 @@
+# Comments — design sketch
+
+**Status: not designed, not planned, not built.** This is a sketch of the
+smallest thing that could work, written down so the shape is not re-derived from
+scratch later. It has not been through a design review, and the two open
+questions at the bottom are genuinely open. Do not treat it as decided.
+
+Comments are step 2 of the wedge in [positioning.md](positioning.md): share,
+then comment, then converge. Humans and agents both post; agent-drafted comments
+wait for the human they act for to approve them.
+
+[← README](../README.md) · [Hosting](hosting.md) · [Positioning](positioning.md)
+
+## Two objects, two state machines
+
+| | States | Belongs to |
+| --- | --- | --- |
+| **Comment** | `pending` → `posted`, or `discarded` | one author |
+| **Thread** | `open` → `resolved` (cites the version that addressed it) | one anchor |
+
+Human-authored comments start `posted`. Agent-authored ones start `pending` and
+become visible to others when the human they act for approves — that gate is the
+whole agent-identity feature, and approval needs to be batchable or the friction
+removed from writing comes back as moderation.
+
+Note this splits states differently from [cost-at-scale.md](cost-at-scale.md)
+§6, which puts `pending|posted|resolved` together on the comment. Resolution is a
+property of a conversation reaching a conclusion, not of a single reply — a
+"resolved reply" means nothing. Approval is per-comment because every utterance
+needs attribution; resolution is per-thread. Keeping them apart means the two
+state machines never interact, which is most of what keeps this small.
+
+Every comment carries `author` and a nullable `on_behalf_of`. That one column is
+delegated identity: a human wrote this, or an agent proposed it and a human let
+it through.
+
+## Anchors are quotes
+
+A thread anchors to `{exact, prefix, suffix}` — the quoted text and enough
+context to disambiguate it — in the style of W3C TextQuoteSelector. **Never
+offsets.** Offsets do not survive the next push, and that is precisely the
+failure every surveyed competitor has (see [positioning.md](positioning.md)).
+
+On each push, every thread re-anchors: search the new version for the exact
+quote, fall back to fuzzy matching, and mark the thread `orphaned` if nothing
+matches. Orphaning is shown, not hidden — a comment about text that no longer
+exists is information.
+
+This is pure string work with no I/O: a few milliseconds for a 200 KB document
+with 50 threads, against a Worker's 30-second CPU budget.
+
+## Where it would live
+
+One **Durable Object per document**, its embedded SQLite holding that document's
+threads and comments. Every write to a document — post, approve, resolve,
+re-anchor — serializes through it. This is the coordinator that v0 deliberately
+does without (`CLAUDE.md`), and comments are the feature that earns it.
+
+The DO is the system of record. [cost-at-scale.md](cost-at-scale.md) §6 instead
+makes R2 thread fragments canonical; the deviation is deliberate, because the
+fragment would be regenerated from DO state on every write anyway, and two
+authoritative copies of the same thing is a category of bug rather than a
+feature. Treat any R2 fragment as a render cache.
+
+D1 keeps its current job as the cross-document index. It only needs a new table
+for "everything awaiting my approval" *across* documents — which per-document
+DOs cannot answer — and even that can wait if approval happens on the document
+page itself.
+
+## What this breaks
+
+**The static-page property.** Today `/d/{docId}` is immutable bytes rendered once
+at publish time, which is the whole reason serving is cheap. Threads make the
+page vary with state. Three ways out, and this is a real decision, not a detail:
+
+1. Serve the document immutably and fetch threads separately — keeps the caching
+   model, costs an agent a second request.
+2. Compose the page per read — kills caching.
+3. Re-render and store on every comment — write amplification, reads stay static.
+
+(1) looks right, and it also settles the open question
+[positioning.md](positioning.md) ends on: agents fetch one predictable threads
+resource instead of parsing them out of the page.
+
+**Comments need reader identity, and there is none.** Reading currently requires
+nothing at all, and an anonymous reader cannot be attributed. Access control —
+phase 2 in [cost-at-scale.md](cost-at-scale.md) — is a hard prerequisite, not a
+parallel track, and it is the larger piece of work.
+
+## Open questions
+
+- Where threads render (the three options above), which decides whether the
+  cheap-serving story survives comments.
+- Whether approval batches per agent, per document, or per session. Batching is
+  the stated mitigation for approval fatigue, and the shape of it is not obvious.
+- Whether resolve may be reopened, and what that does to `resolved_by_version`.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,182 +1,235 @@
 # Hosting
 
-How updoc runs, written for someone whose mental model is Vercel + Vercel
-Postgres (Neon). Cloudflare uses different words for most of the same jobs, and
-is genuinely different in two places that matter.
+What updoc runs on, assuming you know how web apps get deployed but have never
+used Cloudflare. If your reference point is Vercel and Vercel Postgres, the
+[translation table](#coming-from-vercel) maps most of it in one screen.
 
 [← README](../README.md) · [Deploying](deploying.md) · [Development](development.md)
 
-## The one-paragraph version
+## The four things
 
-There is no server, no container, and no Postgres. Your code is one JavaScript
-function that Cloudflare runs in every one of its data centers; it reads and
-writes two storage services that it talks to through variables rather than
-connection strings. You ship it with `wrangler deploy`, which uploads the bundle
-in a few seconds. That is the whole system.
+**Worker** — your code. A single JavaScript entry point (`src/index.ts`) that
+Cloudflare runs in all of its data centers. It takes a `Request` and returns a
+`Response`, like a `fetch` handler in a browser. There is no server process to
+start, no port to listen on, and no region to choose: requests are handled
+wherever the caller happens to be.
 
-## Translation table
+It runs in a V8 isolate — the sandbox that isolates one browser tab from another
+— rather than a container or a VM. Isolates start in about a millisecond, so
+Cloudflare keeps them warm and cold starts are not something you design around.
+The trade is that it is **not Node**. You get web-standard APIs (`fetch`,
+`Request`, `Response`, `crypto`, streams, `URL`) and not `fs`, `net`, or `http`,
+so libraries expecting Node's networking will not run. That is why this repo has
+no Express, no `pg`, and no ORM.
 
-| Vercel | Cloudflare | Notes |
+**R2** — object storage. S3's API, with no charge for data leaving it. You `put`
+and `get` blobs by key. updoc keeps every published version as one immutable
+object at `docs/{docId}/v{n}.html`; reading a document is one `get`, streamed
+straight back to the reader.
+
+**D1** — a SQL database. It is **SQLite**, not Postgres, and that difference does
+real work — see [D1 in practice](#d1-in-practice). updoc uses it purely as an
+index: who owns a doc, what it is called, which versions exist, whether it was
+deleted. No document content is ever stored in it.
+
+**workers.dev** — a free subdomain Cloudflare gives every account, so a Worker is
+reachable the moment you deploy without owning a domain or touching DNS. Ours
+will be `updoc.<account-subdomain>.workers.dev`. From the caller's side it
+behaves like any other URL; the catch is that it sits outside Cloudflare's CDN
+cache, so every request reaches your Worker. It is meant for development and
+early testing, which is exactly where updoc is.
+
+Two more names you will meet: **wrangler**, the CLI that does everything
+(`wrangler dev`, `wrangler deploy`, `wrangler d1 …`), and **workerd**, the
+open-source runtime it runs locally — the same runtime that runs in production,
+so local behavior is real behavior.
+
+## How the code reaches storage
+
+This is where Cloudflare departs most from what you are used to.
+
+You never open a connection to R2 or D1. There is no connection string, no
+credentials in the environment, no pool. `wrangler.jsonc` declares **bindings**:
+
+```jsonc
+"r2_buckets":   [{ "binding": "DOCS", "bucket_name": "updoc-docs" }],
+"d1_databases": [{ "binding": "DB",   "database_name": "updoc", … }]
+```
+
+and Cloudflare hands the code an already-connected client for each, as
+properties of the `env` object every request receives:
+
+```ts
+const object = await env.DOCS.get(key);                  // R2
+const row = await env.DB.prepare(sql).bind(id).first();  // D1
+```
+
+Everything that normally sits between a serverless function and its database —
+pooling, PgBouncer, Neon's HTTP driver, "too many connections" under load — has
+no equivalent here, because there is no connection to run out of. Bindings are
+also the access-control model: a Worker can reach exactly the buckets and
+databases its config names, and nothing else.
+
+## Coming from Vercel
+
+| Vercel | Cloudflare | Worth knowing |
 | --- | --- | --- |
 | Project | Worker | One deployable unit. Ours is named `updoc`. |
-| Serverless / Edge Function | Worker | Same thing here — there is only one kind. |
-| `vercel deploy` | `wrangler deploy` | CLI-driven by default, no git integration required. |
-| `vercel dev` | `wrangler dev` | Runs the real runtime locally, with local storage. |
-| Environment Variables | Vars and Secrets | Vars live in `wrangler.jsonc`; secrets are set by CLI. |
-| Vercel Postgres (Neon) | **D1** | SQLite, not Postgres. See below. |
-| Vercel Blob / S3 | **R2** | S3-compatible object storage, no egress fees. |
-| Vercel Edge Network | Cloudflare CDN | Same job; here it is the same company as the compute. |
-| Preview deployments | Versions / environments | Exists, but not wired to PRs by default. |
+| Serverless / Edge Function | Worker | Only one kind here. |
+| `vercel dev` | `wrangler dev` | Runs the production runtime locally, with local storage. |
+| `vercel deploy` | `wrangler deploy` | CLI, not git-triggered — see [Deploys](#deploys-are-explicit). |
+| Environment Variables | Vars and Secrets | Vars are committed config; secrets are set by CLI. |
+| Vercel Postgres (Neon) | D1 | SQLite. Different enough to read the section below. |
+| Vercel Blob | R2 | S3-compatible, no egress charge. |
+| Vercel Edge Network | Cloudflare CDN | Here it is the same company as the compute. |
+| Preview deployments | Versions | Every deploy is a rollback target; no per-PR URLs by default. |
+| `vercel.json` + dashboard env | `wrangler.jsonc` | One committed file, and it beats the dashboard. |
 
-## What actually runs the code
-
-A Worker is not a container and not a Lambda. It is a V8 isolate — the same
-sandbox a browser tab uses — and Cloudflare keeps thousands of them warm in each
-data center. That has two consequences worth internalizing:
-
-- **Cold starts effectively don't exist.** There is no container to boot, so you
-  don't need the warming tricks or the "avoid heavy imports" discipline that
-  Lambda-based hosting teaches.
-- **It is not Node.** You get web-standard APIs — `fetch`, `Request`, `Response`,
-  `crypto`, streams — not `fs`, `net`, or most of npm's server ecosystem. That is
-  why this repo has no Express, no Prisma, and no `pg`. If a library expects
-  Node's networking, it will not run.
-
-Your code runs wherever the reader is, not in one region you picked.
-
-Billing is $5/month for the account, including 10 million requests and 30 million
-CPU-milliseconds. Note **CPU**-milliseconds: waiting on R2 or D1 is not billed,
-only time actually computing. A request that spends 200ms fetching and 2ms
-assembling a response bills 2ms. Default limit is 30 seconds of CPU per request,
-which nothing here comes close to.
-
-## D1 is SQLite, and that is the biggest adjustment
-
-This is where the Neon mental model will actively mislead you.
-
-- **It is SQLite.** No `SERIAL`, no `JSONB`, no extensions, no `pg_*`. Types are
-  SQLite's five. Our schema is in `migrations/0001_init.sql` and reads like it.
-- **There is no connection string and no pool.** You do not open a connection —
-  a `DB` variable is handed to your code, already connected. All the
-  serverless-Postgres tax you're used to (pooling, PgBouncer, "too many
-  connections" under load, Neon's serverless driver) simply doesn't apply.
-- **One database is single-threaded** and processes queries one at a time. Fine
-  for pointer lookups; it is not where you put a heavy analytical query.
-- **It has one primary region.** Reads can be replicated, writes go to one place.
-  Low stakes for updoc: a read touches D1 once, for a pointer lookup, and the
-  document itself comes from R2.
-- **Limits:** 10 GB per database, 50,000 databases per account, 1,000 queries per
-  request. Pricing is per row read/written, with 25 billion reads and 50 million
-  writes included monthly. At updoc's shape this is free indefinitely.
-- **Backups are "Time Travel":** any point in the last 30 days, restored by
-  timestamp. There is no `pg_dump` to schedule and no Neon-style branching.
-
-Migrations are plain `.sql` files in `migrations/`, applied with
-`wrangler d1 migrations apply`. There is no Prisma, no Drizzle, no ORM at all —
-queries are written by hand in `src/db.ts`.
-
-## R2 is where the actual content lives
-
-R2 is S3's API without S3's egress bill — that last part is the reason the whole
-cost argument in [cost-at-scale.md](cost-at-scale.md) works. Serving a document
-that gets read by 100,000 people costs approximately nothing.
-
-Every published version is one immutable object at `docs/{docId}/v{n}.html`, and
-serving is a straight read-and-stream. Like D1, you get a `DOCS` variable rather
-than credentials and a region.
-
-Storage is $0.015/GB-month. Writes (Class A) are $4.50/million, reads (Class B)
-$0.36/million. A push is a couple of writes; a read is one.
-
-## How a request actually flows
+## A request, end to end
 
 ```
-reader → Cloudflare edge → [no cache today — see below]
-                         ↓
-                       Worker (src/index.ts)
-                         ├─ D1: which version, is it deleted?
-                         └─ R2: the stored HTML → streamed back
+reader → Cloudflare edge → Worker (src/index.ts)
+                             ├─ D1  — which version? is it deleted?
+                             └─ R2  — the stored HTML, streamed back
 ```
 
-The Worker decides which of two surfaces a request belongs to before anything
-else — `/api/v1/*` is the publisher API and needs a key, `/d/*` is public
-reading. That split exists so the two can later live on different domains, which
-matters for reasons covered in [cost-at-scale.md](cost-at-scale.md) §5.
+The Worker's first decision is which of two surfaces a request belongs to:
+`/api/v1/*` is the publisher API and needs a key, `/d/*` is public reading. They
+are split so they can later sit on separate domains — user content on a
+throwaway one, the API on the brand one — for reasons in
+[cost-at-scale.md](cost-at-scale.md) §5.
 
-**Nothing is cached today, and a domain alone will not change that.** Two
-separate reasons, and it is worth knowing both because the second one surprises
-people:
+**Nothing is cached today**, and attaching a domain would not by itself change
+that. Two independent reasons:
 
-1. `workers.dev` URLs bypass the CDN cache entirely.
-2. Cloudflare does not cache HTML by default *even on a real domain*. Default
-   cacheability is decided by file extension, not by MIME type and not by the
-   `Cache-Control` header the Worker sends — and doc urls like `/d/{docId}` have
-   no extension. The origin asking to be cached is not enough.
+1. `workers.dev` bypasses the CDN cache entirely.
+2. Cloudflare does not cache HTML by default *on any domain*. Eligibility is
+   decided by file extension — not MIME type, and not the `Cache-Control` the
+   Worker sends — and `/d/{docId}` has no extension.
 
-So getting reads off the origin takes an explicit **Cache Rule** on the serving
-zone (the modern replacement for the "Cache Everything" page rule), or caching
-inside the Worker via the Cache API. Until one of those exists, every read
-invokes the Worker and touches D1 and R2 — which is fine at current volume and
-is why it has not been done yet.
+Caching therefore needs an explicit **Cache Rule** on the serving zone, or the
+Cache API inside the Worker. Until one exists, every read invokes the Worker and
+touches D1 and R2. That is fine at current volume, which is why it has not been
+done — but it does mean the cheap-serving argument in `cost-at-scale.md` is not
+in effect yet. Whenever it is switched on, deletes have to purge the cache in the
+same change, or unshared documents keep being served. Both are tracked in
+`CLAUDE.md`.
 
-Turning it on brings a second obligation: once responses are cached at the edge,
-deleting a doc has to purge them, or an unshared doc keeps being served. That
-pairing is recorded in `CLAUDE.md`.
+## D1 in practice
+
+Postgres reflexes to unlearn:
+
+- **It is SQLite.** Five storage classes, no `SERIAL`, no `JSONB`, no extensions,
+  no `pg_*`. `migrations/0001_init.sql` reads accordingly.
+- **Migrations are plain `.sql` files** in `migrations/`, applied with
+  `wrangler d1 migrations apply`. No Prisma, no Drizzle — queries are written by
+  hand in `src/db.ts`.
+- **A database is single-threaded**, processing queries one at a time. Ideal for
+  the small indexed lookups updoc makes; not where an analytical query goes.
+- **Writes go to one region**, reads can be replicated. Barely matters here: a
+  read touches D1 once for a pointer, and the document itself comes from R2.
+- **Backups are Time Travel** — restore to any point in the last 30 days by
+  timestamp. No `pg_dump` to schedule, no Neon-style branching.
+
+Limits and price: 10 GB per database, 50,000 databases per account, 1,000
+queries per Worker invocation. Billing is per row read and written, with 25
+billion reads and 50 million writes included monthly, so at updoc's shape it is
+effectively free.
+
+## R2 in practice
+
+R2 is S3's API without S3's egress bill, and that second half is why the cost
+model in [cost-at-scale.md](cost-at-scale.md) works at all: a document read by
+100,000 people costs essentially nothing to serve.
+
+Storage is $0.015/GB-month; writes (Class A) $4.50 per million, reads (Class B)
+$0.36 per million. A push is a couple of writes, a read is one.
+
+Because objects are immutable and HTML is finished at publish time, serving is a
+straight read-and-stream — the Worker never re-renders anything.
 
 ## Config, vars and secrets
 
-`wrangler.jsonc` is the whole deployment config — it is `vercel.json`,
-the dashboard's env screen, and your infra-as-code, in one file. It declares
-which R2 bucket and which D1 database get handed to the code as `DOCS` and `DB`.
+`wrangler.jsonc` is the whole deployment config: bindings, compatibility date,
+and plain variables. It is committed, and it overrides the dashboard — settings
+edited in Cloudflare's UI are overwritten by the next deploy.
 
-Two kinds of configuration, and the distinction is enforced:
+Two kinds of configuration, and the split is enforced:
 
-- **Vars** are plaintext in `wrangler.jsonc`, committed. `SERVING_HOST` and
+- **Vars** — plaintext in `wrangler.jsonc`, committed. `SERVING_HOST` and
   `API_HOST` are vars.
-- **Secrets** never appear in any file. `wrangler secret put NAME` prompts for
-  the value and stores it encrypted; the code reads it off the same `env` object,
-  indistinguishable from a var. `LICENSE_API_KEY` is a secret.
+- **Secrets** — never in any file. `wrangler secret put NAME` prompts and stores
+  the value encrypted; code reads it off the same `env` object, indistinguishable
+  from a var. `LICENSE_API_KEY` is a secret.
 
 Locally, secrets come from `.dev.vars` (gitignored; copy `.dev.vars.example`).
 
-The `database_id` in `wrangler.jsonc` looks like a secret and isn't — it is just
-an identifier, and the binding won't resolve without it, so it gets committed.
+The `database_id` in `wrangler.jsonc` looks like a credential and is not. It is
+an identifier, the binding will not resolve without it, and it is committed.
 
-## Deploys are not git-triggered
+## Deploys are explicit
 
-The habit to unlearn: pushing to `main` deploys nothing. `wrangler deploy`
-uploads the current working tree, from whoever's machine runs it. Cloudflare does
-offer a git integration, and we may add one, but today shipping is deliberate.
+Pushing to `main` deploys nothing. `wrangler deploy` uploads the current working
+tree, from whoever runs it. Cloudflare does offer a git integration; we have not
+set one up, so shipping is a deliberate act.
 
-Every deploy is kept as a version you can roll back to
-(`wrangler rollback`). There are no per-PR preview URLs unless we set them up.
+Every deploy is retained as a version, and `wrangler rollback` returns to an
+earlier one. There are no per-PR preview URLs unless we configure them.
 
-## Local development is the real thing
+## Local development
 
-`wrangler dev` runs the actual Cloudflare runtime (`workerd`) on your machine
-with local R2 and D1 — not mocks, and no account required. The test suite does
-the same, which is why `npm test` needs no credentials and no deployment.
+`wrangler dev` runs workerd on your machine against local R2 and D1 — the real
+runtime and real storage engines, not mocks, and no Cloudflare account needed.
+`npm test` does the same through `@cloudflare/vitest-pool-workers`, which is why
+the suite needs neither credentials nor a deployment.
 
-The practical difference from `vercel dev`: local state lives in `.wrangler/`,
-and a local D1 starts empty, so migrations are applied against it separately.
-[Development](development.md) has the sequence.
+Local state lives in `.wrangler/`, and a local D1 starts empty, so migrations get
+applied to it separately. [Development](development.md) has the sequence,
+including the license-server workaround a local push needs.
 
-## Things that will bite you coming from Vercel
+## Gotchas
 
-- **`npm install <server library>` often won't work.** No Node networking APIs.
-- **No filesystem.** Nothing to write to; R2 or D1 or nothing.
-- **No long-running background work.** A request ends when the response is sent.
-  Deferred work needs `waitUntil`, a Queue, or a Cron Trigger.
-- **SQLite, not Postgres.** Worth repeating, because the schema is where the
-  assumption hides.
-- **The dashboard is not the source of truth.** Editing config in Cloudflare's UI
-  gets overwritten by the next `wrangler deploy`. Change `wrangler.jsonc`.
+- **Most server-side npm packages will not install.** No Node networking APIs.
+- **No filesystem.** R2, D1, or nothing.
+- **No work after the response is sent.** Use `waitUntil`, a Queue, or a Cron
+  Trigger.
+- **The dashboard is not the source of truth.** Change `wrangler.jsonc`.
+- **`console.log` goes nowhere by default.** `wrangler tail` streams it live, and
+  the dashboard's Logs tab keeps it (observability is on in our config).
 
-## Where to look when something breaks
+## Why this stack, and where it strains
 
-- `wrangler tail` streams live logs from the deployed Worker.
-- Observability is on in `wrangler.jsonc`, so requests and `console.error` output
-  are queryable in the Cloudflare dashboard under Workers → updoc → Logs.
-- `wrangler d1 execute updoc --remote --command "select ..."` queries production
-  D1 directly.
-- `scripts/smoke.sh <url>` checks a deployment end to end.
+The decisive property is R2's lack of egress fees. updoc is, at bottom, a service
+that hands the same immutable bytes to many readers, and everywhere else that
+shape is dominated by bandwidth — S3 plus CloudFront is roughly $0.085/GB, which
+at scale *is* the business, and is zero here. The rest follows: immutable version
+URLs cache perfectly, HTML is rendered once at publish time, and the compute per
+read is a lookup and a stream. No component in the serving path is priced per
+user or per seat, which is the other way this category usually gets expensive.
+
+The weak link is D1, and it is worth being clear-eyed. One database is capped at
+10 GB, is single-threaded, and takes writes in a single region. updoc's shape
+keeps that comfortable — a push is a handful of small writes, a read is one
+indexed lookup — but a write-heavy future (agents pushing on every edit, then
+comment threads) would eventually reach it. Two escape hatches are already in the
+design rather than bolted on later: an account can hold 50,000 databases, so the
+index can shard by publisher; and [cost-at-scale.md](cost-at-scale.md) §6 moves
+per-document state into Durable Objects, giving each document its own embedded
+SQLite instead of one shared database. That is where the headroom lives.
+
+Two caveats to hold onto:
+
+- **The property that makes D1 a safe choice is not true yet.** The design treats
+  it as a disposable index rebuildable from R2, which is what makes a young,
+  limited database an acceptable home for it. Today R2 holds only version
+  objects, so ownership and deletion state exist nowhere else. Until per-doc
+  manifests ship (`CLAUDE.md`), D1 is a real system of record and deserves to be
+  treated as one.
+- **This is a concentrated bet on one vendor.** The mitigation is that the
+  valuable half is portable: documents are files behind an S3-compatible API and
+  the index is small and reconstructible, so leaving would mean copying objects
+  and replaying a schema rather than extracting a database nobody else can read.
+
+For a document-sharing service specifically, this is a strong fit, and more so
+the larger it gets. It would be the wrong stack for something transactional,
+relationally complex, or CPU-heavy per request — updoc is none of those.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -18,9 +18,12 @@ It runs in a V8 isolate — the sandbox that isolates one browser tab from anoth
 — rather than a container or a VM. Isolates start in about a millisecond, so
 Cloudflare keeps them warm and cold starts are not something you design around.
 The trade is that it is **not Node**. You get web-standard APIs (`fetch`,
-`Request`, `Response`, `crypto`, streams, `URL`) and not `fs`, `net`, or `http`,
-so libraries expecting Node's networking will not run. That is why this repo has
-no Express, no `pg`, and no ORM.
+`Request`, `Response`, `crypto`, streams, `URL`); Node's own built-ins are
+available only behind an opt-in `nodejs_compat` flag that this project does not
+set, so libraries reaching for `fs`, `net` or `http` will not run here. That is
+why this repo has no Express, no `pg`, and no ORM. See
+[Gotchas](#gotchas) for how that failure actually presents, because it is not
+where you would expect.
 
 **R2** — object storage. S3's API, with no charge for data leaving it. You `put`
 and `get` blobs by key. updoc keeps every published version as one immutable
@@ -189,8 +192,16 @@ including the license-server workaround a local push needs.
 
 ## Gotchas
 
-- **Most server-side npm packages will not install.** No Node networking APIs.
-- **No filesystem.** R2, D1, or nothing.
+- **A Node-oriented package installs fine and then fails.** `npm install`
+  resolves it happily; the break comes at bundling or runtime when it reaches for
+  an API that is not there. A clean install proves nothing. Cloudflare does offer
+  a `nodejs_compat` compatibility flag that provides a large subset of Node's
+  built-ins — it is opt-in, needs a compatibility date of 2024-09-23 or later,
+  and **we do not set it**, so today none of those built-ins are available here.
+- **Nowhere to put a file.** `nodejs_compat` does provide `node:fs`, but the
+  filesystem behind it is virtual and in-memory: `/tmp` is writable and scoped to
+  a single request, and nothing written there is visible to any other request.
+  Persistent storage is R2 or D1, and there is no third option.
 - **No work after the response is sent.** Use `waitUntil`, a Queue, or a Cron
   Trigger.
 - **The dashboard is not the source of truth.** Change `wrangler.jsonc`.
@@ -225,10 +236,13 @@ Two caveats to hold onto:
   objects, so ownership and deletion state exist nowhere else. Until per-doc
   manifests ship (`CLAUDE.md`), D1 is a real system of record and deserves to be
   treated as one.
-- **This is a concentrated bet on one vendor.** The mitigation is that the
-  valuable half is portable: documents are files behind an S3-compatible API and
-  the index is small and reconstructible, so leaving would mean copying objects
-  and replaying a schema rather than extracting a database nobody else can read.
+- **This is a concentrated bet on one vendor**, and the usual reassurance does
+  not hold yet either. Documents are already portable — files behind an
+  S3-compatible API. The index is not: copy R2 and replay the schema today and
+  ownership is gone entirely, and every deleted document's url degrades from 410
+  to 404, because the tombstone exists only in D1. Manifests are what would make
+  "leaving means copying objects" true; until they ship it is the plan, not the
+  situation.
 
 For a document-sharing service specifically, this is a strong fit, and more so
 the larger it gets. It would be the wrong stack for something transactional,

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -233,3 +233,15 @@ Two caveats to hold onto:
 For a document-sharing service specifically, this is a strong fit, and more so
 the larger it gets. It would be the wrong stack for something transactional,
 relationally complex, or CPU-heavy per request — updoc is none of those.
+
+It also holds for where the product is going. Comments (see
+[comments.md](comments.md)) are the workload Durable Objects exist for: a
+document is a natural partition key, so per-document coordinators shard for free
+with no cross-document contention — where a single Postgres would have every
+document's threads contending on the same tables. Re-anchoring comments across a
+rewrite is CPU-bound string matching with no I/O, which is the cheapest thing
+there is to run here, and live updates later have a path through DO WebSockets
+without changing the model. The strain shows up in two places: a DO lives in one
+region, so a distant commenter pays a round trip on writes, and threads make the
+served page vary with state — which turns the caching decision above from
+theoretical into load-bearing.


### PR DESCRIPTION
## Summary

**Why.** `docs/hosting.md` opened by mapping Cloudflare onto Vercel, which only helps a reader who already knows what a Worker or D1 is. For someone who does not, the doc explained the translation before the thing being translated.

**What.** It now defines the four pieces — Worker, R2, D1, workers.dev — before any comparison, and adds the concept with no Vercel equivalent at all: **bindings**. There is no connection string and no pool; `wrangler.jsonc` names a bucket and a database, and Cloudflare hands the code already-connected clients on `env`. That is the single biggest departure from a serverless-Postgres mental model and the old draft never said it.

Also adds a closing section answering whether this stack suits a document-sharing service at scale.

## Decisions

- **Definitions first, comparison second.** The Vercel table stays, but after the four things exist as concepts rather than as translations.
- **Kept the technical register.** This is for someone who ships web apps and has not used Cloudflare — not an introduction to serverless. No analogies, no hand-holding.
- **The stack assessment is honest rather than reassuring.** R2's absent egress bill is decisive for a service that hands identical immutable bytes to many readers — S3 plus CloudFront is ~$0.085/GB, which at scale is the business, and is zero here. D1 is named as the weak link (10 GB, single-threaded, one write region), with the two escape hatches that are already in the architecture: sharding across the 50,000-database allowance, and moving per-document state into Durable Objects.
- **Names the caveat that undercuts the D1 choice.** Choosing a young, limited database is only safe because the design treats it as a disposable index rebuildable from R2 — and that is not true yet, since R2 holds only version objects. Until manifests ship, D1 is a real system of record.

## Changes

- `2cf444d` Rewrites `docs/hosting.md`: defines Worker, R2, D1 and workers.dev before comparing them, explains bindings, and adds "Why this stack, and where it strains". *Verify: the doc answers "what is a Worker" without assuming Cloudflare knowledge, and every relative link resolves.*
- `fa3a2c2` Adds `docs/comments.md`, a sketch of the next feature — comment/thread state machines, quote-based anchors, and a Durable Object per document. Marked explicitly as not designed and not planned. Cross-linked from the README and from the hosting doc's stack assessment, which now covers whether the stack holds for that workload too.
- `665b7bd` Corrects three claims in the hosting doc: Node packages install fine and fail later rather than failing to install, `node:fs` exists under an opt-in flag we do not set (the filesystem is virtual and request-scoped), and the index is not reconstructible today — that is what manifests would buy.

## Notes / follow-ups

- This commit was originally pushed to `docs/split-readme` after PR #2 had already merged, so it never reached `main`. Same content, correctly based this time.
- The operational advice in this doc still comes from Cloudflare's documentation rather than from having run this — nothing is deployed. Worth revisiting after the first real deploy.


