### PR TITLE
Never route the Worker on workers.dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,12 @@ treat D1 as a system of record, not as a cache.
 
 ## Owed when the real serving domain lands
 
-v0 runs on a `workers.dev` subdomain, which sits outside the CDN cache. Two
-things become true the moment user content moves to a real serving domain, and
-both are easy to miss because nothing fails loudly without them:
+`workers_dev` is `false`, so the Worker is unreachable until a custom domain is
+attached — the router would otherwise serve `/d/*` on a `workers.dev` hostname,
+and that domain is on the Public Suffix List, so a listing against it would take
+every Worker on the account's subdomain. Two things become true the moment user
+content moves to a real serving domain, and both are easy to miss because
+nothing fails loudly without them:
 
 - **Caching needs a Cache Rule, not just a domain.** Cloudflare does not cache
   HTML by default — eligibility is decided by file extension, not MIME type and

--- a/README.md
+++ b/README.md
@@ -53,12 +53,14 @@ Roughly in order. Nothing below is started.
 - **The Obsidian side.** A right-click "share" in Copilot that calls this API and
   remembers the doc's id in the note. Without it, the only way to publish is
   `curl` — this is the next thing to build.
-- **Real domains, and actual caching.** Today's `workers.dev` url works but
-  bypasses Cloudflare's cache, so every read hits the server. A domain is only
-  half of the fix — Cloudflare does not cache HTML by default, so it also needs
-  a cache rule, and then deletes have to purge the cache. This is also where
-  documents move off the brand domain onto `symposium.site`, so that one bad
-  upload can't get `symposium.md` flagged by Google Safe Browsing.
+- **Real domains, and actual caching.** There is no `workers.dev` url — that
+  route is off, because the router would serve documents on it and a
+  `workers.dev` listing takes every Worker on the account's subdomain with it.
+  So the domains come first: `symposium.site` for documents, `api.symposium.md`
+  for the API, which is also what keeps one bad upload from getting
+  `symposium.md` flagged by Google Safe Browsing. Caching is a separate fix on
+  top — Cloudflare does not cache HTML by default, so it needs a cache rule, and
+  then deletes have to purge the cache.
   [`docs/serving-domain.md`](docs/serving-domain.md) explains why that split
   can't be added later.
 - **Backups that don't depend on the database.** Right now the database is the

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -52,12 +52,15 @@ npx wrangler d1 migrations apply symposium --remote
 npx wrangler secret put LICENSE_API_URL     # e.g. https://api.brevilabs.com
 npx wrangler secret put LICENSE_API_KEY
 
-# 5. Ship. This prints the workers.dev url.
+# 5. Ship. The Worker has no hostname yet — see below.
 npx wrangler deploy
 
-# 6. Check what just shipped, end to end.
+# 6. Attach the domains, which is what makes it reachable.
+npx wrangler deploy   # after setting SERVING_HOST and API_HOST
+
+# 7. Check what just shipped, end to end, against the surface that ships.
 SYMPOSIUM_LICENSE_KEY=<a real lifetime-tier key> \
-  scripts/smoke.sh https://symposium.<subdomain>.workers.dev
+  scripts/smoke.sh https://api.symposium.md
 ```
 
 The smoke script publishes a doc, reads it, lists it, deletes it and confirms the
@@ -66,10 +69,23 @@ and no stored bytes behind — only the deleted doc's row, which every delete ke
 so the url can go on answering `410`. It is not part of CI — CI has no key and no
 deployment.
 
-`SERVING_HOST` and `API_HOST` stay empty in `wrangler.jsonc` for v0: one
-workers.dev subdomain hosts both surfaces and the router falls back to path
-prefixes. Filling them in later moves doc serving onto the sacrificial domain
-without a code change — and the `url` the API returns follows automatically.
+## There is no workers.dev url
 
-Later deploys are steps 5 and 6 alone, plus step 3 whenever a migration is added.
+`workers_dev` is `false`, so step 5 uploads a Worker that answers on nothing at
+all. That is deliberate, not an unfinished state.
+
+The router resolves by host and falls back to path prefixes when the host matches
+neither `SERVING_HOST` nor `API_HOST` — so a `workers.dev` hostname would happily
+serve `/d/*`, putting user HTML on a domain we neither control nor can afford to
+sacrifice. `workers.dev` is on the Public Suffix List, which makes
+`<subdomain>.workers.dev` the unit a Safe Browsing listing applies to: one bad
+upload would take down every Worker on the account's subdomain. The serving
+domain exists precisely so the blast radius lands somewhere we chose.
+
+So the order is attach first, test second. Set `SERVING_HOST` and `API_HOST` in
+`wrangler.jsonc`, attach `symposium.site` and `api.symposium.md` as custom
+domains, redeploy, and only then smoke-test. The `url` the API returns follows
+the vars automatically.
+
+Later deploys are steps 5 and 7 alone, plus step 3 whenever a migration is added.
 All changes ship through a pull request; never push to `main`.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -41,7 +41,9 @@ right one — leave it alone.
 npx wrangler d1 migrations apply symposium --remote
 ```
 
-**Steps 4–6 ship the Worker, and are what is actually outstanding.**
+**Steps 4–8 ship the Worker, and are what is actually outstanding.** Step 7 is
+the one that makes it reachable: `workers_dev` is `false`, so a Worker with no
+custom domain attached answers on nothing at all.
 
 ```bash
 # 4. Credentials for the license server. Both prompt for the value, so neither

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -8,7 +8,7 @@ commands are creating.
 
 > **The Worker has not been deployed yet.** Its storage has: on the Brevilabs
 > account, steps 1–3 below are done, and `wrangler.jsonc` already carries the
-> real `database_id`. What is left is steps 4–6. One thing to know going in: D1
+> real `database_id`. What is left is steps 4–8. One thing to know going in: D1
 > is currently the only record of who owns a doc, what it is called, and whether
 > it was deleted, so until per-doc manifests ship, back-ups mean D1's own 30-day
 > Time Travel window rather than "rebuild it from R2". That is fine at low volume
@@ -55,10 +55,14 @@ npx wrangler secret put LICENSE_API_KEY
 # 5. Ship. The Worker has no hostname yet — see below.
 npx wrangler deploy
 
-# 6. Attach the domains, which is what makes it reachable.
-npx wrangler deploy   # after setting SERVING_HOST and API_HOST
+# 6. Set SERVING_HOST and API_HOST in wrangler.jsonc, then redeploy. Still
+#    unreachable, which is the point: the hosts go live before any domain does.
+npx wrangler deploy
 
-# 7. Check what just shipped, end to end, against the surface that ships.
+# 7. Attach symposium.site and api.symposium.md as custom domains. This is what
+#    makes it reachable, and by now the running version already knows the hosts.
+
+# 8. Check what just shipped, end to end, against the surface that ships.
 SYMPOSIUM_LICENSE_KEY=<a real lifetime-tier key> \
   scripts/smoke.sh https://api.symposium.md
 ```
@@ -82,10 +86,14 @@ sacrifice. `workers.dev` is on the Public Suffix List, which makes
 upload would take down every Worker on the account's subdomain. The serving
 domain exists precisely so the blast radius lands somewhere we chose.
 
-So the order is attach first, test second. Set `SERVING_HOST` and `API_HOST` in
-`wrangler.jsonc`, attach `symposium.site` and `api.symposium.md` as custom
-domains, redeploy, and only then smoke-test. The `url` the API returns follows
-the vars automatically.
+So the order is configure, then attach, then test — and the redeploy goes *before*
+the attach, not after. Set `SERVING_HOST` and `API_HOST` in `wrangler.jsonc` and
+redeploy while the Worker is still unreachable, then attach the domains, then
+smoke-test. Attaching first would leave the domains pointing at a version whose
+hosts are empty, and the path-prefix fallback would serve `/d/*` on
+`api.symposium.md` and `/api/v1/*` on `symposium.site` until the redeploy landed
+— the exact split this document argues for, undone for the length of a deploy.
+The `url` the API returns follows the vars automatically.
 
-Later deploys are steps 5 and 7 alone, plus step 3 whenever a migration is added.
+Later deploys are steps 5 and 8 alone, plus step 3 whenever a migration is added.
 All changes ship through a pull request; never push to `main`.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -36,11 +36,15 @@ index: who owns a doc, what it is called, which versions exist, whether it was
 deleted. No document content is ever stored in it.
 
 **workers.dev** — a free subdomain Cloudflare gives every account, so a Worker is
-reachable the moment you deploy without owning a domain or touching DNS. Ours
-will be `symposium.<account-subdomain>.workers.dev`. From the caller's side it
-behaves like any other URL; the catch is that it sits outside Cloudflare's CDN
-cache, so every request reaches your Worker. It is meant for development and
-early testing, which is exactly where Symposium is.
+normally reachable the moment you deploy without owning a domain or touching DNS.
+**Symposium does not use it.** `workers_dev` is `false` in `wrangler.jsonc`,
+because the router falls back to path prefixes on any unrecognized host and would
+therefore serve user documents at `/d/*` on a `workers.dev` url. That domain is
+on the Public Suffix List, so a Safe Browsing listing would apply to
+`<subdomain>.workers.dev` and take every Worker on the account with it — the
+opposite of what the serving domain is for. It also sits outside Cloudflare's CDN
+cache. The tradeoff is that a fresh deploy answers on nothing until a custom
+domain is attached.
 
 Two more names you will meet: **wrangler**, the CLI that does everything
 (`wrangler dev`, `wrangler deploy`, `wrangler d1 …`), and **workerd**, the
@@ -105,7 +109,8 @@ throwaway one, the API on the brand one — for reasons in
 **Nothing is cached today**, and attaching a domain would not by itself change
 that. Two independent reasons:
 
-1. `workers.dev` bypasses the CDN cache entirely.
+1. Nothing is reachable yet — `workers_dev` is off and no custom domain is
+   attached, so there is no hostname for a cache to sit in front of.
 2. Cloudflare does not cache HTML by default *on any domain*. Eligibility is
    decided by file extension — not MIME type, and not the `Cache-Control` the
    Worker sends — and `/d/{docId}` has no extension.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -9,18 +9,17 @@ repo's source.
 
 ## Surfaces
 
-Two surfaces, which will eventually be two domains:
+Two surfaces on two domains:
 
 | Surface | Paths | Auth | Notes |
 | --- | --- | --- | --- |
 | API | `/api/v1/*` | required | Publisher-facing. JSON in, JSON out. |
 | Serving | `/d/*` | none | Reader-facing. Public HTML. Never sets a cookie. |
 
-In v0 both run on one `workers.dev` subdomain and the path prefix decides which
-is which. Later they split across a brand domain and a sacrificial serving
-domain; when that happens the `url` field returned by a push starts pointing at
-the serving domain, which is the only reason a client should never build a doc
-url itself. **Always use the `url` the API returns.**
+The API is served from `api.symposium.md` and documents from `symposium.site`.
+The `url` field a push returns therefore points at a different host than the one
+the client called, which is the reason a client must never build a doc url
+itself. **Always use the `url` the API returns.**
 
 `GET /health` → `200 {"ok": true}` is reachable on both, unauthenticated.
 
@@ -80,7 +79,7 @@ Any other method or path under `/api/v1` is `404 not_found`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
- "url": "https://symposium.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "url": "https://symposium.site/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
  "version": 1}
 ```
 
@@ -101,7 +100,7 @@ it does on `POST`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
- "url": "https://symposium.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+ "url": "https://symposium.site/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
  "version": 2}
 ```
 
@@ -145,7 +144,7 @@ Only the calling publisher's live docs, newest first by creation time.
 {"docs": [
    {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
     "title": "Q3 architecture review",
-    "url": "https://symposium.example.workers.dev/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+    "url": "https://symposium.site/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
     "version": 2,
     "updatedAt": 1785000000000}
  ],
@@ -264,7 +263,7 @@ note travelled to a vault signed in with a different license key. Fall back to
 ## A whole round trip
 
 ```bash
-BASE=https://symposium.example.workers.dev
+BASE=https://api.symposium.md
 KEY=<lifetime license key>
 
 # publish

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -270,12 +270,17 @@ KEY=<lifetime license key>
 curl -sS -X POST "$BASE/api/v1/docs" \
   -H "authorization: Bearer $KEY" -H 'content-type: application/json' \
   -d '{"title":"Notes","html":"<!doctype html><html><body><p>hello</p></body></html>"}'
-# → {"docId":"9f2k…","url":"https://…/d/9f2k…","version":1}
+# → {"docId":"9f2k…","url":"https://symposium.site/d/9f2k…","version":1}
 
-curl -sS "$BASE/d/9f2k…"                       # the public page, no auth
+# The document reads use the `url` that push returned, never "$BASE/d/…": the
+# page lives on the serving domain, and the API host resolves every path to the
+# API surface, which would answer these unauthenticated reads 401.
+DOC=https://symposium.site/d/9f2k…
+
+curl -sS "$DOC"                                # the public page, no auth
 curl -sS "$BASE/api/v1/docs?limit=10" -H "authorization: Bearer $KEY"
 curl -sS -X DELETE "$BASE/api/v1/docs/9f2k…" -H "authorization: Bearer $KEY" -i
-curl -sS "$BASE/d/9f2k…" -o /dev/null -w '%{http_code}\n'   # → 410
+curl -sS "$DOC" -o /dev/null -w '%{http_code}\n'            # → 410
 ```
 
 `scripts/smoke.sh` runs exactly this sequence against a deployment and checks

--- a/docs/serving-domain.md
+++ b/docs/serving-domain.md
@@ -79,10 +79,13 @@ insuring against is one occurrence.
 
 ## Status
 
-**Both domains are registered as of 2026-07-25**: `symposium.md` for the brand,
-`symposium.site` for documents. Neither is wired up yet — v0 still serves both
-surfaces from one `workers.dev` subdomain, and the router falls back to path
-prefixes while `SERVING_HOST` and `API_HOST` are empty.
+**Both domains are registered as of 2026-07-25** — `symposium.md` for the brand,
+`symposium.site` for documents — and both are delegated to Cloudflare. Neither is
+attached to the Worker yet, so nothing is reachable: `workers_dev` is `false`
+precisely because the path-prefix fallback would otherwise serve `/d/*` on a
+`workers.dev` url, which is the mistake this whole document argues against. The
+fallback stays in the router for the window where one host var is set and the
+other is not.
 
 Three things become true together when the real domains land, and
 [`CLAUDE.md`](../CLAUDE.md) carries the detail:

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -2,7 +2,7 @@
 #
 # End-to-end smoke check against a *deployed* Symposium worker.
 #
-#   SYMPOSIUM_LICENSE_KEY=... scripts/smoke.sh https://symposium.<subdomain>.workers.dev
+#   SYMPOSIUM_LICENSE_KEY=... scripts/smoke.sh https://api.symposium.md
 #
 # It publishes a doc, reads it back from its public url, finds it in the
 # publisher's list, deletes it, and confirms the url has become 410. Every step
@@ -25,8 +25,10 @@ usage() {
   cat >&2 <<'EOF'
 usage: SYMPOSIUM_LICENSE_KEY=<lifetime license key> scripts/smoke.sh <base url>
 
-  <base url>          e.g. https://symposium.<subdomain>.workers.dev
+  <base url>          the API host, e.g. https://api.symposium.md
                       (or set SYMPOSIUM_BASE_URL instead of passing it)
+                      Document reads use the url the push returns, so the
+                      serving domain is never passed in.
   SYMPOSIUM_LICENSE_KEY   a lifetime-tier license key with a push quota to spare.
                       Never passed as an argument, never printed.
 EOF

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,18 +23,12 @@
     }
   ],
 
-  // No workers.dev route, ever. `resolveSurface` decides by host first and falls
-  // back to path prefixes when the host matches neither var, so a workers.dev
-  // hostname would go on serving /d/* — putting user HTML on a domain we do not
-  // control and cannot sacrifice. workers.dev is on the Public Suffix List, so
-  // the unit a Safe Browsing listing would hit is <subdomain>.workers.dev: one
-  // bad upload would take every Worker on the account's subdomain with it. The
-  // whole point of the serving domain is that the blast radius is a domain we
-  // chose to spend (see docs/serving-domain.md).
-  //
-  // The cost is that the Worker has no hostname until a custom domain is
-  // attached. That is the intended order: attach the domains, then smoke-test
-  // the surface that ships.
+  // No workers.dev route, ever. `resolveSurface` falls back to path prefixes on
+  // any host matching neither var below, so a workers.dev hostname would serve
+  // /d/* — user HTML on a domain we cannot sacrifice, and one whose Public
+  // Suffix List entry makes a listing hit every Worker on the account.
+  // docs/serving-domain.md is the argument; docs/deploying.md covers the cost,
+  // which is that the Worker has no hostname until a custom domain is attached.
   "workers_dev": false,
 
   // Empty until the custom domains are attached, which is what makes the path

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,11 +23,25 @@
     }
   ],
 
-  // Empty in v0: one workers.dev subdomain hosts both surfaces and the router
-  // falls back to path prefixes (/api/v1 vs /d). Filling these in splits the
-  // API onto the brand domain and doc serving onto the sacrificial domain
-  // without a code change — serving of user content never goes on the brand
-  // domain (see docs/cost-at-scale.md §6).
+  // No workers.dev route, ever. `resolveSurface` decides by host first and falls
+  // back to path prefixes when the host matches neither var, so a workers.dev
+  // hostname would go on serving /d/* — putting user HTML on a domain we do not
+  // control and cannot sacrifice. workers.dev is on the Public Suffix List, so
+  // the unit a Safe Browsing listing would hit is <subdomain>.workers.dev: one
+  // bad upload would take every Worker on the account's subdomain with it. The
+  // whole point of the serving domain is that the blast radius is a domain we
+  // chose to spend (see docs/serving-domain.md).
+  //
+  // The cost is that the Worker has no hostname until a custom domain is
+  // attached. That is the intended order: attach the domains, then smoke-test
+  // the surface that ships.
+  "workers_dev": false,
+
+  // Empty until the custom domains are attached, which is what makes the path
+  // prefixes (/api/v1 vs /d) the only routing until then. Filling these in
+  // splits the API onto the brand domain and doc serving onto the sacrificial
+  // domain without a code change — serving of user content never goes on the
+  // brand domain (see docs/cost-at-scale.md §6).
   "vars": {
     "SERVING_HOST": "",
     "API_HOST": ""


### PR DESCRIPTION
Fixes #13

## Problem

`resolveSurface` in `src/index.ts` picks the surface by hostname first and falls
back to path prefixes whenever the host matches neither `SERVING_HOST` nor
`API_HOST`. Both are empty until the custom domains are attached, so a
`workers.dev` hostname matches nothing, lands on the fallback, and serves
reader-facing `/d/*` — user-uploaded HTML on a domain we do not own.

`workers.dev` is on the Public Suffix List, so the unit a Google Safe Browsing
listing applies to is the account's own `*.workers.dev` subdomain: one malicious
upload takes every Worker on the account with it. That is the exact blast-radius
failure `docs/serving-domain.md` exists to prevent, and it is worse than the
case that document argues against — `symposium.site` is a domain chosen because
we can afford to lose it, and the account subdomain is not.

This was not hypothetical. `wrangler deploy` was failing on *"You need to
register a workers.dev subdomain before publishing to workers.dev"*, and the
obvious unblock was to register one.

## Fix

`workers_dev: false`. The route stops existing rather than being avoided by
convention, which is what makes the mistake impossible instead of merely
undocumented.

The alternative considered and rejected was registering the account subdomain
and turning the route off after attaching the custom domains. It commits an
account-wide, effectively permanent name to get a url that would be discarded
hours later, and leaves a window where documents are reachable at that address.

Accepted cost: a deployed Worker answers on no hostname until a custom domain is
attached, which moves the smoke test after the domains. That is the better order
anyway — it exercises the surface that ships instead of one thrown away.

The path-prefix fallback stays in the router deliberately. It is still correct
for the window where one host var is set and the other is not, which is why no
test moved.

## Scope

Budget gate: PASS — 8 files, +103/−50; one line of production behavior
(`workers_dev: false`), and the rest is documentation that was asserting a url
which no longer exists. Leaving those stale would be the more expensive choice.

## Changes

- `wrangler.jsonc` — `workers_dev: false`, with a comment naming the router line
  that makes an unmatched host dangerous and pointing at the docs for the rest.
- `docs/deploying.md` — a section on why there is no `workers.dev` url, and a
  corrected step order. Setting the host vars now redeploys *before* the domains
  are attached: attaching first would bind the real domains to a running version
  with empty vars, and for the length of that deploy the path-prefix fallback
  would serve `/d/*` on `api.symposium.md` and `/api/v1/*` on `symposium.site`
  — the split this PR exists to establish, undone on the first requests those
  domains ever take. With `workers_dev: false` the redeploy step is reachable on
  nothing, so closing the window costs nothing.
- `docs/http-api.md` — Surfaces names the two real hosts. Examples read
  documents from the `url` a push returns rather than from `$BASE`, because
  `$BASE` is now the API host and every path on it resolves to the API surface,
  which would answer those unauthenticated reads `401` instead of `200`/`410`.
- `scripts/smoke.sh` — usage names the API host and says why the serving domain
  is never passed in.
- `README.md`, `CLAUDE.md`, `docs/hosting.md`, `docs/serving-domain.md` — each
  said a `workers.dev` url exists. None does now.

## Verification

- `npm test` — 209 passed across 8 files.
- `npm run typecheck` — clean.
- `wrangler.jsonc` validated against `node_modules/wrangler/config-schema.json`:
  `workers_dev` is a real top-level boolean, default `true`.
- `workers.dev` confirmed on the Public Suffix List, which is what makes the
  blast-radius claim above true rather than assumed.
- Not verified, and deliberately so: that `wrangler deploy` now succeeds. No
  custom domain is attached yet, so the deploy is the next step rather than
  evidence for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq


