### PR TITLE
Prove delete pages R2 with three objects, not 1001

### DIFF
--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -35,6 +35,17 @@ const MAX_LIMIT = 100;
 /** R2 caps both a list page and a bulk delete at 1000 keys. */
 const OBJECT_BATCH = 1000;
 
+export interface DeleteDeps {
+  /**
+   * Keys per R2 listing page. Injected by tests so the loop below can be walked
+   * across pages with three objects rather than a thousand — what it has to
+   * prove is that delete keeps asking until the prefix is empty, and a thousand
+   * writes proved that no better while timing out on a slow machine. Production
+   * never sets it: R2's cap is the real number.
+   */
+  objectBatch?: number;
+}
+
 /**
  * Destroy every object under the doc's prefix.
  *
@@ -44,12 +55,12 @@ const OBJECT_BATCH = 1000;
  * can hold more than a page of versions — 100 pushes a day compounds — so this
  * pages rather than assuming one listing covers it.
  */
-async function deleteDocObjects(env: Env, docId: string): Promise<void> {
+async function deleteDocObjects(env: Env, docId: string, objectBatch: number): Promise<void> {
   const prefix = docObjectPrefix(docId);
   let cursor: string | undefined;
 
   do {
-    const listing = await env.DOCS.list({ prefix, limit: OBJECT_BATCH, cursor });
+    const listing = await env.DOCS.list({ prefix, limit: objectBatch, cursor });
     if (listing.objects.length > 0) {
       await env.DOCS.delete(listing.objects.map((object) => object.key));
     }
@@ -76,6 +87,7 @@ export async function deleteDoc(
   env: Env,
   publisher: Publisher,
   docId: string,
+  deps: DeleteDeps = {},
 ): Promise<Response> {
   // An id that cannot exist is answered without touching D1.
   if (!isDocId(docId)) return docNotFound(docId);
@@ -85,7 +97,7 @@ export async function deleteDoc(
   }
 
   try {
-    await deleteDocObjects(env, docId);
+    await deleteDocObjects(env, docId, deps.objectBatch ?? OBJECT_BATCH);
   } catch (error) {
     // Past this point the doc is withdrawn from every reader whatever R2 does,
     // so answering anything but 204 would be a lie in the direction that costs

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -1,5 +1,7 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
+import { deleteDoc } from "../src/api/manage.js";
+import type { Publisher } from "../src/auth.js";
 import type { Env } from "../src/config.js";
 import type { DocRow } from "../src/db.js";
 import { docObjectPrefix, versionObjectKey } from "../src/storage.js";
@@ -231,12 +233,17 @@ describe("DELETE /api/v1/docs/{docId}", () => {
     // 100 pushes a day compounds: a long-lived doc outgrows R2's 1000-key
     // listing page, and a delete that read only the first page would leave the
     // rest of the doc sitting in the bucket forever.
-    await Promise.all(
-      Array.from({ length: 1001 }, (_, i) => env.DOCS.put(versionObjectKey(docId, i + 1), "x")),
-    );
+    //
+    // Three objects over a page of two, not 1001 over a page of 1000: the
+    // listing truncates either way, which is the only condition the loop turns
+    // on. Called directly rather than over HTTP because the page size is the
+    // point here, and every other delete test covers the route.
+    for (let n = 1; n <= 3; n++) await env.DOCS.put(versionObjectKey(docId, n), "x");
 
-    expect((await del(KEY_A, docId)).status).toBe(204);
+    const publisher: Publisher = { id: publisherA, plan: "believer" };
+    const response = await deleteDoc(env, publisher, docId, { objectBatch: 2 });
 
+    expect(response.status).toBe(204);
     expect(await objectKeys(docId)).toEqual([]);
   });
 


### PR DESCRIPTION
Fixes #11

## Problem

`test/manage.test.ts` proves that deleting a doc destroys every stored version,
including the ones past R2's 1000-key listing page — the guarantee that a doc
pushed 100 times a day for a fortnight is fully withdrawn rather than mostly
withdrawn. It proved it by writing 1001 objects so R2 would truncate a listing,
then deleting and asserting the prefix was empty.

Writing 1001 objects is the slow part, and it is not the part under test. The
file's budget is 5000ms; on CI it took 6897ms and failed, while the same commit
runs the whole file in under a second on a laptop. What failed was the setup,
not `deleteDocObjects` — so unrelated PRs paid for a rerun on a test that was
measuring how fast the machine writes keys.

## Fix

`OBJECT_BATCH = 1000` at `src/api/manage.ts:36` hardcoded the R2 listing page
size, so the only way to make a listing truncate was to out-write it. It is now
injectable through a `DeleteDeps` parameter on `deleteDoc`, following the
`AuthDeps` seam in `src/auth.ts` that already injects `fetch`, `now` and
`store`. The test sets the page size to 2 and writes 3 objects.

The loop turns on one condition — `listing.truncated` — and 3-over-2 truncates
exactly as 1001-over-1000 does, so the guarantee is unchanged and the waiting is
gone. Production never passes the parameter and still uses R2's own 1000; no
deployed behavior changes, and nothing in the frozen `docs/http-api.md` is
touched.

Raising the 5s budget was the alternative and is the one the issue rules out: it
buys quiet until the next slow machine, and the number creeps each time. A fake
`env.DOCS` returning a short page would have been simpler still, but CLAUDE.md
forbids binding doubles outside deliberately broken ones — a page size is a
parameter, not a double, and the test still runs against real R2 via Miniflare.

## Scope

Budget gate: PASS — 2 files, +26/−7; the whole change is one optional parameter
threaded through an existing private function, with no new machinery, no new
production branch, and the production default unchanged.

## Changes

- `src/api/manage.ts` — adds `DeleteDeps { objectBatch? }`, threads it through
  `deleteDoc` into `deleteDocObjects`, defaulting to the existing
  `OBJECT_BATCH`.
- `test/manage.test.ts` — the pagination test writes 3 objects and calls
  `deleteDoc` directly with `{ objectBatch: 2 }`. Direct rather than over HTTP
  because the page size is the point; the other eleven delete tests in that
  describe still exercise the route end to end.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 209 passed across 8 files, matching the baseline on `main`.
- Timing, `npx vitest run test/manage.test.ts`, three runs each:
  before 897ms / 1055ms / 898ms, after 393ms / 368ms / 432ms. The pagination
  test itself was 511–530ms of that — over half the file — and now falls below
  vitest's slow-test threshold entirely. In the full-suite run the file went
  from 1258ms to 623ms.
- The test still fails if the loop stops paging: replacing
  `cursor = listing.truncated ? listing.cursor : undefined` with
  `cursor = undefined` turned exactly this test red —
  `expected [ Array(1) ] to deeply equal []`, the leftover third object — with
  the other 32 tests in the file still passing. The line was then restored and
  the suite re-run green.

Not verified: the issue's "ten CI runs with no rerun" criterion, which needs CI
runs this PR has not had yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq
