### PR TITLE
Shorten doc ids to 16 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ lists the ones that bind day to day.
 | [HTTP API](docs/http-api.md) | Every endpoint, in full. The frozen contract Obsidian Copilot is built against. |
 | [Hosting](docs/hosting.md) | How this runs on Cloudflare. **Start here if you know Vercel but not Workers.** |
 | [Serving domain](docs/serving-domain.md) | Why user content lives on `symposium.site` and never on the brand domain. |
+| [Private sharing](docs/private-sharing.md) | How reader identity works, and the phases from public links to agents. Designed, not built. |
 | [Deploying](docs/deploying.md) | Provisioning the resources and shipping. |
 | [Development](docs/development.md) | Running it locally, including the license-server workaround. |
 | [Comments](docs/comments.md) | Design sketch for the next step of the product. Not planned, not built. |

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -95,9 +95,10 @@ between pushes. Three ways out, and this is a real decision, not a detail:
 resource instead of parsing them out of the page.
 
 **Comments need reader identity, and there is none.** Reading currently requires
-nothing at all, and an anonymous reader cannot be attributed. Access control —
-phase 2 in [cost-at-scale.md](cost-at-scale.md) — is a hard prerequisite, not a
-parallel track, and it is the larger piece of work.
+nothing at all, and an anonymous reader cannot be attributed. Access control is a
+hard prerequisite, not a parallel track, and it is the larger piece of work.
+[private-sharing.md](private-sharing.md) is the design for it — comments are
+Phase 4 there, blocked on the OAuth reader identity in Phase 3.
 
 ## Open questions
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -78,14 +78,18 @@ Any other method or path under `/api/v1` is `404 not_found`.
 ```
 
 ```json
-{"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
- "url": "https://symposium.site/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+{"docId": "9f2k4mvq7t0xbz3n",
+ "url": "https://symposium.site/d/9f2k4mvq7t0xbz3n",
  "version": 1}
 ```
 
-A `docId` is 26 characters of lowercase Crockford base32 (`0-9`, `a-z` without
-`i`, `l`, `o`, `u`) — 128 bits of randomness. It is the only access control a doc
-has: whoever holds the url holds the doc.
+A `docId` is 16 characters of lowercase Crockford base32 (`0-9`, `a-z` without
+`i`, `l`, `o`, `u`) — 80 bits of randomness. It is the only access control a doc
+has: whoever holds the url holds the doc, so treat the id as a secret and do not
+log it anywhere a reader would not already be allowed.
+
+The alphabet is case-insensitive to read but not to send: ids are lowercase, and
+an uppercase one is rejected rather than folded.
 
 The API accepts **HTML only**. Copilot renders markdown locally, because that is
 the only way callouts, wikilinks and dataview output survive. There is no
@@ -99,8 +103,8 @@ that is present but blank is not a title, and becomes `Untitled` here exactly as
 it does on `POST`.
 
 ```json
-{"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
- "url": "https://symposium.site/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+{"docId": "9f2k4mvq7t0xbz3n",
+ "url": "https://symposium.site/d/9f2k4mvq7t0xbz3n",
  "version": 2}
 ```
 
@@ -142,9 +146,9 @@ Only the calling publisher's live docs, newest first by creation time.
 
 ```json
 {"docs": [
-   {"docId": "9f2k4mvq7t0xbz3ncrhs5wda1p",
+   {"docId": "9f2k4mvq7t0xbz3n",
     "title": "Q3 architecture review",
-    "url": "https://symposium.site/d/9f2k4mvq7t0xbz3ncrhs5wda1p",
+    "url": "https://symposium.site/d/9f2k4mvq7t0xbz3n",
     "version": 2,
     "updatedAt": 1785000000000}
  ],
@@ -252,7 +256,7 @@ re-sharing a note update the page instead of minting a second link.
 
 ```yaml
 ---
-symposium: 9f2k4mvq7t0xbz3ncrhs5wda1p
+symposium: 9f2k4mvq7t0xbz3n
 ---
 ```
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -152,7 +152,7 @@ Only the calling publisher's live docs, newest first by creation time.
     "version": 2,
     "updatedAt": 1785000000000}
  ],
- "cursor": "MTc4NTAwMDAwMDAwMC45ZjJrNG12cTd0MHhiejNuY3JoczV3ZGExcA"}
+ "cursor": "MTc4NTAwMDAwMDAwMC45ZjJrNG12cTd0MHhiejNu"}
 ```
 
 - `updatedAt` is epoch milliseconds — the last push, not the creation.

--- a/docs/private-sharing.md
+++ b/docs/private-sharing.md
@@ -1,0 +1,165 @@
+# Private sharing and reader identity
+
+**Status: designed, not built.** Nothing here exists in code. It is written down
+because two of the decisions are not retrofittable — the same reason
+[serving-domain.md](serving-domain.md) exists — and because
+[comments.md](comments.md) has a hard dependency on the identity half of it.
+
+[← README](../README.md) · [Serving domain](serving-domain.md) · [Comments](comments.md) · [Positioning](positioning.md)
+
+## The constraint everything else follows from
+
+Today a doc's url *is* its access control. There are no readers, no accounts, no
+permissions. That is also what makes the security argument in `src/serve.ts`
+work, and it says so out loud:
+
+> the origin is cookieless and holds nothing but already-public docs, so there is
+> no session or private data on it to steal
+
+That sentence is what buys `'unsafe-inline'`, `'unsafe-eval'` and an open
+`connect-src` — the policy that lets uploaded documents run charts, simulations
+and Pyodide. Private sharing falsifies both halves of it at once.
+
+**So the obvious implementation is the one that must not be built.** Put a
+session cookie on `symposium.site` and any uploaded document's JavaScript can
+issue same-origin `fetch()` calls carrying that session. `HttpOnly` does not
+help: it stops a script *reading* the cookie, not *using* it. One hostile
+document would read every private document its reader can reach and post the
+contents anywhere, because `connect-src` is deliberately open and nothing can
+close it while scripts run at all.
+
+Cookies on the serving origin mean choosing between private sharing and
+interactive documents. Both are load-bearing.
+
+## The shape: identity never touches the serving origin
+
+`symposium.site` stays cookieless forever. Identity lives on the brand domain,
+and access is granted **per document** rather than ambiently.
+
+```
+reader → symposium.site/d/{id}      private, no grant → 302
+       → symposium.md  sign in       OAuth, session lives here
+       → API checks the ACL          mints a short-lived signed grant
+       → symposium.site/d/{id}?…     signature verified, bytes served
+```
+
+The property that saves the CSP: **a document's scripts can read their own
+grant, but cannot forge one for a document they were not given.** Same-origin
+stops being a skeleton key, because there is no ambient authority to borrow.
+
+Two questions this leaves, both worth deciding before code:
+
+**Grant transport.** A query signature is simplest and leaks into referrers,
+logs and shared screenshots — though `Referrer-Policy: no-referrer` is already
+set. A path-scoped `HttpOnly` cookie (`Path=/d/{docId}`) is not sent to another
+document's path, which restores most of the isolation, but cookie scoping is a
+weaker fence than a signature and puts state back on the origin we promised to
+keep clean. Prefer the signature.
+
+**Per-document origins.** Serving each doc from `{docId}.symposium.site` on a
+wildcard certificate makes the browser's own origin boundary do the isolating,
+which is how `googleusercontent.com` works. It is strictly stronger than
+signatures and strictly more moving parts. **This is the retrofit hazard**: it
+changes every url the product has ever issued, so it is nearly free to adopt
+before there are readers and effectively impossible after. Decide it at Phase 2,
+not later.
+
+## What it costs elsewhere
+
+**Caching, and therefore the cost model.** A private document cannot sit in a
+shared edge cache. Either `no-store`, or the cache key includes the grant — and
+then every reader is a miss. [cost-at-scale.md](cost-at-scale.md) argues serving
+is nearly free *because* reads are cacheable; that argument holds for public docs
+and fails for private ones. Private sharing is structurally more expensive per
+read, which is an argument for it being the paid tier rather than an obstacle
+to it.
+
+**The frozen contract.** Two sentences in [http-api.md](http-api.md) stop being
+true: *"Reading a doc requires nothing"* and *"Serving responses never set a
+cookie."* This is the first change that genuinely requires a client release.
+
+**Unshare gets better.** Today delete cannot recall a copy already fetched. With
+expiring grants, access actually lapses, which is much closer to what people
+assume "unshare" means.
+
+## Phases
+
+Each phase ships something usable on its own. The ordering is forced by
+dependencies, not preference.
+
+### Phase 1 — public links *(shipped)*
+
+The url is the capability. 80 bits of entropy, `noindex`, no reader identity.
+Publishing gated to lifetime license holders.
+
+### Phase 2 — privacy without accounts
+
+The cheapest thing that answers "can I share this with only some people".
+
+- **Expiring links.** A grant with a lifetime, signed by the Worker. No reader
+  identity, no database work beyond a key.
+- **Password on a document.** Publisher sets one; readers exchange it for a
+  grant on the brand domain. Still no accounts.
+
+Both are days of work and cover most of what people mean by "private". Neither
+tells you *who* read it, which is exactly why they do not unblock comments.
+
+**Decide per-document origins here.** After this phase there are private urls in
+circulation and changing their shape breaks them.
+
+### Phase 3 — reader identity
+
+The large one, and the prerequisite for everything after.
+
+- OAuth sign-in on `symposium.md` — Google and GitHub cover nearly everyone
+  without our storing a password. The session lives on the brand domain only.
+- A `readers` table, and an ACL per document: named readers, or a domain rule
+  ("anyone at acme.com"), or public. Public stays the default.
+- Grants become per-reader and short-lived, minted after the ACL check.
+- The list endpoint learns who a document is shared with.
+
+This is where "who read it" becomes answerable, and where the product stops
+being a link and starts being a place.
+
+### Phase 4 — comments
+
+[comments.md](comments.md) is the design; it is blocked on Phase 3 and says so.
+Every utterance needs attribution, and an anonymous reader cannot be attributed.
+
+Threads anchor to quotes rather than offsets, so they survive the next push.
+Where threads render is the open question that decides whether the cheap-serving
+story survives — see that document.
+
+### Phase 5 — agents as first-class participants
+
+The end state, and the reason the product exists: humans and agents converge on
+one artifact instead of pasting it between tools.
+
+Agents authenticate too, and **delegated identity is already in the comments
+schema**: every comment carries `author` and a nullable `on_behalf_of`. That one
+column is the whole feature — a human wrote this, or an agent proposed it and a
+human let it through.
+
+- An agent gets a token scoped to one publisher and one document, issued by the
+  human it acts for. Not a license key, not a shared secret: something
+  revocable, attributable, and narrow.
+- Agent-authored comments start `pending` and become visible on approval.
+  Approval must batch, or the friction removed from writing comes back as
+  moderation — the batching shape is an open question in `comments.md`.
+- Agents read one predictable threads resource rather than parsing the page,
+  which also settles the question [positioning.md](positioning.md) ends on.
+
+The scoping matters more here than for humans. A human's session is bounded by
+their attention; an agent's is bounded only by its token, so the token has to be
+the fence.
+
+## What is not decided
+
+- Grant transport: signature versus path-scoped cookie. Leaning signature.
+- Per-document origins. Nearly free before Phase 2 ships, effectively impossible
+  after.
+- Whether Phase 2 ships at all, or whether privacy waits for real identity.
+  Shipping it first buys time; it also puts urls in circulation whose shape
+  Phase 3 may want to change.
+- How an agent token is issued and revoked, and whether it is per-document or
+  per-publisher.

--- a/docs/private-sharing.md
+++ b/docs/private-sharing.md
@@ -43,26 +43,50 @@ reader → symposium.site/d/{id}      private, no grant → 302
        → symposium.site/d/{id}?…     signature verified, bytes served
 ```
 
-The property that saves the CSP: **a document's scripts can read their own
-grant, but cannot forge one for a document they were not given.** Same-origin
-stops being a skeleton key, because there is no ambient authority to borrow.
+Grants remove *ambient* authority: a document's scripts cannot forge a grant for
+a document they were not given. That is necessary and it is not sufficient.
 
-Two questions this leaves, both worth deciding before code:
+### Grants alone do not fix a shared origin
 
-**Grant transport.** A query signature is simplest and leaks into referrers,
-logs and shared screenshots — though `Referrer-Policy: no-referrer` is already
-set. A path-scoped `HttpOnly` cookie (`Path=/d/{docId}`) is not sent to another
-document's path, which restores most of the isolation, but cookie scoping is a
-weaker fence than a signature and puts state back on the origin we promised to
-keep clean. Prefer the signature.
+A hostile public document can steal a grant somebody else legitimately obtained:
 
-**Per-document origins.** Serving each doc from `{docId}.symposium.site` on a
-wildcard certificate makes the browser's own origin boundary do the isolating,
-which is how `googleusercontent.com` works. It is strictly stronger than
-signatures and strictly more moving parts. **This is the retrofit hazard**: it
-changes every url the product has ever issued, so it is nearly free to adopt
-before there are readers and effectively impossible after. Decide it at Phase 2,
-not later.
+1. It calls `window.open('/d/{targetId}')` and keeps the opener reference.
+2. The popup bounces to `symposium.md`, where the reader signs in — or types the
+   document's password — and comes back with a grant.
+3. Back on `symposium.site`, opener and popup are same-origin **again**, because
+   the same-origin check is evaluated per access rather than pinned at open
+   time. The opener reads `popup.location.href`, which contains the signature,
+   and `popup.document`, which contains the document.
+
+Nothing already in place stops this. `frame-ancestors 'none'` governs framing,
+not popups. `Referrer-Policy: no-referrer` is irrelevant. `noopener` is the
+*opener's* choice and a hostile opener will not make it.
+`Cross-Origin-Opener-Policy: same-origin` severs cross-origin openers and leaves
+same-origin ones intact, which is exactly the case here.
+
+**So origin isolation is a prerequisite for private documents, not an
+enhancement.** Serve each document from its own origin — `{docId}.symposium.site`
+on a wildcard certificate, the way `googleusercontent.com` works — or from an
+equivalently isolated browsing context. Then `window.open` on another document's
+id crosses an origin boundary and the opener can read nothing.
+
+Two things follow, and both are ordering constraints rather than preferences:
+
+**It must ship with the first grant, not after it.** An expiring link and a
+password-protected document are both grants, so the theft above works against
+Phase 2 exactly as it works against Phase 3. Shipping privacy on a shared origin
+first would put grant-bearing urls in circulation before the fence exists.
+
+**It changes every url the product has ever issued.** Nearly free while every
+document is public and links are disposable; effectively impossible once readers
+hold private ones. This is the retrofit hazard, the same shape as the serving
+domain split itself.
+
+**Grant transport**, once origins are isolated, is the smaller question. A query
+signature is simplest and leaks into logs and shared screenshots — though
+`Referrer-Policy: no-referrer` is already set. A `HttpOnly` cookie scoped to the
+document's own origin is cleaner but puts state back on a serving origin we
+promised to keep clean. Prefer the signature.
 
 ## What it costs elsewhere
 
@@ -104,8 +128,9 @@ The cheapest thing that answers "can I share this with only some people".
 Both are days of work and cover most of what people mean by "private". Neither
 tells you *who* read it, which is exactly why they do not unblock comments.
 
-**Decide per-document origins here.** After this phase there are private urls in
-circulation and changing their shape breaks them.
+**Origin isolation ships with this phase, not after it.** An expiring link is a
+grant, so the `window.open` theft above applies from the first private document
+onwards. Once private urls are in circulation, changing their shape breaks them.
 
 ### Phase 3 — reader identity
 
@@ -155,9 +180,11 @@ the fence.
 
 ## What is not decided
 
-- Grant transport: signature versus path-scoped cookie. Leaning signature.
-- Per-document origins. Nearly free before Phase 2 ships, effectively impossible
-  after.
+- Grant transport: signature versus a cookie scoped to the document's own
+  origin. Leaning signature.
+- The exact isolation mechanism — per-document subdomains on a wildcard
+  certificate, or a sandboxed opaque origin. *Whether* to isolate is settled;
+  the mechanism is not.
 - Whether Phase 2 ships at all, or whether privacy waits for real identity.
   Shipping it first buys time; it also puts urls in circulation whose shape
   Phase 3 may want to change.

--- a/docs/private-sharing.md
+++ b/docs/private-sharing.md
@@ -65,10 +65,34 @@ not popups. `Referrer-Policy: no-referrer` is irrelevant. `noopener` is the
 same-origin ones intact, which is exactly the case here.
 
 **So origin isolation is a prerequisite for private documents, not an
-enhancement.** Serve each document from its own origin — `{docId}.symposium.site`
-on a wildcard certificate, the way `googleusercontent.com` works — or from an
-equivalently isolated browsing context. Then `window.open` on another document's
-id crosses an origin boundary and the opener can read nothing.
+enhancement.** Each document needs its own origin — a wildcard certificate over
+per-document subdomains, the way `googleusercontent.com` works, or an
+equivalently isolated browsing context. Then `window.open` on another document
+crosses an origin boundary and the opener can read nothing.
+
+### The origin label must not be the capability
+
+The obvious form of that — `{docId}.symposium.site` — trades one leak for
+another. A hostname is not confidential: it appears in the DNS query, and absent
+Encrypted Client Hello it appears in the TLS SNI, both before any encryption. A
+recursive resolver, a corporate DNS server, or anything on the network path
+would learn the id — and the id is the only access control a doc has. The
+observer could just fetch it.
+
+Today's scheme does not have this problem, because the id lives in the request
+path, which is encrypted, and every document shares one hostname.
+
+So the two jobs need two identifiers:
+
+| | secret? | job |
+| --- | --- | --- |
+| origin label | no | isolates browsing contexts |
+| doc id, and any grant | yes | authorises the read, stays in the encrypted path |
+
+`{originLabel}.symposium.site/d/{docId}` gives isolation without exposure. The
+label being enumerable is harmless: reaching the origin without the path id and
+the grant gets you nothing. ECH would close the SNI half of the leak but not the
+DNS half, so it is not a substitute for separating the two.
 
 Two things follow, and both are ordering constraints rather than preferences:
 
@@ -184,7 +208,12 @@ the fence.
   origin. Leaning signature.
 - The exact isolation mechanism — per-document subdomains on a wildcard
   certificate, or a sandboxed opaque origin. *Whether* to isolate is settled;
-  the mechanism is not.
+  the mechanism is not. Whichever is chosen, the origin label is not the
+  capability.
+- Where the origin label comes from: a second stored identifier, or something
+  derived from the doc id by a one-way function so it need not be stored. The
+  second is tempting and has to survive the observation that anyone can compute
+  the label from an id they already hold — which is fine — but not the reverse.
 - Whether Phase 2 ships at all, or whether privacy waits for real identity.
   Shipping it first buys time; it also puts urls in circulation whose shape
   Phase 3 may want to change.

--- a/docs/serving-domain.md
+++ b/docs/serving-domain.md
@@ -99,3 +99,12 @@ Three things become true together when the real domains land, and
 3. **Purge on delete, in the same change.** Once there is an edge cache, an
    unshared doc keeps being served from it. Shipping caching without purging is
    how a withdrawn document stays readable.
+
+## What changes when reading stops being anonymous
+
+The argument above rests on the serving origin being cookieless, which is also
+what lets uploaded documents run scripts. Private sharing breaks that, and the
+way out is to keep identity on the brand domain and grant access per document
+rather than by session — including a per-document-origin option that is nearly
+free to adopt now and effectively impossible later.
+[private-sharing.md](private-sharing.md) has the reasoning and the phases.

--- a/docs/serving-domain.md
+++ b/docs/serving-domain.md
@@ -105,6 +105,9 @@ Three things become true together when the real domains land, and
 The argument above rests on the serving origin being cookieless, which is also
 what lets uploaded documents run scripts. Private sharing breaks that, and the
 way out is to keep identity on the brand domain and grant access per document
-rather than by session — including a per-document-origin option that is nearly
-free to adopt now and effectively impossible later.
+rather than by session — and that is not sufficient on its own. A hostile public
+document can `window.open` a private one and read the grant off the popup once it
+returns to this origin, so isolating documents from each other is a prerequisite,
+not an enhancement. It is nearly free to adopt now and effectively impossible
+once readers hold private links.
 [private-sharing.md](private-sharing.md) has the reasoning and the phases.

--- a/src/db.ts
+++ b/src/db.ts
@@ -305,7 +305,7 @@ export interface ServableVersion {
  *
  * Liveness is *not* a predicate here: a deleted doc must still be found, so the
  * caller can tell 410 from 404. That distinction is the one thing this query
- * exists to preserve, and it is safe to expose because a doc id is 128 random
+ * exists to preserve, and it is safe to expose because a doc id is 80 random
  * bits — knowing one already means having been given the link.
  */
 export async function findServableVersion(

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -1,18 +1,32 @@
 /**
- * Doc ids: 128 bits of CSPRNG entropy in lowercase Crockford base32.
+ * Doc ids: 80 bits of CSPRNG entropy in lowercase Crockford base32.
  *
  * The id is the only thing standing between a public url and the doc behind it,
- * so it has to be unguessable — 128 bits, never a counter or a hash of anything
- * the publisher controls. Crockford's alphabet drops i/l/o/u, which keeps the id
+ * so it has to be unguessable — never a counter, never a hash of anything the
+ * publisher controls. Crockford's alphabet drops i/l/o/u, which keeps the id
  * url-safe, case-insensitively unambiguous, and safe to read aloud.
+ *
+ * 80 bits, not 128. The threat is someone enumerating urls to find a doc they
+ * were not given, and at a million docs and a sustained 10,000 guesses a second
+ * — far above what the edge would pass — that is a few million years for one
+ * hit. 128 bits bought another 10^15 of margin nobody needs and cost ten
+ * characters of every shared link.
+ *
+ * Not base64: it packs 6 bits per character rather than 5, so the same id would
+ * be 14 characters instead of 16, but it is case-sensitive. An id that changes
+ * meaning when someone types it with a stray capital is a permanent support
+ * cost, and being safe to read aloud is why this alphabet was chosen.
+ *
+ * 10 bytes is 80 bits is exactly 16 groups of 5, so every character carries
+ * data and none is a zero-padded remainder.
  */
 const ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
 
 /** Bytes of entropy per id. */
-export const DOC_ID_BYTES = 16;
+export const DOC_ID_BYTES = 10;
 
-/** ceil(128 / 5) — 25 full characters, then one carrying the last 3 bits. */
-export const DOC_ID_LENGTH = 26;
+/** 80 / 5 — exact, so there is no partial trailing character. */
+export const DOC_ID_LENGTH = 16;
 
 const DOC_ID_PATTERN = new RegExp(`^[${ALPHABET}]{${DOC_ID_LENGTH}}$`);
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -179,8 +179,10 @@ export function servingError(code: "not_found" | "gone" | "internal", message: s
 
 /**
  * One message for "no such id", "malformed id" and "no such version" alike. The
- * id space is not worth probing at 128 bits, but a reply that distinguished the
- * cases would still be telling a stranger which ids are real.
+ * id space is not worth probing at 80 bits, but a reply that distinguished the
+ * cases would still be telling a stranger which ids are real — and that matters
+ * more now the space is smaller, since an oracle is worth more to an enumerator
+ * than the raw arithmetic suggests.
  */
 function noDocAt(pathname: string): Response {
   return servingError("not_found", `No doc at ${pathname}`);

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -10,7 +10,11 @@ import {
 } from "../src/auth.js";
 import { LICENSE_CACHE_TTL_MS, type Env } from "../src/config.js";
 import type { PublisherRow, PublisherStore } from "../src/db.js";
+import { DOC_ID_LENGTH } from "../src/ids.js";
 import worker from "../src/index.js";
+
+/** Shape-valid, never in the database. Derived so a length change cannot strand it. */
+const VALID_DOC_ID = "0123456789abcdefghjkmnpqrstvwxyz".repeat(2).slice(0, DOC_ID_LENGTH);
 
 /** A plausible Copilot Plus key. Distinctive so leak assertions mean something. */
 const KEY = "cplus_live_9f4c1a77e0b24d3e";
@@ -376,7 +380,7 @@ describe("the gate is on publishing, not on the publisher", () => {
   it("401s POST and PUT for a plan that may not publish", async () => {
     for (const [method, path] of [
       ["POST", "/docs"],
-      ["PUT", "/docs/9f2k4mvq7t0xbz3ncrhs5wda1p"],
+      ["PUT", `/docs/${VALID_DOC_ID}`],
     ] as const) {
       const res = await call(method, path, seeded("plus"));
 

--- a/test/ids.test.ts
+++ b/test/ids.test.ts
@@ -19,14 +19,21 @@ describe("encodeBase32", () => {
     expect(seen.size).toBe(256);
   });
 
-  it("pads the trailing partial group with zero bits, not characters", () => {
-    // 16 bytes = 128 bits = 25 full groups of 5 bits, then 3 bits left over
-    // that get zero-padded out to a 26th character.
+  it("emits no padding character", () => {
+    // 10 bytes = 80 bits = exactly 16 groups of 5, so an id has no trailing
+    // partial group at all. The zero-padding branch still exists for other
+    // lengths and is covered below.
     expect(encodeBase32(new Uint8Array(DOC_ID_BYTES))).toHaveLength(DOC_ID_LENGTH);
     expect(encodeBase32(new Uint8Array(DOC_ID_BYTES))).not.toContain("=");
   });
 
-  it("carries all 128 bits — flipping any single bit changes the id", () => {
+  it("pads a trailing partial group with zero bits, not characters", () => {
+    // One byte is 8 bits: one full group of 5, then 3 bits zero-padded into a
+    // second character. Kept because DOC_ID_BYTES no longer exercises it.
+    expect(encodeBase32(new Uint8Array([0xff]))).toBe("zw");
+  });
+
+  it("carries all 80 bits — flipping any single bit changes the id", () => {
     // The encoder shifts a 32-bit accumulator, so a bit dropped off the top
     // would silently collapse distinct inputs onto one id and shrink the
     // guessing space well below 2^128.
@@ -43,7 +50,7 @@ describe("encodeBase32", () => {
 describe("newDocId", () => {
   const ids = Array.from({ length: 1000 }, newDocId);
 
-  it("is 26 lowercase Crockford base32 characters", () => {
+  it("is 16 lowercase Crockford base32 characters", () => {
     for (const id of ids) {
       expect(id).toHaveLength(DOC_ID_LENGTH);
       expect(id).toMatch(CROCKFORD);
@@ -66,8 +73,8 @@ describe("newDocId", () => {
   });
 
   it("spends its full entropy budget rather than a fixed prefix", () => {
-    // Every one of the 26 characters carries data — the last one 3 bits — so a
-    // sequential or constant-seeded id would leave some position never varying.
+    // Every one of the 16 characters carries a full 5 bits, so a sequential or
+    // constant-seeded id would leave some position never varying.
     for (let i = 0; i < DOC_ID_LENGTH; i++) {
       const distinct = new Set(ids.map((id) => id[i]));
       expect(distinct.size).toBeGreaterThan(1);

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -17,7 +17,13 @@ const KEY_A = "cplus_live_a1b2c3d4e5f60718";
 const KEY_B = "cplus_live_9988776655443322";
 
 /** A doc id of the right shape that no push ever minted. */
-const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrs";
+/**
+ * A well-formed id that is not in the database. Derived from DOC_ID_LENGTH, not
+ * written out: a literal of the wrong length is rejected by `isDocId` on shape
+ * before D1 is consulted, which silently turns every "not found" test into a
+ * test of the shape check.
+ */
+const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrstvwxyz".repeat(2).slice(0, DOC_ID_LENGTH);
 
 async function sha256Hex(value: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -2,6 +2,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
 import type { DocRow } from "../src/db.js";
+import { DOC_ID_LENGTH } from "../src/ids.js";
 import { docObjectPrefix, versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
@@ -168,7 +169,7 @@ async function seedDoc(
 }
 
 /** Valid doc ids that sort predictably, so a paging test can name what it expects. */
-const seededId = (i: number) => String(i).padStart(26, "0");
+const seededId = (i: number) => String(i).padStart(DOC_ID_LENGTH, "0");
 
 /** Every docId the list yields when walked to the end, in order. */
 async function walk(key: string, limit: number): Promise<string[]> {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -4,7 +4,7 @@ import type { Env } from "../src/config.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../src/config.js";
 import { commitVersionMetadata } from "../src/db.js";
 import type { DocRow, PushQuotaRow, VersionRow } from "../src/db.js";
-import { isDocId } from "../src/ids.js";
+import { DOC_ID_LENGTH, isDocId } from "../src/ids.js";
 import { MAX_REQUEST_BYTES, utcDay, utf8Length } from "../src/quota.js";
 import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
@@ -123,10 +123,10 @@ async function seedDocs(publisher: string, live: number, deleted = 0): Promise<v
   await env.DB.prepare(
     `WITH RECURSIVE seq(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < ?)
      INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at, deleted_at)
-     SELECT printf('%026d', i), ?, 'seeded', 1, ?, ?, CASE WHEN i > ? THEN ? END
+     SELECT printf('%0' || ? || 'd', i), ?, 'seeded', 1, ?, ?, CASE WHEN i > ? THEN ? END
        FROM seq`,
   )
-    .bind(live + deleted, publisher, now, now, live, now)
+    .bind(live + deleted, DOC_ID_LENGTH, publisher, now, now, live, now)
     .run();
 }
 

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -17,6 +17,14 @@ import worker from "../src/index.js";
  */
 const API_ORIGIN = "https://symposium.workers.dev";
 
+/**
+ * A well-formed id that is not in the database. Derived from DOC_ID_LENGTH, not
+ * written out: a literal of the wrong length is rejected by `isDocId` on shape
+ * before D1 is consulted, which silently turns every "not found" test into a
+ * test of the shape check.
+ */
+const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrstvwxyz".repeat(2).slice(0, DOC_ID_LENGTH);
+
 const KEY_A = "cplus_live_a1b2c3d4e5f60718";
 const KEY_B = "cplus_live_9988776655443322";
 
@@ -276,7 +284,7 @@ describe("PUT /api/v1/docs/{docId}", () => {
   });
 
   it("404s a doc that does not exist", async () => {
-    const response = await put(KEY_A, "0123456789abcdefghjkmnpqrs", { html: page("<p>x</p>") });
+    const response = await put(KEY_A, UNKNOWN_DOC_ID, { html: page("<p>x</p>") });
 
     expect(response.status).toBe(404);
     expect(await allObjects()).toHaveLength(0);

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -1,6 +1,7 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
+import { DOC_ID_LENGTH } from "../src/ids.js";
 import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
@@ -15,7 +16,13 @@ const ORIGIN = "https://symposium.workers.dev";
 const KEY = "cplus_live_a1b2c3d4e5f60718";
 
 /** A doc id of the right shape that no push ever minted. */
-const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrs";
+/**
+ * A well-formed id that is not in the database. Derived from DOC_ID_LENGTH, not
+ * written out: a literal of the wrong length is rejected by `isDocId` on shape
+ * before D1 is consulted, which silently turns every "not found" test into a
+ * test of the shape check.
+ */
+const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrstvwxyz".repeat(2).slice(0, DOC_ID_LENGTH);
 
 async function sha256Hex(value: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));


### PR DESCRIPTION
Fixes #19

## Problem

Doc ids carry 128 bits, which is 26 characters of Crockford base32 and makes
every shared link 43 characters:
`https://symposium.site/d/xeajh8m0xnc8pyjj5ct07dd5zw`.

The id is the only access control a doc has, so it must resist enumeration. But
128 bits is far past what that needs. At a million docs and a sustained 10,000
guesses per second — well above what the edge would pass — the numbers are:

| chars | bits | time to find one doc @1M docs |
| --- | --- | --- |
| 26 (today) | 130 | 4×10²¹ years |
| **16** | **80** | **3.8 million years** |
| 13 | 65 | 117 years |

The extra 48 bits buy margin nobody will use and cost ten characters of every
link a person reads, types, or says aloud.

## Fix

16 characters, 80 bits.

**Stayed on Crockford base32 rather than base64url**, which would have given 14
characters instead of 16 — that is how YouTube fits 64 bits into 11. base64 is
case-sensitive, so an id changes meaning when someone types it with a stray
capital. Being safe to read aloud is why this alphabet was chosen; two
characters is not worth losing it.

10 bytes is 80 bits is exactly 16 groups of 5, so unlike the old size there is
no zero-padded trailing character.

## Scope

Budget gate: PASS — 13 files, +326/−38.

Two unrelated changes, bundled at the author's request rather than because they
belong together. Reviewing them separately is reasonable:

- **The id change** — 9 files, +88/−35. Two constants; the rest is the contract
  text, comments quoting the old bit count, and test seeds with the old length
  baked in as a literal.
- **The design doc** — 4 files, +238/−3. `docs/private-sharing.md` plus links
  from the README, `comments.md` and `serving-domain.md`. No code.

## Changes

- `92e231c` — `DOC_ID_BYTES` 16→10 and `DOC_ID_LENGTH` 26→16, with the reasoning
  and the rejected base64 alternative recorded at the top of `src/ids.ts`.
  - `docs/http-api.md` — the length, the bit count, and every example id.
  - `src/serve.ts` — a comment citing 128 bits for why `noDocAt` gives one
    message for all three not-found cases. Still true at 80, and it now says why
    the oracle matters *more* as the space shrinks.
  - `test/ids.test.ts` — the padding test split in two: an id no longer has a
    partial trailing group, so the encoder's zero-padding branch needs its own
    case (`0xff` → `zw`) rather than riding along.
  - `test/manage.test.ts`, `test/push.test.ts` — seeds padded to a literal 26,
    which silently produced ids the validator rejects. They derive from
    `DOC_ID_LENGTH` now, so the next size change cannot repeat it.

- `f64af0f` — `docs/private-sharing.md`. Unrelated to the id change; see Scope.
  The security argument in `src/serve.ts` for letting uploaded docs run scripts
  rests on the serving origin being cookieless and holding only public docs, and
  private sharing falsifies both. So the obvious implementation — a session
  cookie on `symposium.site` — is the one that must not be built: `HttpOnly`
  stops a script *reading* a cookie, not *using* it, and `connect-src` cannot be
  closed while scripts run at all. The doc lays out the alternative (identity on
  the brand domain, per-document signed grants), what it costs the cache and the
  cost model, and Phases 1–5 through to agents with delegated identity. Written
  now because per-document origins are not retrofittable — they change every url
  ever issued.

- `a9307fe` — three `UNKNOWN_DOC_ID` fixtures stayed 26 characters while the
  validator moved to 16, so requests built from them were rejected on shape
  before D1 was consulted. The tests still passed, which was the defect: they
  asserted the shape check instead of the paths they were written for. The
  versionless-doc case in `serve.test.ts` was worst — it inserts a row and
  asserts 404, and would have passed with the whole no-version branch deleted.
  Also `src/db.ts` still cited "128 random bits" in a security rationale.

## Verification

- `npm test` — 210 passed across 8 files (209 plus the new padding case).
  `npm run typecheck` — clean. Run with `--exclude '**/.claude/**'`; an agent
  worktree otherwise inflates the count.
- Observed the failure the seeds caused before fixing them: 8 tests in
  `manage.test.ts` red on 26-character seeded ids.
- Sample output: `https://symposium.site/d/v5627mqz1am2m1zx`.
- **Mutation-tested the fixture fix**, because "the tests pass" was true before
  it too. Breaking the D1 lookup in `findServableVersion` makes "404s a doc row
  with no version yet" fail; before `a9307fe` that test passed regardless.

## Notes

- **Deploy sequence, which is load-bearing.** Production runs the old validator
  until `wrangler deploy` completes, so a doc published in that window gets a
  26-character id and is stranded by the new one. Do not publish during the
  deploy — an answer that works only because the publisher population is one.
  1. `SELECT COUNT(*) FROM docs WHERE LENGTH(id) != 16 AND deleted_at IS NULL`
  2. deploy
  3. re-check, because step 1 does not prove step 3
  4. any straggler is deleted directly with wrangler, D1 row and R2 objects, since
     the API path is closed to it by then
- **Legacy documents must be deleted before this merges, and they have been.**
  `isDocId` gates `DELETE` and `PUT` before D1 (`src/api/manage.ts:81`,
  `src/api/push.ts:268`) while the list and the 500-doc ceiling read D1 rows
  directly, so a 26-character doc surviving this change would be undeletable
  while still holding a list entry, a quota slot and its R2 bytes — making the
  id change do the one thing `http-api.md` says must never happen: losing
  publish must not mean losing unshare. Production D1 held two legacy rows, one
  live; it was deleted through the normal endpoint, which destroys the R2
  objects too. `SELECT COUNT(*) FROM docs WHERE deleted_at IS NULL` is now `0`.
  Rejected a dual-format validator (a permanent wrinkle for a population that is
  now empty) and a cleanup migration (D1 cannot delete R2 objects, so it would
  orphan the bytes).
- The two remaining deleted rows keep their `410` only until this merges; after
  it their urls answer `404` on shape. Neither link was ever shared.
- **The already-published doc will 404 after this deploys.** `isDocId` gates on
  length before any database read. Exactly one doc exists; I will republish it
  and hand over the new url rather than teach the validator two formats forever.
- The frozen part of `docs/http-api.md` is untouched: no status code, error
  `code`, or field name changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq






