### PR TITLE
Lead the README with the tagline instead of the product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Symposium
-
-**Where people and agents get on the same page.**
+# Where people and agents get on the same page
 
 Every version and every thread live at one address, so anyone who opens it can
 catch up without being briefed.
 
-That is what Symposium is for, not what it does today. Only the first step exists:
-push a local md/html file and get a public HTML page on the internet. The upload
-API is private and programmatic, its only caller is Obsidian Copilot's share
-action, and there are no reader accounts, no permissions, and no comments.
+---
+
+That is what **Symposium** is for, not what it does today. Only the first step
+exists: push a local md/html file and get a public HTML page on the internet.
+The upload API is private and programmatic, its only caller is Obsidian
+Copilot's share action, and there are no reader accounts, no permissions, and no
+comments.
 
 ## What works today
 
@@ -96,7 +97,7 @@ lists the ones that bind day to day.
 | [Development](docs/development.md) | Running it locally, including the license-server workaround. |
 | [Comments](docs/comments.md) | Design sketch for the next step of the product. Not planned, not built. |
 | [Positioning](docs/positioning.md) | Why the product exists and what it becomes. |
-| [Cost at scale](docs/cost-at-scale.md) | Whether the free wedge is affordable, and the architecture that keeps it so. |
+| [Cost at scale](docs/cost-at-scale.md) | What it costs to serve, who pays, and the architecture that keeps both cheap. |
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

**Why:** the tagline was bold body text. GitHub renders that at exactly the same
size as any other bold phrase in the file, so the line the product is built
around had no more visual weight than a list item's lead-in. Headings are the
only thing that changes size in a README, which makes this a structural problem
rather than a formatting one.

**What:** the tagline is the `<h1>` and the sub-headline is the paragraph under
it. Nothing else in the README moves.

```
# Where people and agents get on the same page

Every version and every thread live at one address, so anyone who opens it can
catch up without being briefed.

---

That is what **Symposium** is for, not what it does today. Only the first step
exists: push a local md/html file and get a public HTML page on the internet.
```

## Decisions

- **The product name moves into the first body sentence.** GitHub already prints
  `Brevilabs/symposium` directly above the README, so an `<h1>` repeating it
  spent the largest text on the page on the one thing the reader has already
  been told. The name is still the first bolded word they hit.
- **A horizontal rule separates the promise from the caveat.** "That is what
  Symposium is for, not what it does today" was landing one line under the
  tagline and taking it back before the reader had finished it. The sentence
  stays, because the honesty is the point of this README; it just needed a beat
  before it so it reads as a turn rather than a retraction.
- **Dropped the last "free wedge" phrasing**, in the docs table's description of
  the cost doc. Final survivor of the pricing model #5 replaced.

## Changes

- `d4198fd` — README hero. Verify by rendering the README: the tagline is the
  largest text on the page and the sub-headline sits immediately below it.
  `npm test` (198 pass) unaffected; no source changes.

## Notes / follow-ups

- This commit was originally pushed to #6 as `758b59f` and missed that merge by
  one commit, so it is rebased onto `main` here rather than re-authored.
- `rename/symposium`, `docs/serving-domain`, `docs/hosting-rewrite` and
  `docs/split-readme` are all merged and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq
