### PR TITLE
Set SERVING_HOST and API_HOST to the real domains

### DIFF
--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -5,7 +5,11 @@ import type { DocRow } from "../src/db.js";
 import { docObjectPrefix, versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
-/** v0 runs both surfaces on one workers.dev subdomain. */
+/**
+ * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
+ * router fall back to path prefixes. Deliberately not a real deployment host:
+ * these tests are about the surfaces, not about which domain carries them.
+ */
 const API_ORIGIN = "https://symposium.workers.dev";
 
 const KEY_A = "cplus_live_a1b2c3d4e5f60718";

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -10,7 +10,11 @@ import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
-/** v0 runs both surfaces on one workers.dev subdomain. */
+/**
+ * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
+ * router fall back to path prefixes. Deliberately not a real deployment host:
+ * these tests are about the surfaces, not about which domain carries them.
+ */
 const API_ORIGIN = "https://symposium.workers.dev";
 
 const KEY_A = "cplus_live_a1b2c3d4e5f60718";
@@ -131,7 +135,13 @@ describe("POST /api/v1/docs", () => {
     const article = `<p>${"content ".repeat(26_000)}</p>`;
     expect(article.length).toBeGreaterThan(200 * 1024);
 
-    const body = await pushedOk(await post(KEY_A, { title: "A note", html: page(article) }), 201);
+    // `SERVING_HOST: ""` pins the request-host fallback instead of inheriting
+    // whatever wrangler.jsonc configures. This test is about the stored bytes;
+    // which host the url names is D3's job, below.
+    const body = await pushedOk(
+      await post(KEY_A, { title: "A note", html: page(article) }, { SERVING_HOST: "" }),
+      201,
+    );
 
     expect(isDocId(body.docId)).toBe(true);
     expect(body).toEqual({

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -5,7 +5,11 @@ import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
-/** v0 runs both surfaces on one workers.dev subdomain. */
+/**
+ * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
+ * router fall back to path prefixes. Deliberately not a real deployment host:
+ * these tests are about the surfaces, not about which domain carries them.
+ */
 const ORIGIN = "https://symposium.workers.dev";
 
 const KEY = "cplus_live_a1b2c3d4e5f60718";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,13 +31,23 @@
   // which is that the Worker has no hostname until a custom domain is attached.
   "workers_dev": false,
 
-  // Empty until the custom domains are attached, which is what makes the path
-  // prefixes (/api/v1 vs /d) the only routing until then. Filling these in
-  // splits the API onto the brand domain and doc serving onto the sacrificial
-  // domain without a code change — serving of user content never goes on the
-  // brand domain (see docs/cost-at-scale.md §6).
+  // The surface split. Documents serve from the sacrificial domain, the API
+  // from the brand one, and `resolveSurface` decides by host — so /api/v1 is
+  // unreachable on symposium.site rather than merely unadvertised (see
+  // docs/serving-domain.md, docs/cost-at-scale.md §6).
+  //
+  // Both together or neither. The router falls back to path prefixes while
+  // *either* is empty, which would leave /api/v1 answering on the sacrificial
+  // domain and defeat the split.
+  //
+  // These must be deployed BEFORE the custom domains are attached. Attaching
+  // first binds the real domains to a version that still has them empty, and
+  // for the length of that deploy the fallback serves /d/* on the API host and
+  // /api/v1/* on the serving host — the split inverted, on the first requests
+  // those domains ever take. With workers_dev false this deploy is reachable on
+  // nothing, so going first costs nothing.
   "vars": {
-    "SERVING_HOST": "",
-    "API_HOST": ""
+    "SERVING_HOST": "symposium.site",
+    "API_HOST": "api.symposium.md"
   }
 }


### PR DESCRIPTION
Fixes #14

## Problem

`SERVING_HOST` and `API_HOST` are still empty, so `resolveSurface`
(`src/index.ts:58`) tells the two surfaces apart by url path instead of by host.
`/api/v1` would answer on the sacrificial domain, which is the thing
`docs/serving-domain.md` exists to prevent.

Blocks the phase 1 deploy: both zones are delegated and the Worker is live with
`workers_dev: false`, so it currently answers on no hostname at all.

## Fix

Documents from `symposium.site`, API from `api.symposium.md`. Both together —
the router falls back to path prefixes while *either* is empty.

This deploy must go out **before** the custom domains are attached. Attaching
first binds the real domains to a version whose vars are still empty, and for
the length of that deploy the fallback serves `/d/*` on the API host and
`/api/v1/*` on the serving host: the split inverted, on the very first requests
those domains take. With `workers_dev` false, a deploy with no domain attached
is reachable on nothing, so going first costs nothing.

## Scope

Budget gate: PASS — 4 files, +39/−11. Two of those lines are the change; the
rest is one test that had to stop depending on deploy config, and three stale
comments the `workers.dev` removal left behind.

## Changes

- `dd9741a` — the two vars, plus:
  - `test/push.test.ts` — a **real failure**, not a cosmetic one. The test env
    inherits `vars` from `wrangler.jsonc`, so a test about *stored bytes* was
    quietly asserting that no serving host was configured; setting one broke it.
    It now pins `SERVING_HOST: ""` to exercise the request-host fallback on
    purpose. Which host the url names is already covered by the D3 test.
  - `test/manage.test.ts`, `test/serve.test.ts`, `test/push.test.ts` — the
    `v0 runs both surfaces on one workers.dev subdomain` comments went stale
    when that route was removed. They now say what the constant is for: a host
    matching neither var, which is what makes the fallback fire.

## Verification

- `npm test` — 209 passed across 8 files. `npm run typecheck` — clean.
- The failure above was observed before the fix and after it: `url` came back
  `https://symposium.site/...` where the test expected the request host.
- Not verified here: that the surfaces actually split in production. Nothing is
  reachable until the custom domains are attached, which is the next step and
  needs this deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq
