### PR TITLE
Attach symposium.site and api.symposium.md

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,21 @@
     "enabled": true
   },
 
+  // The two hostnames the Worker answers on, and the only ones — `workers_dev`
+  // is false. Declared here rather than clicked in the dashboard so the repo
+  // describes production: a custom domain created by hand is state nothing in
+  // this file knows about.
+  //
+  // `custom_domain` makes Cloudflare create and own the DNS record, which is
+  // why neither zone should carry a hand-made record for these names. They must
+  // match `vars` below exactly; the router compares the request host against
+  // those strings, so a name attached here but missing there would fall through
+  // to path prefixes and serve both surfaces on one domain.
+  "routes": [
+    { "pattern": "symposium.site", "custom_domain": true },
+    { "pattern": "api.symposium.md", "custom_domain": true }
+  ],
+
   // R2 is the system of record: every served byte lives here.
   "r2_buckets": [{ "binding": "DOCS", "bucket_name": "symposium-docs" }],
 


### PR DESCRIPTION
Fixes #16

## Problem

The Worker answers on no hostname. `workers_dev` is `false` (#13) and no custom
domain is attached, so `symposium` is deployed, bound to R2 and D1, and
unreachable. `SERVING_HOST` and `API_HOST` are already live on version
`aa1ead70`, so the running code knows which host means which surface — nothing
routes to it.

This is the last step before phase 1 is a live service.

## Fix

Declare both hostnames as `custom_domain` routes.

In `wrangler.jsonc` rather than the dashboard, because a custom domain created
by hand is state nothing in the repo knows about: the next person reading this
file would conclude the Worker is unreachable, and a rebuild from config alone
would produce a dead deployment.

The patterns match `vars` exactly. The router compares the request host against
those strings, so a name attached here but absent there falls through to path
prefixes and puts both surfaces on one domain — the failure `docs/serving-domain.md`
exists to prevent.

## Scope

Budget gate: PASS — 1 file, +15/−0. Two route entries and the comment recording
why they live in config and why they must track `vars`.

## Changes

- `1a9e8f5` — `routes` with `custom_domain: true` for `symposium.site` and
  `api.symposium.md`.

## Verification

- `wrangler deploy --dry-run` parses the config and resolves all four bindings.
- `npm run typecheck` clean; `npm test` 209 passed across 8 files. Run with
  `--exclude '**/.claude/**'`: an agent worktree under `.claude/worktrees/`
  otherwise gets scanned and inflates the count to 418 across 16 files.
- **Not verified, and cannot be before merge:** that the attach succeeds. The
  deploy is the action — it creates the DNS records and binds the domains — so
  there is no dry run for it. Both zones are confirmed delegated to Cloudflare
  (`casey`/`stephane` serving both, `.md` registry state `OK`), and neither
  carries a hand-made record at these names. If a zone is not yet Active,
  the deploy fails cleanly and is re-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq
