### PR TITLE
Rename the product from updoc to Symposium

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# updoc
+# Symposium
 
 Push a local md/html file, get a public HTML page on the internet. v0 scope: HTML
 upload → public page, upload API private and programmatic (Obsidian Copilot only).
@@ -51,7 +51,7 @@ in the positioning doc.
 These are day-one decisions, not retrofits:
 
 - User content is served from a **sacrificial domain**, separate from the brand
-  domain. Reputation damage must not land on `updoc.md`.
+  domain. Reputation damage must not land on `symposium.md`.
 - Shared docs are **`noindex` + `nofollow` by default**.
 - **Publisher-gated, reader-open**: publishing requires a key; reading requires
   nothing.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# updoc
+# Symposium
 
 **Where people and agents get on the same page.**
 
 Every version and every thread live at one address, so anyone who opens it can
 catch up without being briefed.
 
-That is what updoc is for, not what it does today. Only the first step exists:
+That is what Symposium is for, not what it does today. Only the first step exists:
 push a local md/html file and get a public HTML page on the internet. The upload
 API is private and programmatic, its only caller is Obsidian Copilot's share
 action, and there are no reader accounts, no permissions, and no comments.
@@ -52,7 +52,7 @@ Roughly in order. Nothing below is started.
   half of the fix — Cloudflare does not cache HTML by default, so it also needs
   a cache rule, and then deletes have to purge the cache. Real domains also let
   user content live somewhere separate from the brand, so a bad doc can't damage
-  `updoc.md`'s reputation.
+  `symposium.md`'s reputation.
 - **Backups that don't depend on the database.** Right now the database is the
   only record of who owns a doc and what it's called. The plan is for each doc to
   carry its own description alongside its files, so the database could be rebuilt
@@ -71,7 +71,7 @@ Roughly in order. Nothing below is started.
 
 ## Where this is going
 
-updoc is the first step of an agent-first docs product: a shared artifact where
+Symposium is the first step of an agent-first docs product: a shared artifact where
 humans and agents comment and iterate together to converge on consensus. The
 argument for it, and the constraints it has to respect, are in
 [`docs/positioning.md`](docs/positioning.md) and

--- a/docs/cost-at-scale.md
+++ b/docs/cost-at-scale.md
@@ -1,14 +1,14 @@
 ---
-title: updoc.md - Business Feasibility - Cost at Scale
+title: symposium.md - Business Feasibility - Cost at Scale
 date: 2026-07-21
 tags:
-  - updoc
+  - symposium
   - feasibility
   - business
 status: draft
 ---
 
-# updoc.md - Business Feasibility - Cost at Scale
+# symposium.md - Business Feasibility - Cost at Scale
 
 Companion to [[Agent-First Docs - Product Positioning]]. That doc argues *why* the product should exist. This one asks a colder question: **can we afford to give the wedge away for free, and does the cost curve stay sane from 1k to 100k to 1M users?**
 
@@ -24,7 +24,7 @@ Scope of the launch product being costed: **one-click sharing from Copilot for O
 Three properties of the product shape (from the positioning doc) drive the whole cost story:
 
 1. **The artifact is static.** Every push mints an immutable version. Immutable version URLs are perfectly cacheable, so a doc that goes viral costs approximately nothing extra: the CDN absorbs it, origin serves it once. We are closer to Pastebin than to Google Docs.
-2. **No live editor, no realtime sync.** Google Docs' real infrastructure cost is not storage, it is operational-transform sync fanout, presence, and cursors for concurrent editors. Notion carries a heavy block-database and realtime layer. updoc's model is push-based: the expensive collaborative-editing problem is deliberately not in the architecture. Even comments (phase 3) can be poll-based for a long time before anyone notices.
+2. **No live editor, no realtime sync.** Google Docs' real infrastructure cost is not storage, it is operational-transform sync fanout, presence, and cursors for concurrent editors. Notion carries a heavy block-database and realtime layer. Symposium's model is push-based: the expensive collaborative-editing problem is deliberately not in the architecture. Even comments (phase 3) can be poll-based for a long time before anyone notices.
 3. **Zero inference COGS.** The agents are the users' own (Claude Code, Copilot, whatever calls our MCP). Unlike Notion AI or any "AI docs" product, we pay for no tokens, ever. Our marginal cost for agent traffic is a JSON API call. This is the quiet structural advantage of the agent-first posture: the intelligence is BYO.
 
 The sanity checks from the market:
@@ -151,7 +151,7 @@ Free + public + no permission system + one-click publish = **the exact recipe fo
 
 Day-one mitigations, all cheap in dollars:
 
-1. **Serve user content from a separate domain** than the product/brand domain (the `notion.site` / `googleusercontent.com` pattern). Reputation damage lands on the sacrificial domain, not on `updoc.md` itself. This is the single highest-leverage decision and it costs $10/yr.
+1. **Serve user content from a separate domain** than the product/brand domain (the `notion.site` / `googleusercontent.com` pattern). Reputation damage lands on the sacrificial domain, not on `symposium.md` itself. This is the single highest-leverage decision and it costs $10/yr.
 2. **`noindex` + `nofollow` by default.** Shared docs are for invited readers, not search engines. This deletes the SEO-spam incentive entirely, which is most of the spam volume. (Publishers can opt into indexing later, as a feature, maybe a paid one.)
 3. **Publisher-gated, reader-open.** Publishing requires a Copilot install and an account; reading requires nothing. The abuse funnel is throttled at the account layer: new-account rate limits, velocity checks on pushes.
 4. **Automated scanning on push**: outbound links against Google Safe Browsing (free API); if/when image upload ships, CSAM hash-matching via Cloudflare's free tool (also a legal obligation, not a nice-to-have).
@@ -214,7 +214,7 @@ Phase 1 (public share only) could genuinely ship with zero D1: slug uniqueness v
 
 Outline is the nearest existing product ([[Agent-First Docs - Product Positioning#Why nobody serves this today]]), which makes "just build on it" tempting. Decision (2026-07-23): no. The downsides are structural, not cosmetic:
 
-- **License.** Outline is BUSL-1.1, which prohibits offering it as a commercial hosted service - exactly what updoc.md is. Building on it means a commercial agreement with the named incumbent-to-beat.
+- **License.** Outline is BUSL-1.1, which prohibits offering it as a commercial hosted service - exactly what symposium.md is. Building on it means a commercial agreement with the named incumbent-to-beat.
 - **Wrong data model.** Workspace-wiki (teams, collections, members) vs our per-doc unit with its own audience. Per-doc grantees and "my docs" would be surgery on the spine; single-team instances vs hosting a million individuals likewise.
 - **Editor-centric where we are push-centric.** Its heart is a realtime ProseMirror/Yjs editor; anchors are marks in editor state, which is the exact fragility we differentiate against (whole-doc replace destroys anchors). Our quote-based re-anchoring engine doesn't exist there and would be built against a hostile representation, while we inherit the sync tax section 1 designed out.
 - **Not HTML-native, not our stack.** Sanitized ProseMirror/markdown pipeline vs HTML-as-API (section 6); needs Node + Postgres + Redis + websockets, which forfeits the all-Cloudflare cost structure and makes a big Postgres the system of record.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -18,10 +18,10 @@ creates real Cloudflare resources on whichever account wrangler is logged into.
 
 ```bash
 # 1. The R2 bucket. The name must match `bucket_name` in wrangler.jsonc.
-npx wrangler r2 bucket create updoc-docs
+npx wrangler r2 bucket create symposium-docs
 
 # 2. The D1 database. This prints a `database_id`.
-npx wrangler d1 create updoc
+npx wrangler d1 create symposium
 ```
 
 **Now edit `wrangler.jsonc`** and replace the `database_id` placeholder
@@ -30,7 +30,7 @@ it. It is not a secret; the binding will not resolve without it.
 
 ```bash
 # 3. Create the schema on the real database (--remote, not --local).
-npx wrangler d1 migrations apply updoc --remote
+npx wrangler d1 migrations apply symposium --remote
 
 # 4. Credentials for the license server. Both prompt for the value, so neither
 #    ends up in your shell history. LICENSE_API_KEY is *ours*, never a
@@ -44,8 +44,8 @@ npx wrangler secret put LICENSE_API_KEY
 npx wrangler deploy
 
 # 6. Check what just shipped, end to end.
-UPDOC_LICENSE_KEY=<a real Copilot Plus key> \
-  scripts/smoke.sh https://updoc.<subdomain>.workers.dev
+SYMPOSIUM_LICENSE_KEY=<a real Copilot Plus key> \
+  scripts/smoke.sh https://symposium.<subdomain>.workers.dev
 ```
 
 The smoke script publishes a doc, reads it, lists it, deletes it and confirms the

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Running updoc on your machine. No Cloudflare account needed.
+Running Symposium on your machine. No Cloudflare account needed.
 
 [← README](../README.md) · [HTTP API](http-api.md) · [Deploying](deploying.md)
 
@@ -28,12 +28,12 @@ the key:
 KEY=any-string-you-like
 HASH=$(printf '%s' "$KEY" | shasum -a 256 | cut -d' ' -f1)
 
-npx wrangler d1 migrations apply updoc --local
-npx wrangler d1 execute updoc --local --command \
+npx wrangler d1 migrations apply symposium --local
+npx wrangler d1 execute symposium --local --command \
   "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at)
    VALUES ('$HASH', 'plus', $(($(date +%s) * 1000)))"
 
-UPDOC_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
+SYMPOSIUM_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
 ```
 
 Alternatively, copy `.dev.vars.example` to `.dev.vars` and point

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,6 +1,6 @@
 # Hosting
 
-What updoc runs on, assuming you know how web apps get deployed but have never
+What Symposium runs on, assuming you know how web apps get deployed but have never
 used Cloudflare. If your reference point is Vercel and Vercel Postgres, the
 [translation table](#coming-from-vercel) maps most of it in one screen.
 
@@ -26,21 +26,21 @@ why this repo has no Express, no `pg`, and no ORM. See
 where you would expect.
 
 **R2** — object storage. S3's API, with no charge for data leaving it. You `put`
-and `get` blobs by key. updoc keeps every published version as one immutable
+and `get` blobs by key. Symposium keeps every published version as one immutable
 object at `docs/{docId}/v{n}.html`; reading a document is one `get`, streamed
 straight back to the reader.
 
 **D1** — a SQL database. It is **SQLite**, not Postgres, and that difference does
-real work — see [D1 in practice](#d1-in-practice). updoc uses it purely as an
+real work — see [D1 in practice](#d1-in-practice). Symposium uses it purely as an
 index: who owns a doc, what it is called, which versions exist, whether it was
 deleted. No document content is ever stored in it.
 
 **workers.dev** — a free subdomain Cloudflare gives every account, so a Worker is
 reachable the moment you deploy without owning a domain or touching DNS. Ours
-will be `updoc.<account-subdomain>.workers.dev`. From the caller's side it
+will be `symposium.<account-subdomain>.workers.dev`. From the caller's side it
 behaves like any other URL; the catch is that it sits outside Cloudflare's CDN
 cache, so every request reaches your Worker. It is meant for development and
-early testing, which is exactly where updoc is.
+early testing, which is exactly where Symposium is.
 
 Two more names you will meet: **wrangler**, the CLI that does everything
 (`wrangler dev`, `wrangler deploy`, `wrangler d1 …`), and **workerd**, the
@@ -55,8 +55,8 @@ You never open a connection to R2 or D1. There is no connection string, no
 credentials in the environment, no pool. `wrangler.jsonc` declares **bindings**:
 
 ```jsonc
-"r2_buckets":   [{ "binding": "DOCS", "bucket_name": "updoc-docs" }],
-"d1_databases": [{ "binding": "DB",   "database_name": "updoc", … }]
+"r2_buckets":   [{ "binding": "DOCS", "bucket_name": "symposium-docs" }],
+"d1_databases": [{ "binding": "DB",   "database_name": "symposium", … }]
 ```
 
 and Cloudflare hands the code an already-connected client for each, as
@@ -77,7 +77,7 @@ databases its config names, and nothing else.
 
 | Vercel | Cloudflare | Worth knowing |
 | --- | --- | --- |
-| Project | Worker | One deployable unit. Ours is named `updoc`. |
+| Project | Worker | One deployable unit. Ours is named `symposium`. |
 | Serverless / Edge Function | Worker | Only one kind here. |
 | `vercel dev` | `wrangler dev` | Runs the production runtime locally, with local storage. |
 | `vercel deploy` | `wrangler deploy` | CLI, not git-triggered — see [Deploys](#deploys-are-explicit). |
@@ -128,7 +128,7 @@ Postgres reflexes to unlearn:
   `wrangler d1 migrations apply`. No Prisma, no Drizzle — queries are written by
   hand in `src/db.ts`.
 - **A database is single-threaded**, processing queries one at a time. Ideal for
-  the small indexed lookups updoc makes; not where an analytical query goes.
+  the small indexed lookups Symposium makes; not where an analytical query goes.
 - **Writes go to one region**, reads can be replicated. Barely matters here: a
   read touches D1 once for a pointer, and the document itself comes from R2.
 - **Backups are Time Travel** — restore to any point in the last 30 days by
@@ -136,7 +136,7 @@ Postgres reflexes to unlearn:
 
 Limits and price: 10 GB per database, 50,000 databases per account, 1,000
 queries per Worker invocation. Billing is per row read and written, with 25
-billion reads and 50 million writes included monthly, so at updoc's shape it is
+billion reads and 50 million writes included monthly, so at Symposium's shape it is
 effectively free.
 
 ## R2 in practice
@@ -210,7 +210,7 @@ including the license-server workaround a local push needs.
 
 ## Why this stack, and where it strains
 
-The decisive property is R2's lack of egress fees. updoc is, at bottom, a service
+The decisive property is R2's lack of egress fees. Symposium is, at bottom, a service
 that hands the same immutable bytes to many readers, and everywhere else that
 shape is dominated by bandwidth — S3 plus CloudFront is roughly $0.085/GB, which
 at scale *is* the business, and is zero here. The rest follows: immutable version
@@ -219,7 +219,7 @@ read is a lookup and a stream. No component in the serving path is priced per
 user or per seat, which is the other way this category usually gets expensive.
 
 The weak link is D1, and it is worth being clear-eyed. One database is capped at
-10 GB, is single-threaded, and takes writes in a single region. updoc's shape
+10 GB, is single-threaded, and takes writes in a single region. Symposium's shape
 keeps that comfortable — a push is a handful of small writes, a read is one
 indexed lookup — but a write-heavy future (agents pushing on every edit, then
 comment threads) would eventually reach it. Two escape hatches are already in the
@@ -246,7 +246,7 @@ Two caveats to hold onto:
 
 For a document-sharing service specifically, this is a strong fit, and more so
 the larger it gets. It would be the wrong stack for something transactional,
-relationally complex, or CPU-heavy per request — updoc is none of those.
+relationally complex, or CPU-heavy per request — Symposium is none of those.
 
 It also holds for where the product is going. Comments (see
 [comments.md](comments.md)) are the workload Durable Objects exist for: a

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -66,7 +66,7 @@ Any other method or path under `/api/v1` is `404 not_found`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
- "url": "https://updoc.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "url": "https://symposium.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
  "version": 1}
 ```
 
@@ -87,7 +87,7 @@ it does on `POST`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
- "url": "https://updoc.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "url": "https://symposium.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
  "version": 2}
 ```
 
@@ -131,7 +131,7 @@ Only the calling publisher's live docs, newest first by creation time.
 {"docs": [
    {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
     "title": "Q3 architecture review",
-    "url": "https://updoc.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+    "url": "https://symposium.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
     "version": 2,
     "updatedAt": 1785000000000}
  ],
@@ -176,7 +176,7 @@ retargeting. The origin is cookieless and holds nothing but already-public docs.
 
 Two things are injected into the document at push time, so the stored bytes and
 the served bytes are the same thing: a `<meta name="robots" content="noindex,nofollow">`
-in the head, and a small `Shared with updoc` footer before `</body>`. Nothing
+in the head, and a small `Shared with Symposium` footer before `</body>`. Nothing
 else is touched — the markup is never sanitized, rewritten or reformatted.
 
 `404` for an unknown id or version; `410` once the doc is deleted.
@@ -239,7 +239,7 @@ re-sharing a note update the page instead of minting a second link.
 
 ```yaml
 ---
-updoc: 9f2k4mvq7t0xbz3ncrhs5wda1p
+symposium: 9f2k4mvq7t0xbz3ncrhs5wda1p
 ---
 ```
 
@@ -250,7 +250,7 @@ note travelled to a vault signed in with a different license key. Fall back to
 ## A whole round trip
 
 ```bash
-BASE=https://updoc.example.workers.dev
+BASE=https://symposium.example.workers.dev
 KEY=<copilot plus license key>
 
 # publish

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,4 +1,4 @@
--- updoc v0 pointer index.
+-- Symposium v0 pointer index.
 --
 -- R2 is the system of record; every row here is rebuildable by scanning R2.
 -- Timestamps are epoch milliseconds (INTEGER), so no date parsing at read time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "updoc",
+  "name": "symposium",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "updoc",
+      "name": "symposium",
       "version": "0.0.0",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.21",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "updoc",
+  "name": "symposium",
   "version": "0.0.0",
   "description": "Push a local md/html file, get a public HTML page on the internet",
   "type": "module",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# End-to-end smoke check against a *deployed* updoc worker.
+# End-to-end smoke check against a *deployed* Symposium worker.
 #
-#   UPDOC_LICENSE_KEY=... scripts/smoke.sh https://updoc.<subdomain>.workers.dev
+#   SYMPOSIUM_LICENSE_KEY=... scripts/smoke.sh https://symposium.<subdomain>.workers.dev
 #
 # It publishes a doc, reads it back from its public url, finds it in the
 # publisher's list, deletes it, and confirms the url has become 410. Every step
@@ -19,22 +19,22 @@
 # machine via `ps`. Nothing here echoes it, and the API never returns it.
 set -euo pipefail
 
-BASE_URL=${1:-${UPDOC_BASE_URL:-}}
+BASE_URL=${1:-${SYMPOSIUM_BASE_URL:-}}
 
 usage() {
   cat >&2 <<'EOF'
-usage: UPDOC_LICENSE_KEY=<copilot plus license key> scripts/smoke.sh <base url>
+usage: SYMPOSIUM_LICENSE_KEY=<copilot plus license key> scripts/smoke.sh <base url>
 
-  <base url>          e.g. https://updoc.<subdomain>.workers.dev
-                      (or set UPDOC_BASE_URL instead of passing it)
-  UPDOC_LICENSE_KEY   a Copilot Plus license key with a push quota to spare.
+  <base url>          e.g. https://symposium.<subdomain>.workers.dev
+                      (or set SYMPOSIUM_BASE_URL instead of passing it)
+  SYMPOSIUM_LICENSE_KEY   a Copilot Plus license key with a push quota to spare.
                       Never passed as an argument, never printed.
 EOF
   exit 2
 }
 
 [ -n "$BASE_URL" ] || usage
-[ -n "${UPDOC_LICENSE_KEY:-}" ] || usage
+[ -n "${SYMPOSIUM_LICENSE_KEY:-}" ] || usage
 
 # Trailing slashes would double up in every url built below.
 BASE_URL=${BASE_URL%/}
@@ -55,7 +55,7 @@ BODY="$WORK/body"
 # builtin, so escaping the key for that quoting never puts it in a process's
 # arguments either.
 printf 'header = "Authorization: Bearer %s"\n' \
-  "$(printf '%s' "$UPDOC_LICENSE_KEY" | sed 's/[\\"]/\\&/g')" >"$AUTH"
+  "$(printf '%s' "$SYMPOSIUM_LICENSE_KEY" | sed 's/[\\"]/\\&/g')" >"$AUTH"
 
 HTTP_STATUS=""
 
@@ -116,10 +116,10 @@ json_string() {
 
 # Marks the doc this run published, so the read-back is checking our own bytes
 # rather than any doc happening to be there.
-MARKER="updoc-smoke-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+MARKER="symposium-smoke-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
 cat >"$WORK/push.json" <<EOF
-{"title":"updoc smoke check $MARKER",
+{"title":"Symposium smoke check $MARKER",
  "html":"<!doctype html><html lang=en><head><meta charset=utf-8><title>smoke</title></head><body><p>$MARKER</p></body></html>"}
 EOF
 
@@ -142,7 +142,7 @@ printf '      docId %s\n      url   %s\n' "$DOC_ID" "$DOC_URL"
 public_request "$DOC_URL"
 expect_status 200 "GET $DOC_URL"
 expect_body "$MARKER" "the page serves the bytes that were pushed"
-expect_body "Shared with updoc" "the page carries the updoc footer"
+expect_body "Shared with Symposium" "the page carries the Symposium footer"
 
 api_request GET "$BASE_URL/api/v1/docs?limit=100"
 expect_status 200 "GET /api/v1/docs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ const API_PREFIX = "/api/v1";
 
 /**
  * Lowercase and drop the trailing root dot, so `A.Com` and `a.com.` both match
- * `a.com`. The root dot matters: `new URL("https://updoc.page./x").hostname` is
- * `"updoc.page."`, so without this a request with a dotted Host header would
+ * `a.com`. The root dot matters: `new URL("https://symposium.page./x").hostname` is
+ * `"symposium.page."`, so without this a request with a dotted Host header would
  * miss the serving-host match and fall through to the path prefix — which is
  * exactly how `/api/v1` would become reachable on the serving domain.
  */

--- a/src/render.ts
+++ b/src/render.ts
@@ -29,7 +29,7 @@
 export const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
 
 /**
- * The "shared with updoc" byline (D9).
+ * The "Shared with Symposium" byline (D9).
  *
  * `all:initial` first, then only the properties we want back: the page's own
  * stylesheet has no way to guess this class, but it very often styles `div`,
@@ -37,12 +37,12 @@ export const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
  * styles keep it self-contained — no stylesheet to fetch, nothing for the CSP
  * to allow.
  */
-export const UPDOC_FOOTER =
-  '<div class="updoc-footer" style="' +
+export const SYMPOSIUM_FOOTER =
+  '<div class="symposium-footer" style="' +
   "all:initial;display:block;box-sizing:border-box;width:100%;clear:both;" +
   "margin:4rem 0 0;padding:1rem 0;border-top:1px solid rgba(128,128,128,0.25);" +
   "font:400 13px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;" +
-  'color:#888;text-align:center">Shared with updoc</div>';
+  'color:#888;text-align:center">Shared with Symposium</div>';
 
 /** HTMLRewriter treats injected content as markup, not text, only when asked. */
 const AS_HTML = { html: true } as const;
@@ -83,14 +83,14 @@ export async function bakeServedHtml(html: string): Promise<Uint8Array> {
       element(body) {
         body.onEndTag((endTag) => {
           footerPlaced = true;
-          endTag.before(UPDOC_FOOTER, AS_HTML);
+          endTag.before(SYMPOSIUM_FOOTER, AS_HTML);
         });
       },
     })
     .onDocument({
       end(end) {
         if (!metaPlaced) end.append(NOINDEX_META, AS_HTML);
-        if (!footerPlaced) end.append(UPDOC_FOOTER, AS_HTML);
+        if (!footerPlaced) end.append(SYMPOSIUM_FOOTER, AS_HTML);
       },
     })
     .transform(new Response(html));

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,7 +34,7 @@ const DOC_PATH_PREFIX = `${SERVING_PREFIX}/`;
 const VERSION_SEGMENT = /^v([1-9][0-9]{0,8})$/;
 
 /**
- * The Content Security Policy. This is the security boundary of updoc, so every
+ * The Content Security Policy. This is the security boundary of Symposium, so every
  * directive below is a deliberate choice rather than a copied default.
  *
  * The threat model is unusual and worth stating plainly: the page's own author

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -368,7 +368,7 @@ describe("resolvePublisher — license env not configured", () => {
 
 describe("authenticateRequest", () => {
   const request = (authorization?: string) =>
-    new Request("https://updoc.test/api/v1/docs", {
+    new Request("https://symposium.test/api/v1/docs", {
       headers: authorization === undefined ? {} : { authorization },
     });
 
@@ -445,7 +445,7 @@ describe("/api/v1 is gated on a publisher", () => {
   const ctx = {} as ExecutionContext;
   const call = (authorization?: string, db: D1Database = fakeD1()) =>
     worker.fetch(
-      new Request("https://updoc.workers.dev/api/v1/docs", {
+      new Request("https://symposium.workers.dev/api/v1/docs", {
         headers: authorization === undefined ? {} : { authorization },
       }),
       env({ DB: db, SERVING_HOST: "", API_HOST: "" }),

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -6,7 +6,7 @@ const env = { SERVING_HOST: "", API_HOST: "" } as Env;
 const ctx = {} as ExecutionContext;
 
 const call = (path: string) =>
-  worker.fetch(new Request(`https://updoc.test${path}`), env, ctx);
+  worker.fetch(new Request(`https://symposium.test${path}`), env, ctx);
 
 describe("worker", () => {
   it("serves a health check", async () => {

--- a/test/ids.test.ts
+++ b/test/ids.test.ts
@@ -57,7 +57,7 @@ describe("newDocId", () => {
   it("is url-safe as a single path segment", () => {
     for (const id of ids.slice(0, 50)) {
       expect(encodeURIComponent(id)).toBe(id);
-      expect(new URL(`https://updoc.page/d/${id}`).pathname).toBe(`/d/${id}`);
+      expect(new URL(`https://symposium.page/d/${id}`).pathname).toBe(`/d/${id}`);
     }
   });
 

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -6,7 +6,7 @@ import { docObjectPrefix, versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
 /** v0 runs both surfaces on one workers.dev subdomain. */
-const API_ORIGIN = "https://updoc.workers.dev";
+const API_ORIGIN = "https://symposium.workers.dev";
 
 const KEY_A = "cplus_live_a1b2c3d4e5f60718";
 const KEY_B = "cplus_live_9988776655443322";
@@ -389,10 +389,10 @@ describe("GET /api/v1/docs", () => {
     const created = await publish(KEY_A, "A note");
 
     const response = await send("GET", "/api/v1/docs", KEY_A, undefined, {
-      SERVING_HOST: "updoc.page",
+      SERVING_HOST: "symposium.page",
     });
 
-    expect((await listed(response)).docs[0]?.url).toBe(`https://updoc.page/d/${created.docId}`);
+    expect((await listed(response)).docs[0]?.url).toBe(`https://symposium.page/d/${created.docId}`);
   });
 
   it("orders newest first", async () => {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -6,12 +6,12 @@ import { commitVersionMetadata } from "../src/db.js";
 import type { DocRow, PushQuotaRow, VersionRow } from "../src/db.js";
 import { isDocId } from "../src/ids.js";
 import { MAX_REQUEST_BYTES, utcDay, utf8Length } from "../src/quota.js";
-import { NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
+import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
 /** v0 runs both surfaces on one workers.dev subdomain. */
-const API_ORIGIN = "https://updoc.workers.dev";
+const API_ORIGIN = "https://symposium.workers.dev";
 
 const KEY_A = "cplus_live_a1b2c3d4e5f60718";
 const KEY_B = "cplus_live_9988776655443322";
@@ -147,7 +147,7 @@ describe("POST /api/v1/docs", () => {
     const html = await object!.text();
 
     expect(html.slice(0, html.indexOf("</head>"))).toContain(NOINDEX_META);
-    expect(html).toContain(`${UPDOC_FOOTER}</body>`);
+    expect(html).toContain(`${SYMPOSIUM_FOOTER}</body>`);
     expect(html).toContain(article);
     expect(object!.httpMetadata?.contentType).toBe("text/html; charset=utf-8");
 
@@ -162,7 +162,7 @@ describe("POST /api/v1/docs", () => {
   });
 
   it("keeps uploaded scripts intact (D6)", async () => {
-    const interactive = '<script>window.__updoc = "runs";</script><canvas id="figure"></canvas>';
+    const interactive = '<script>window.__symposium = "runs";</script><canvas id="figure"></canvas>';
 
     const body = await pushedOk(
       await post(KEY_A, { title: "Figure", html: page(interactive) }),
@@ -198,11 +198,11 @@ describe("POST /api/v1/docs", () => {
 
   it("points the url at the serving host once one is configured (D3)", async () => {
     const body = await pushedOk(
-      await post(KEY_A, { title: "t", html: page("<p>x</p>") }, { SERVING_HOST: "updoc.page" }),
+      await post(KEY_A, { title: "t", html: page("<p>x</p>") }, { SERVING_HOST: "symposium.page" }),
       201,
     );
 
-    expect(body.url).toBe(`https://updoc.page/d/${body.docId}`);
+    expect(body.url).toBe(`https://symposium.page/d/${body.docId}`);
   });
 });
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bakeServedHtml, NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
+import { bakeServedHtml, NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 
 const bake = async (html: string): Promise<string> =>
   new TextDecoder().decode(await bakeServedHtml(html));
@@ -22,10 +22,10 @@ describe("bakeServedHtml — what gets injected", () => {
     expect(NOINDEX_META).toBe('<meta name="robots" content="noindex,nofollow">');
   });
 
-  it("names updoc in text a reader can see", async () => {
+  it("names Symposium in text a reader can see", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
-    expect(baked).toContain(">Shared with updoc<");
+    expect(baked).toContain(">Shared with Symposium<");
   });
 });
 
@@ -34,14 +34,14 @@ describe("bakeServedHtml — where the injections land", () => {
     const baked = await bake(page("<p>hello</p>"));
 
     expect(headOf(baked)).toContain(NOINDEX_META);
-    expect(baked).toContain(`${UPDOC_FOOTER}</body>`);
+    expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
   });
 
   it("injects each exactly once, however many candidate tags the page has", async () => {
     const baked = await bake(page("<div><p>one</p></div><div><p>two</p></div>"));
 
     expect(occurrences(baked, NOINDEX_META)).toBe(1);
-    expect(occurrences(baked, UPDOC_FOOTER)).toBe(1);
+    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
   });
 
   it("keeps the document's own head content, including its own meta tags", async () => {
@@ -61,7 +61,7 @@ describe("bakeServedHtml — documents missing the tags to hang them on", () => 
     );
 
     expect(headOf(baked)).toContain(NOINDEX_META);
-    expect(baked).toContain(UPDOC_FOOTER);
+    expect(baked).toContain(SYMPOSIUM_FOOTER);
     expect(baked).toContain("<p>hi</p>");
   });
 
@@ -69,7 +69,7 @@ describe("bakeServedHtml — documents missing the tags to hang them on", () => 
     const baked = await bake("<!doctype html>\n<html>\n<body>\n<p>hi</p>\n</body>\n</html>");
 
     expect(baked).toContain(NOINDEX_META);
-    expect(baked).toContain(`${UPDOC_FOOTER}</body>`);
+    expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
     // The doctype has to stay first: a meta ahead of it would put the page into
     // quirks mode, which is a real change to how the document renders.
     expect(baked.startsWith("<!doctype html>")).toBe(true);
@@ -80,7 +80,7 @@ describe("bakeServedHtml — documents missing the tags to hang them on", () => 
 
     expect(baked).toContain("<p>just a fragment</p>");
     expect(baked).toContain(NOINDEX_META);
-    expect(baked).toContain(UPDOC_FOOTER);
+    expect(baked).toContain(SYMPOSIUM_FOOTER);
   });
 });
 
@@ -109,7 +109,7 @@ describe("bakeServedHtml — the document's own content", () => {
 
     expect(baked).toContain(decoys);
     expect(occurrences(baked, NOINDEX_META)).toBe(1);
-    expect(occurrences(baked, UPDOC_FOOTER)).toBe(1);
+    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
   });
 
   it("preserves non-ASCII content byte for byte", async () => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -11,8 +11,8 @@ const ctx = {} as ExecutionContext;
 const get = (url: string, vars: Partial<Env> = {}) =>
   worker.fetch(new Request(url), env(vars), ctx);
 
-const WORKERS_DEV = "updoc.workers.dev";
-const TWO_DOMAIN = { servingHost: "updoc.page", apiHost: "api.updoc.md" };
+const WORKERS_DEV = "symposium.workers.dev";
+const TWO_DOMAIN = { servingHost: "symposium.page", apiHost: "api.symposium.md" };
 
 describe("resolveSurface — workers.dev, no hosts configured", () => {
   const unset = {};
@@ -43,25 +43,25 @@ describe("resolveSurface — workers.dev, no hosts configured", () => {
 
 describe("resolveSurface — two configured domains", () => {
   it("routes by host, not path", () => {
-    expect(resolveSurface("updoc.page", "/d/abc", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("api.updoc.md", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+    expect(resolveSurface("symposium.page", "/d/abc", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("api.symposium.md", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
   });
 
   it("keeps /api/v1 off the serving host", () => {
-    expect(resolveSurface("updoc.page", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("updoc.page", "/api/v1/docs/abc", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("symposium.page", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("symposium.page", "/api/v1/docs/abc", TWO_DOMAIN)).toBe("serving");
   });
 
   it("keeps doc serving off the API host", () => {
-    expect(resolveSurface("api.updoc.md", "/d/abc", TWO_DOMAIN)).toBe("api");
+    expect(resolveSurface("api.symposium.md", "/d/abc", TWO_DOMAIN)).toBe("api");
   });
 
   it("matches the host case-insensitively and ignores the root dot", () => {
     // Both forms reach `/api/v1` if the match fails, so each asserts the
     // security property rather than just a normalisation detail.
-    expect(resolveSurface("UPDOC.PAGE", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("updoc.page.", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("updoc.page", "/api/v1/docs", { servingHost: "UPDOC.Page." })).toBe(
+    expect(resolveSurface("SYMPOSIUM.PAGE", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("symposium.page.", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
+    expect(resolveSurface("symposium.page", "/api/v1/docs", { servingHost: "SYMPOSIUM.Page." })).toBe(
       "serving",
     );
   });
@@ -69,11 +69,11 @@ describe("resolveSurface — two configured domains", () => {
   it("does not match a subdomain or suffix of a configured host", () => {
     // A path with no prefix to fall back on, so "unknown" can only mean the
     // host itself did not match.
-    expect(resolveSurface("evil.updoc.page", "/nope", TWO_DOMAIN)).toBe("unknown");
-    expect(resolveSurface("updoc.page.evil.com", "/nope", TWO_DOMAIN)).toBe("unknown");
-    expect(resolveSurface("notupdoc.page", "/nope", TWO_DOMAIN)).toBe("unknown");
+    expect(resolveSurface("evil.symposium.page", "/nope", TWO_DOMAIN)).toBe("unknown");
+    expect(resolveSurface("symposium.page.evil.com", "/nope", TWO_DOMAIN)).toBe("unknown");
+    expect(resolveSurface("notsymposium.page", "/nope", TWO_DOMAIN)).toBe("unknown");
     // And a lookalike host still gets no serving treatment for an API path.
-    expect(resolveSurface("evil.updoc.page", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+    expect(resolveSurface("evil.symposium.page", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
   });
 
   it("falls back to path prefixes on an unrecognised host", () => {
@@ -82,7 +82,7 @@ describe("resolveSurface — two configured domains", () => {
   });
 
   it("routes by host when only the serving host is configured", () => {
-    expect(resolveSurface("updoc.page", "/api/v1/docs", { servingHost: "updoc.page" })).toBe(
+    expect(resolveSurface("symposium.page", "/api/v1/docs", { servingHost: "symposium.page" })).toBe(
       "serving",
     );
   });
@@ -90,10 +90,10 @@ describe("resolveSurface — two configured domains", () => {
 
 describe("worker dispatch", () => {
   it("serves the health check on any host", async () => {
-    for (const host of [WORKERS_DEV, "updoc.page", "api.updoc.md"]) {
+    for (const host of [WORKERS_DEV, "symposium.page", "api.symposium.md"]) {
       const res = await get(`https://${host}/health`, {
-        SERVING_HOST: "updoc.page",
-        API_HOST: "api.updoc.md",
+        SERVING_HOST: "symposium.page",
+        API_HOST: "api.symposium.md",
       });
       expect(res.status).toBe(200);
       await expect(res.json()).resolves.toEqual({ ok: true });
@@ -128,10 +128,10 @@ describe("worker dispatch", () => {
     // Including the trailing-root-dot form, which `new URL()` preserves in
     // `hostname` and which would otherwise miss the host match and fall
     // through to the /api/v1 path prefix.
-    for (const host of ["updoc.page", "updoc.page.", "UPDOC.PAGE"]) {
+    for (const host of ["symposium.page", "symposium.page.", "SYMPOSIUM.PAGE"]) {
       const res = await get(`https://${host}/api/v1/docs`, {
-        SERVING_HOST: "updoc.page",
-        API_HOST: "api.updoc.md",
+        SERVING_HOST: "symposium.page",
+        API_HOST: "api.symposium.md",
       });
       expect(res.status).toBe(404);
       // Two independent signals that the serving surface answered: only it
@@ -144,7 +144,7 @@ describe("worker dispatch", () => {
   });
 
   it("never sets a cookie on the serving surface", async () => {
-    const res = await get("https://updoc.page/d/abc", { SERVING_HOST: "updoc.page" });
+    const res = await get("https://symposium.page/d/abc", { SERVING_HOST: "symposium.page" });
     expect(res.headers.get("set-cookie")).toBeNull();
   });
 });

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -1,12 +1,12 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
-import { NOINDEX_META, UPDOC_FOOTER } from "../src/render.js";
+import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
 /** v0 runs both surfaces on one workers.dev subdomain. */
-const ORIGIN = "https://updoc.workers.dev";
+const ORIGIN = "https://symposium.workers.dev";
 
 const KEY = "cplus_live_a1b2c3d4e5f60718";
 
@@ -122,7 +122,7 @@ describe("GET /d/{docId}", () => {
     expect(html).toContain("<p>second draft</p>");
     expect(html).not.toContain("<p>first draft</p>");
     expect(html).toContain(NOINDEX_META);
-    expect(html).toContain(UPDOC_FOOTER);
+    expect(html).toContain(SYMPOSIUM_FOOTER);
   });
 
   it("serves version 1 at the same url before there is a version 2", async () => {
@@ -413,7 +413,7 @@ describe("a doc that is not there", () => {
     // arrangement in which the prefix lookalikes below reach this handler at
     // all — on workers.dev the router answers them as unknown paths — and it is
     // the arrangement where mistaking `/dx{docId}` for a doc url would matter.
-    const servingHost = { SERVING_HOST: "updoc.workers.dev", DB: noDb };
+    const servingHost = { SERVING_HOST: "symposium.workers.dev", DB: noDb };
 
     for (const path of impossible) {
       const response = await get(path, undefined, servingHost);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "updoc",
+  "name": "symposium",
   "main": "src/index.ts",
   "compatibility_date": "2026-07-24",
   "observability": {
@@ -8,7 +8,7 @@
   },
 
   // R2 is the system of record: every served byte lives here.
-  "r2_buckets": [{ "binding": "DOCS", "bucket_name": "updoc-docs" }],
+  "r2_buckets": [{ "binding": "DOCS", "bucket_name": "symposium-docs" }],
 
   // D1 holds pointer rows only (ids, sizes, timestamps) and is rebuildable
   // from R2. `database_id` is a placeholder — the real id is created and
@@ -17,7 +17,7 @@
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "updoc",
+      "database_name": "symposium",
       "database_id": "00000000-0000-0000-0000-000000000000",
       "migrations_dir": "migrations"
     }


### PR DESCRIPTION
## Summary

**Why:** updoc cannot be the name. `updoc.io` is report-writing software in the
same category, and UpDoc clinical AI is funded and FDA-cleared. Beyond the
collisions, "up" + "doc" describes uploading documents, so the mark is
descriptive — hard to register without proving acquired distinctiveness, and
hard to enforce because courts discount similarity in the descriptive parts of a
mark.

**What:** the product is Symposium. `symposium.md` is unregistered, and a USPTO
wordmark search returns no SYMPOSIUM registration in class 9 or class 42 — the
only bare marks are wines, 1994 loudspeakers, and coffee. The name is
suggestive rather than descriptive, so it registers on its own strength.

No behavior changes. Every rename is a string.

## Decisions

- **Brand mentions in prose are capitalized `Symposium`.** updoc was a coined
  lowercase word; symposium is a common noun, and lowercase mid-sentence reads
  as the noun rather than the product.
- **Identifiers stay lowercase**: the worker name, `symposium-docs`,
  `database_name`, the package name, hostnames, the `symposium:` frontmatter
  key, and CLI arguments.
- **The `docs/http-api.md` contract changes, deliberately.** CLAUDE.md freezes
  it, and two items carry the name: the frontmatter key Copilot writes into a
  note, and the injected `Shared with Symposium` footer. Both are free right now
  because nothing is deployed and the Copilot side does not exist yet. Both
  become a cross-repo release the moment either ships, which is the argument for
  doing it in this PR rather than a later one.

## Changes

- `4b8b29a` — rename across all 23 files that named the product. Verify with
  `npm test` (198 pass) and `npm run typecheck` (clean); the footer string is
  asserted identically in `src/render.ts`, `test/render.test.ts`,
  `scripts/smoke.sh` and `docs/http-api.md`.

## Notes / follow-ups

- The GitHub repo is renamed to `Brevilabs/symposium`; GitHub redirects the old
  URL, and this clone's remote is updated.
- The local working directory is still `~/webapps/updoc`.
- `symposium.md` is not registered yet. Worth buying before this goes anywhere.
- A knockout search is not a clearance search: it matched literal strings, so
  phonetic neighbours were not swept, and common-law users never appear on the
  register. `symposium.app` (an agentic-CLI experiment) and `symposiumapp.com`
  (Tighten Co's speaker tool) are both unregistered and both real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq
