### PR TITLE
Deploy from CI and record what actually shipped

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,12 @@ jobs:
 
           if [ -n "$base" ] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
             echo "comparing migrations against last successful deploy ${base:0:8}"
-            git diff --name-only --diff-filter=MD "$base" HEAD -- migrations/ \
+            # --no-renames: rename detection is on by default, and a
+            # same-content move reports as a single `R` that this filter drops
+            # entirely. Decomposed into D + A, the old name shows up as the
+            # deletion it is — and the old name is the one `d1_migrations`
+            # knows.
+            git diff --no-renames --name-only --diff-filter=MD "$base" HEAD -- migrations/ \
               | xargs -r -n1 basename | sort > /tmp/changed.txt
             clash="$(comm -12 /tmp/changed.txt /tmp/applied.txt)"
             if [ -n "$clash" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,31 @@
-# This workflow cannot run until CLOUDFLARE_API_TOKEN exists as a repository
-# secret. Until then every deploy is still a manual `npx wrangler deploy`, and
-# the deployment records on the repo page go on describing whatever commit they
-# last described. See docs/deploying.md.
+# CLOUDFLARE_API_TOKEN is an *environment* secret on `production`, and that
+# environment's deployment branch policy allows only `main`. Neither is
+# optional. `workflow_dispatch` runs the workflow definition from the ref it is
+# given, so nothing written in this file can defend this file: a branch that
+# deletes the guard below and dispatches itself is refused only because the
+# branch policy blocks the job, and a branch that also deletes the
+# `environment:` block loses its only path to the token. See docs/deploying.md.
 
 name: Deploy
 
-# Only what changes the deployed Worker. A docs-only merge would otherwise
-# redeploy identical bytes and overwrite the recorded SHA with a commit that
-# changed nothing about production.
+# Everything that can change what is deployed, or change whether the gates below
+# pass. `test/**` and the tsconfig/vitest/package files are here even though they
+# never alter the Worker: a source change that fails Test, corrected by editing
+# only a test, would otherwise merge without deploying and leave the repo page
+# reporting an undeployed commit as live. A redundant redeploy of identical bytes
+# is the cheaper mistake. Docs and README stay out.
 on:
   push:
     branches: [main]
     paths:
       - "src/**"
+      - "test/**"
       - "migrations/**"
       - "wrangler.jsonc"
+      - "package.json"
       - "package-lock.json"
+      - "tsconfig.json"
+      - "vitest.config.ts"
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
@@ -34,9 +44,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    # Naming an environment is what creates the deployment record on the repo
-    # page and what lets a required reviewer gate the job. Configure the
-    # reviewer in Settings → Environments; without one this deploys on merge.
+    # Naming an environment does two things: it creates the deployment record on
+    # the repo page, and it is what makes the token reachable at all, since the
+    # secret lives on this environment rather than on the repository. The
+    # environment's branch policy is therefore also the deploy's access control.
     environment:
       name: production
       url: https://symposium.site
@@ -67,8 +78,12 @@ jobs:
           echo "::error::Refusing to deploy $REF. Production ships from main."
           exit 1
 
+      # Full history: the migration check below diffs against the push's base
+      # commit, which a shallow clone does not contain.
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -99,6 +114,7 @@ jobs:
       - name: Check migrations are applied
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
           npx wrangler d1 execute symposium --remote --json \
@@ -112,6 +128,26 @@ jobs:
             exit 1
           fi
           echo "all $(wc -l < /tmp/on-disk.txt | tr -d ' ') migration(s) applied"
+
+          # An applied migration is immutable. `d1_migrations` stores a name and
+          # a timestamp, no checksum, so editing a file already listed there
+          # passes the comparison above while the database never ran the new
+          # SQL, and code expecting the new schema ships against the old one.
+          # Names are all D1 can offer, so the evidence comes from git instead.
+          # A first push or a force push leaves no usable base: skip rather than
+          # fail, since a missing base is not evidence of an edit.
+          if [ -n "${BEFORE:-}" ] && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            git diff --name-only --diff-filter=M "$BEFORE" HEAD -- migrations/ \
+              | xargs -r -n1 basename | sort > /tmp/edited.txt
+            clash="$(comm -12 /tmp/edited.txt /tmp/applied.txt)"
+            if [ -n "$clash" ]; then
+              echo "::error::Edited a migration D1 has already applied. Add a new migration instead."
+              echo "$clash" | sed 's/^/  /'
+              exit 1
+            fi
+          else
+            echo "no base commit to diff against; skipping the edited-migration check"
+          fi
 
       # `--message` fills the Message column in the dashboard's Deployments
       # tab, which is otherwise a list of uuids and timestamps. It is what makes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,8 +41,11 @@ jobs:
       name: production
       url: https://symposium.site
 
+    # The token is deliberately NOT here. A job-level `env` hands the
+    # production credential to every step, including ones that only need to
+    # parse untrusted input, so it lives on the two steps that call Cloudflare
+    # and nowhere else. The account id is not a credential.
     env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: "960579f222ad237394703bd52f28114c"
 
     steps:
@@ -51,10 +54,17 @@ jobs:
       # so a wrong-branch dispatch never reaches the code. A job-level `if:`
       # would skip instead of fail, and a silent skip reads as a deploy that
       # worked.
+      #
+      # The ref goes through `env:` rather than `${{ }}` inside the script. A
+      # `${{ }}` expression is pasted into the script text before bash parses
+      # it, and git refs allow `$`, `(` and `)`, so a branch named
+      # `x$(...)` would execute rather than print. `"$REF"` is data.
       - name: Refuse to deploy anything but main
         if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
         run: |
-          echo "::error::Refusing to deploy ${{ github.ref }}. Production ships from main."
+          echo "::error::Refusing to deploy $REF. Production ships from main."
           exit 1
 
       - name: Check out repository
@@ -87,6 +97,8 @@ jobs:
       # matching wrangler's console wording, which would break silently the
       # next time that string changes.
       - name: Check migrations are applied
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail
           npx wrangler d1 execute symposium --remote --json \
@@ -111,6 +123,8 @@ jobs:
       # against the *previous* deployment, and the job would record a green
       # deploy for a commit that never shipped.
       - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           npx wrangler deploy \
             --message "$(git log -1 --format='%h %s' | cut -c1-100)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,13 +194,32 @@ jobs:
       # A deploy that reports success and serves nothing is the failure this
       # catches. Both hosts, because they are separate custom domains and one
       # can be attached while the other is not.
+      #
+      # Retried, because the deploy above is already irreversible: a single
+      # transient timeout would fail the job, skip the recording step, and leave
+      # the repo page naming the previous SHA while the new one serves — the
+      # drift this workflow exists to remove, caused by the check for it.
+      #
+      # A loop rather than `curl --retry`, which acts on curl-level transients
+      # and, absent `--fail`, does not treat an HTTP 502 as an error at all.
+      # The status code is what this step judges, so the retry belongs around
+      # the comparison.
       - name: Check both hosts answer
         run: |
           set -euo pipefail
           for host in api.symposium.md symposium.site; do
-            code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://$host/health")"
+            code=""
+            for attempt in 1 2 3 4 5; do
+              code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://$host/health" || echo 000)"
+              if [ "$code" = "200" ]; then break; fi
+              echo "$host → $code (attempt $attempt of 5)"
+              sleep 5
+            done
             echo "$host → $code"
-            [ "$code" = "200" ] || { echo "::error::$host answered $code"; exit 1; }
+            if [ "$code" != "200" ]; then
+              echo "::error::$host answered $code after 5 attempts"
+              exit 1
+            fi
           done
 
       # The `production` record is created by the `environment:` block above.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,130 @@
+# This workflow cannot run until CLOUDFLARE_API_TOKEN exists as a repository
+# secret. Until then every deploy is still a manual `npx wrangler deploy`, and
+# the deployment records on the repo page go on describing whatever commit they
+# last described. See docs/deploying.md.
+
+name: Deploy
+
+# Only what changes the deployed Worker. A docs-only merge would otherwise
+# redeploy identical bytes and overwrite the recorded SHA with a commit that
+# changed nothing about production.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "migrations/**"
+      - "wrangler.jsonc"
+      - "package-lock.json"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+# A deploy must never be cancelled part-way, and two must never overlap: the
+# second would race the first's `wrangler deploy` and the recorded SHA would be
+# whichever finished last rather than whichever is serving.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    # Naming an environment is what creates the deployment record on the repo
+    # page and what lets a required reviewer gate the job. Configure the
+    # reviewer in Settings → Environments; without one this deploys on merge.
+    environment:
+      name: production
+      url: https://symposium.site
+
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: "960579f222ad237394703bd52f28114c"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # CI runs these too, on the same push. Repeated here on purpose: the two
+      # workflows run in parallel, so a deploy that trusted CI could finish
+      # before CI went red and ship the build that failed.
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      # Fail on an unapplied migration rather than applying it. Running
+      # `migrations apply` here would let a merged PR silently alter the
+      # production database; failing cannot corrupt anything, and it turns a
+      # code/schema mismatch into a red build instead of a 500 at runtime.
+      #
+      # Compares filenames against the `d1_migrations` table rather than
+      # matching wrangler's console wording, which would break silently the
+      # next time that string changes.
+      - name: Check migrations are applied
+        run: |
+          set -euo pipefail
+          npx wrangler d1 execute symposium --remote --json \
+            --command "SELECT name FROM d1_migrations" \
+            | jq -r '.[0].results[].name' | sort > /tmp/applied.txt
+          ls migrations/*.sql | xargs -n1 basename | sort > /tmp/on-disk.txt
+          missing="$(comm -23 /tmp/on-disk.txt /tmp/applied.txt)"
+          if [ -n "$missing" ]; then
+            echo "::error::Unapplied migrations. Run: npx wrangler d1 migrations apply symposium --remote"
+            echo "$missing" | sed 's/^/  /'
+            exit 1
+          fi
+          echo "all $(wc -l < /tmp/on-disk.txt | tr -d ' ') migration(s) applied"
+
+      # `--message` fills the Message column in the dashboard's Deployments
+      # tab, which is otherwise a list of uuids and timestamps. It is what makes
+      # a rollback decision possible without cross-referencing GitHub.
+      - name: Deploy
+        id: deploy
+        run: |
+          npx wrangler deploy \
+            --message "$(git log -1 --format='%h %s' | cut -c1-100)" | tee /tmp/deploy.log
+
+      # A deploy that reports success and serves nothing is the failure this
+      # catches. Both hosts, because they are separate custom domains and one
+      # can be attached while the other is not.
+      - name: Check both hosts answer
+        run: |
+          set -euo pipefail
+          for host in api.symposium.md symposium.site; do
+            code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://$host/health")"
+            echo "$host → $code"
+            [ "$code" = "200" ] || { echo "::error::$host answered $code"; exit 1; }
+          done
+
+      # The `production` record is created by the `environment:` block above.
+      # This is its pair for the API host, which has no environment of its own.
+      - name: Record the API deployment
+        run: |
+          set -euo pipefail
+          # jq builds the body: required_contexts must be a real empty array,
+          # and gh's -f/-F flags send the string "[]", which the API 422s.
+          # A herestring rather than a heredoc — heredoc terminators inside a
+          # YAML block scalar depend on dedenting and break quietly.
+          body="$(jq -nc --arg sha "$GITHUB_SHA" \
+            '{ref:$sha,environment:"production-api",description:"Publisher API",auto_merge:false,required_contexts:[]}')"
+          id="$(gh api -X POST "repos/$GITHUB_REPOSITORY/deployments" --input - --jq '.id' <<<"$body")"
+          status="$(jq -nc --arg sha "$GITHUB_SHA" \
+            '{state:"success",environment:"production-api",environment_url:"https://api.symposium.md",description:("Deployed from "+$sha)}')"
+          gh api -X POST "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" --input - --silent <<<"$status"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,11 @@ jobs:
           # would fail once and then wave the same broken state through
           # forever. A failed deploy does not move this baseline. It also works
           # under `workflow_dispatch`, which has no push range at all.
-          gh api "repos/$GITHUB_REPOSITORY/deployments?environment=production&per_page=50" \
+          # --paginate: without it only the first page is searched, so enough
+          # consecutive failed deploys push the last successful record out of
+          # view, `base` comes back empty, and the check below skips itself.
+          # Retrying would defeat the guard.
+          gh api --paginate "repos/$GITHUB_REPOSITORY/deployments?environment=production&per_page=100" \
             --jq '.[] | "\(.id) \(.sha)"' > /tmp/deployments.txt
           base=""
           while read -r id sha; do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,17 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: "960579f222ad237394703bd52f28114c"
 
     steps:
+      # `workflow_dispatch` takes any ref, and the step below would check it
+      # out and ship it with the production token. First step, before checkout,
+      # so a wrong-branch dispatch never reaches the code. A job-level `if:`
+      # would skip instead of fail, and a silent skip reads as a deploy that
+      # worked.
+      - name: Refuse to deploy anything but main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Refusing to deploy ${{ github.ref }}. Production ships from main."
+          exit 1
+
       - name: Check out repository
         uses: actions/checkout@v4
 
@@ -93,11 +104,16 @@ jobs:
       # `--message` fills the Message column in the dashboard's Deployments
       # tab, which is otherwise a list of uuids and timestamps. It is what makes
       # a rollback decision possible without cross-referencing GitHub.
+      #
+      # No pipe here, deliberately. The default `run:` shell is `bash -e`
+      # without `pipefail`, so piping through `tee` would return tee's exit
+      # code, a failed deploy would pass, the health checks below would pass
+      # against the *previous* deployment, and the job would record a green
+      # deploy for a commit that never shipped.
       - name: Deploy
-        id: deploy
         run: |
           npx wrangler deploy \
-            --message "$(git log -1 --format='%h %s' | cut -c1-100)" | tee /tmp/deploy.log
+            --message "$(git log -1 --format='%h %s' | cut -c1-100)"
 
       # A deploy that reports success and serves nothing is the failure this
       # catches. Both hosts, because they are separate custom domains and one

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Check migrations are applied
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          BEFORE: ${{ github.event.before }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           npx wrangler d1 execute symposium --remote --json \
@@ -130,23 +130,40 @@ jobs:
           echo "all $(wc -l < /tmp/on-disk.txt | tr -d ' ') migration(s) applied"
 
           # An applied migration is immutable. `d1_migrations` stores a name and
-          # a timestamp, no checksum, so editing a file already listed there
+          # a timestamp, no checksum, so changing a file already listed there
           # passes the comparison above while the database never ran the new
           # SQL, and code expecting the new schema ships against the old one.
-          # Names are all D1 can offer, so the evidence comes from git instead.
-          # A first push or a force push leaves no usable base: skip rather than
-          # fail, since a missing base is not evidence of an edit.
-          if [ -n "${BEFORE:-}" ] && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            git diff --name-only --diff-filter=M "$BEFORE" HEAD -- migrations/ \
-              | xargs -r -n1 basename | sort > /tmp/edited.txt
-            clash="$(comm -12 /tmp/edited.txt /tmp/applied.txt)"
+          # Deleting one passes too, and leaves a history that cannot rebuild
+          # the schema on the fresh-account path in docs/deploying.md.
+          #
+          # Names are all D1 can offer, so the evidence comes from git. The
+          # baseline is the last SUCCESSFUL production deployment, not the
+          # push's parent: a failed deploy leaves the bad file on `main`, where
+          # the next push no longer sees it as changed, so a parent-based check
+          # would fail once and then wave the same broken state through
+          # forever. A failed deploy does not move this baseline. It also works
+          # under `workflow_dispatch`, which has no push range at all.
+          gh api "repos/$GITHUB_REPOSITORY/deployments?environment=production&per_page=50" \
+            --jq '.[] | "\(.id) \(.sha)"' > /tmp/deployments.txt
+          base=""
+          while read -r id sha; do
+            ok="$(gh api "repos/$GITHUB_REPOSITORY/deployments/$id/statuses?per_page=100" \
+              --jq '[.[] | select(.state=="success")] | length')"
+            if [ "$ok" -gt 0 ]; then base="$sha"; break; fi
+          done < /tmp/deployments.txt
+
+          if [ -n "$base" ] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "comparing migrations against last successful deploy ${base:0:8}"
+            git diff --name-only --diff-filter=MD "$base" HEAD -- migrations/ \
+              | xargs -r -n1 basename | sort > /tmp/changed.txt
+            clash="$(comm -12 /tmp/changed.txt /tmp/applied.txt)"
             if [ -n "$clash" ]; then
-              echo "::error::Edited a migration D1 has already applied. Add a new migration instead."
+              echo "::error::Changed or deleted a migration D1 has already applied. Add a new migration instead."
               echo "$clash" | sed 's/^/  /'
               exit 1
             fi
           else
-            echo "no base commit to diff against; skipping the edited-migration check"
+            echo "no successful production deployment to compare against; skipping the immutability check"
           fi
 
       # `--message` fills the Message column in the dashboard's Deployments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,14 +87,14 @@ rows — and D1 has a 30-day Time Travel window underneath. Do it well before
 there is enough data that reconstructing it by hand would hurt. Until then,
 treat D1 as a system of record, not as a cache.
 
-## Owed when the real serving domain lands
+## Owed now that the serving domain has landed
 
-`workers_dev` is `false`, so the Worker is unreachable until a custom domain is
-attached — the router would otherwise serve `/d/*` on a `workers.dev` hostname,
-and that domain is on the Public Suffix List, so a listing against it would take
-every Worker on the account's subdomain. Two things become true the moment user
-content moves to a real serving domain, and both are easy to miss because
-nothing fails loudly without them:
+The domains are attached: documents on `symposium.site`, the API on
+`api.symposium.md`. `workers_dev` stays `false` — the router would otherwise
+serve `/d/*` on a `workers.dev` hostname, and that domain is on the Public
+Suffix List, so a listing against it would take every Worker on the account's
+subdomain. Two things came due the moment user content moved to a real serving
+domain, and both are easy to miss because nothing fails loudly without them:
 
 - **Caching needs a Cache Rule, not just a domain.** Cloudflare does not cache
   HTML by default — eligibility is decided by file extension, not MIME type and
@@ -108,10 +108,10 @@ nothing fails loudly without them:
   without the second is how a withdrawn doc stays readable. The private-cache
   copies readers already hold are unrecallable by any design, and the README says
   so.
-- **Set `SERVING_HOST` and `API_HOST`.** The router resolves surface by host
-  first and only falls back to path prefixes while both are empty. Leaving them
-  unset on a two-domain deployment means `/api/v1` stays reachable on the
-  sacrificial domain, which is the whole point of splitting them.
+`SERVING_HOST` and `API_HOST` are already set, which is what makes the router
+resolve surface by host instead of falling back to path prefixes. Leave them
+set: unset on a two-domain deployment, `/api/v1` becomes reachable on the
+sacrificial domain, which is the whole point of splitting them.
 
 ## Git hygiene
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ comments.
 
 ## What works today
 
-Everything here is built and tested. Nothing is deployed yet, so none of it is
-reachable on the internet until someone runs [Deploying](docs/deploying.md).
+Everything here is built, tested, and live. See [Production](#production) for
+where it runs.
 
 - **Publish a note.** Send rendered HTML, get back a link. Obsidian Copilot
   renders the note locally, so callouts, wikilinks and dataview output survive —
@@ -94,6 +94,18 @@ argument for it, and the constraints it has to respect, are in
 [`docs/cost-at-scale.md`](docs/cost-at-scale.md). Read both before proposing
 architecture — several decisions in them are not retrofittable, and `CLAUDE.md`
 lists the ones that bind day to day.
+
+## Production
+
+| | |
+| --- | --- |
+| [symposium.site](https://symposium.site) | Serves published documents. User HTML lives here and never on the brand domain. |
+| [api.symposium.md](https://api.symposium.md) | The publisher API. Key-authenticated, no browser surface. |
+| [Cloudflare dashboard](https://dash.cloudflare.com/960579f222ad237394703bd52f28114c/workers/services/view/symposium/production) | The Worker itself: deployments, versions, logs, and the rollback button. |
+
+Deploys run from [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)
+on merge to `main`. [Deploying](docs/deploying.md) covers how, and how to roll
+back.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,15 @@ Roughly in order. Nothing below is started.
 - **The Obsidian side.** A right-click "share" in Copilot that calls this API and
   remembers the doc's id in the note. Without it, the only way to publish is
   `curl` — this is the next thing to build.
-- **Real domains, and actual caching.** There is no `workers.dev` url — that
-  route is off, because the router would serve documents on it and a
-  `workers.dev` listing takes every Worker on the account's subdomain with it.
-  So the domains come first: `symposium.site` for documents, `api.symposium.md`
-  for the API, which is also what keeps one bad upload from getting
-  `symposium.md` flagged by Google Safe Browsing. Caching is a separate fix on
-  top — Cloudflare does not cache HTML by default, so it needs a cache rule, and
-  then deletes have to purge the cache.
+- **Caching.** Cloudflare does not cache HTML by default, so every read today
+  invokes the Worker and touches D1 and R2. It needs a cache rule, and then
+  deletes have to purge the cache in the same change or unshared documents keep
+  being served. The domain split it sits on top of is already live: documents on
+  `symposium.site`, the API on `api.symposium.md`, and no `workers.dev` url at
+  all, since the router would serve documents there and a `workers.dev` listing
+  takes every Worker on the account's subdomain with it.
   [`docs/serving-domain.md`](docs/serving-domain.md) explains why that split
-  can't be added later.
+  could not have been added later.
 - **Backups that don't depend on the database.** Right now the database is the
   only record of who owns a doc and what it's called. The plan is for each doc to
   carry its own description alongside its files, so the database could be rebuilt

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -143,6 +143,14 @@ Two things the workflow deliberately does not do:
   would let a merged PR silently alter the production database; failing cannot
   corrupt anything and turns a code/schema mismatch into a red build. Apply them
   by hand, then merge.
+
+  It also fails if an already-applied migration was **changed or deleted**,
+  which the name comparison alone cannot see: `d1_migrations` stores names and
+  timestamps, no checksums, so an edited file looks applied while the database
+  never ran the new SQL. The evidence comes from git, against the last
+  successful production deployment rather than the previous commit — a failed
+  deploy leaves the bad file on `main`, where a commit-to-commit check would
+  stop noticing it. Once applied, a migration is append-only: add a new file.
 - **It does not smoke-test.** That needs a real lifetime key, spends a push from
   its daily quota, and writes to production R2 and D1 on every merge. `/health`
   on both hosts is the liveness check instead. Run `scripts/smoke.sh` by hand

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -41,9 +41,10 @@ right one — leave it alone.
 npx wrangler d1 migrations apply symposium --remote
 ```
 
-**Steps 4–8 ship the Worker, and are what is actually outstanding.** Step 7 is
-the one that makes it reachable: `workers_dev` is `false`, so a Worker with no
-custom domain attached answers on nothing at all.
+**Steps 4–8 ship the Worker.** They have all run on the Brevilabs account; what
+follows is the record of how, and the procedure for a fresh account. Step 7 is
+the one that makes the Worker reachable: `workers_dev` is `false`, so a Worker
+with no custom domain attached answers on nothing at all.
 
 ```bash
 # 4. Credentials for the license server. Both prompt for the value, so neither

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -103,11 +103,24 @@ Merging to `main` runs `.github/workflows/deploy.yml`, which typechecks, tests,
 refuses to deploy over an unapplied migration, ships, checks both hosts answer,
 and records what shipped on the repo page. Nobody deploys from a laptop.
 
-It needs one repository secret, `CLOUDFLARE_API_TOKEN`, scoped to **Workers
-Scripts: Edit** on the Brevilabs account — not a Global API Key, which would
-also reach DNS, R2 and D1. **Until that secret exists the workflow cannot run**,
-and deploys stay manual: steps 5 and 8 above, plus step 3 whenever a migration
-is added.
+It needs one repository secret, `CLOUDFLARE_API_TOKEN`, holding two account
+permissions on the Brevilabs account: **Workers Scripts: Edit** to deploy, and
+**D1: Edit** to read the `d1_migrations` table. Not a Global API Key, which
+would also reach DNS and every other zone setting. Create it under My Profile →
+API Tokens → Create Token; the *Edit Cloudflare Workers* template is a fine
+starting point, but confirm D1 is in its permission list and add it if not.
+
+D1: Edit is broader than the guard needs — it only runs a `SELECT` — but the
+query endpoint takes arbitrary SQL, so a read-only permission may not authorize
+it and an under-scoped token fails every deploy rather than degrading. The cost
+is real and worth naming: this token can write the production database, which is
+the price of checking the schema from CI at all.
+
+Set it with `gh secret set CLOUDFLARE_API_TOKEN --repo Brevilabs/symposium`,
+which reads the value from stdin and never puts it in shell history.
+
+**Until that secret exists the workflow cannot run**, and deploys stay manual:
+steps 5 and 8 above, plus step 3 whenever a migration is added.
 
 Two things the workflow deliberately does not do:
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -103,8 +103,10 @@ Merging to `main` runs `.github/workflows/deploy.yml`, which typechecks, tests,
 refuses to deploy over an unapplied migration, ships, checks both hosts answer,
 and records what shipped on the repo page. Nobody deploys from a laptop.
 
-It needs one repository secret, `CLOUDFLARE_API_TOKEN`, holding two account
-permissions on the Brevilabs account: **Workers Scripts: Edit** to deploy, and
+It needs one secret, `CLOUDFLARE_API_TOKEN` — an *environment* secret on
+`production`, never a repository one, for the reasons below. The token holds two
+account permissions on the Brevilabs account: **Workers Scripts: Edit** to
+deploy, and
 **D1: Edit** to read the `d1_migrations` table. Not a Global API Key, which
 would also reach DNS and every other zone setting. Create it under My Profile →
 API Tokens → Create Token; the *Edit Cloudflare Workers* template is a fine
@@ -119,15 +121,27 @@ it and an under-scoped token fails every deploy rather than degrading. The cost
 is real and worth naming: this token can write the production database, which is
 the price of checking the schema from CI at all.
 
-Add it as an **environment** secret on `production` (Settings → Environments →
-production), not a repository secret, and set that environment's **deployment
-branch policy to `main`**. Both halves are load-bearing, and the reason is that
-`workflow_dispatch` runs the workflow definition from whatever ref it is given:
-a branch carrying an edited copy of `deploy.yml` with the guard removed would
-otherwise deploy itself. The branch policy refuses the job, and a branch that
-strips the `environment:` block to escape the policy loses the only path to the
-secret. A repository secret has neither property — every workflow in the repo
-can read it.
+Add it under Settings → Environments → production → **Environment secrets**, and
+set that environment's **deployment branch policy** to `main`. Both halves are
+load-bearing, and the reason is that `workflow_dispatch` runs the workflow
+definition from whatever ref it is given: a branch carrying an edited copy of
+`deploy.yml` with the guard removed would otherwise deploy itself. The branch
+policy refuses the job, and a branch that strips the `environment:` block to
+escape the policy loses the only path to the secret. A repository secret has
+neither property — every workflow in the repo can read it, so the guard in
+`deploy.yml` would be the only thing standing between a feature branch and
+production, and that guard lives in the file such a branch is editing.
+
+The `main` rule must be **branch**-typed. GitHub's rules carry a ref type, and
+the API reports this one as `{"name":"main","type":"branch"}`. A tag-typed rule
+named `main` — or any `*` tag rule — would let someone push a tag called `main`
+and dispatch from it, which no branch rule matches and no in-file guard survives.
+Check with:
+
+```bash
+gh api repos/Brevilabs/symposium/environments/production/deployment-branch-policies \
+  --jq '.branch_policies[] | {name, type}'
+```
 
 Required reviewers would gate this further, but GitHub rejects that protection
 rule on this billing plan for a private repo, so the branch policy is the whole

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -97,5 +97,51 @@ hosts are empty, and the path-prefix fallback would serve `/d/*` on
 — the exact split this document argues for, undone for the length of a deploy.
 The `url` the API returns follows the vars automatically.
 
-Later deploys are steps 5 and 8 alone, plus step 3 whenever a migration is added.
+## Later deploys happen in CI
+
+Merging to `main` runs `.github/workflows/deploy.yml`, which typechecks, tests,
+refuses to deploy over an unapplied migration, ships, checks both hosts answer,
+and records what shipped on the repo page. Nobody deploys from a laptop.
+
+It needs one repository secret, `CLOUDFLARE_API_TOKEN`, scoped to **Workers
+Scripts: Edit** on the Brevilabs account — not a Global API Key, which would
+also reach DNS, R2 and D1. **Until that secret exists the workflow cannot run**,
+and deploys stay manual: steps 5 and 8 above, plus step 3 whenever a migration
+is added.
+
+Two things the workflow deliberately does not do:
+
+- **It does not apply migrations.** It compares `migrations/` against the
+  `d1_migrations` table and fails when they disagree. Applying them from CI
+  would let a merged PR silently alter the production database; failing cannot
+  corrupt anything and turns a code/schema mismatch into a red build. Apply them
+  by hand, then merge.
+- **It does not smoke-test.** That needs a real lifetime key, spends a push from
+  its daily quota, and writes to production R2 and D1 on every merge. `/health`
+  on both hosts is the liveness check instead. Run `scripts/smoke.sh` by hand
+  when the change warrants it.
+
+Gate it further by adding a required reviewer to the `production` environment in
+Settings → Environments, which turns a merge into "merged, and someone approved
+the deploy".
+
+## Rolling back
+
+Every deploy creates an immutable version and Cloudflare keeps them all.
+
+```bash
+npx wrangler versions list          # ids, timestamps, and the commit in Message
+npx wrangler rollback <version-id>
+```
+
+Or the dashboard: **Compute (Workers) → symposium → Deployments**, then
+**⋯ → Rollback** on a version. The workflow passes `--message` so that list
+reads as commits rather than uuids.
+
+**Rollback reverts code and nothing else.** D1 rows and R2 objects written by
+the bad version stay written, which is the other half of why migrations are not
+applied from CI. Nothing records a rollback either, so the deployment records on
+the repo page will name the commit that was deployed forward until the next
+merge corrects them.
+
 All changes ship through a pull request; never push to `main`.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -6,13 +6,15 @@ commands are creating.
 
 [← README](../README.md) · [Hosting](hosting.md) · [HTTP API](http-api.md)
 
-> **The Worker has not been deployed yet.** Its storage has: on the Brevilabs
-> account, steps 1–3 below are done, and `wrangler.jsonc` already carries the
-> real `database_id`. What is left is steps 4–8. One thing to know going in: D1
-> is currently the only record of who owns a doc, what it is called, and whether
-> it was deleted, so until per-doc manifests ship, back-ups mean D1's own 30-day
-> Time Travel window rather than "rebuild it from R2". That is fine at low volume
-> and should be fixed well before it isn't — see `CLAUDE.md`.
+> **The Worker is deployed.** All eight steps below have run on the Brevilabs
+> account, and `wrangler.jsonc` carries the real `database_id`. They are kept as
+> the record of how production was built and as the procedure for a fresh
+> account — do not re-run them against Brevilabs'. Routine deploys now happen in
+> CI; see [Later deploys happen in CI](#later-deploys-happen-in-ci). One thing to
+> know going in: D1 is still the only record of who owns a doc, what it is called,
+> and whether it was deleted, so until per-doc manifests ship, back-ups mean D1's
+> own 30-day Time Travel window rather than "rebuild it from R2". That is fine at
+> low volume and should be fixed well before it isn't — see `CLAUDE.md`.
 
 Run in order, from a checkout with `npx wrangler login` already done, against
 whichever account wrangler is logged into.
@@ -73,8 +75,8 @@ SYMPOSIUM_LICENSE_KEY=<a real lifetime-tier key> \
 The smoke script publishes a doc, reads it, lists it, deletes it and confirms the
 `410`. It spends one push against that key's daily quota and leaves no live doc
 and no stored bytes behind — only the deleted doc's row, which every delete keeps
-so the url can go on answering `410`. It is not part of CI — CI has no key and no
-deployment.
+so the url can go on answering `410`. It is not part of CI, which has no lifetime
+key to spend.
 
 ## There is no workers.dev url
 
@@ -105,9 +107,9 @@ refuses to deploy over an unapplied migration, ships, checks both hosts answer,
 and records what shipped on the repo page. Nobody deploys from a laptop.
 
 It needs one secret, `CLOUDFLARE_API_TOKEN` — an *environment* secret on
-`production`, never a repository one, for the reasons below. The token holds two
-account permissions on the Brevilabs account: **Workers Scripts: Edit** to
-deploy, and
+`production`, never a repository one, for the reasons below. It is configured on
+the Brevilabs repo; what follows is how it was built and how to rebuild it. The
+token holds two account permissions: **Workers Scripts: Edit** to deploy, and
 **D1: Edit** to read the `d1_migrations` table. Not a Global API Key, which
 would also reach DNS and every other zone setting. Create it under My Profile →
 API Tokens → Create Token; the *Edit Cloudflare Workers* template is a fine
@@ -148,8 +150,12 @@ Required reviewers would gate this further, but GitHub rejects that protection
 rule on this billing plan for a private repo, so the branch policy is the whole
 of the platform-level control.
 
-**Until that secret exists the workflow cannot run**, and deploys stay manual:
-steps 5 and 8 above, plus step 3 whenever a migration is added.
+Without the secret the workflow cannot run at all, and deploys fall back to being
+manual: steps 5 and 8 above, plus step 3 whenever a migration is added. That is
+also the recovery path if the token is ever revoked.
+
+Migrations remain manual in every case. Step 3, then merge — the workflow fails
+rather than applying one.
 
 Two things the workflow deliberately does not do:
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -119,8 +119,19 @@ it and an under-scoped token fails every deploy rather than degrading. The cost
 is real and worth naming: this token can write the production database, which is
 the price of checking the schema from CI at all.
 
-Set it with `gh secret set CLOUDFLARE_API_TOKEN --repo Brevilabs/symposium`,
-which reads the value from stdin and never puts it in shell history.
+Add it as an **environment** secret on `production` (Settings → Environments →
+production), not a repository secret, and set that environment's **deployment
+branch policy to `main`**. Both halves are load-bearing, and the reason is that
+`workflow_dispatch` runs the workflow definition from whatever ref it is given:
+a branch carrying an edited copy of `deploy.yml` with the guard removed would
+otherwise deploy itself. The branch policy refuses the job, and a branch that
+strips the `environment:` block to escape the policy loses the only path to the
+secret. A repository secret has neither property — every workflow in the repo
+can read it.
+
+Required reviewers would gate this further, but GitHub rejects that protection
+rule on this billing plan for a private repo, so the branch policy is the whole
+of the platform-level control.
 
 **Until that secret exists the workflow cannot run**, and deploys stay manual:
 steps 5 and 8 above, plus step 3 whenever a migration is added.
@@ -137,11 +148,9 @@ Two things the workflow deliberately does not do:
   on both hosts is the liveness check instead. Run `scripts/smoke.sh` by hand
   when the change warrants it.
 
-Gate it further in Settings → Environments on the `production` environment. A
-required reviewer turns a merge into "merged, and someone approved the deploy".
-A deployment branch policy limited to `main` enforces at the platform level what
-the workflow's first step already enforces in code, and unlike the workflow it
-cannot be changed by a pull request.
+What remains ungated is that a merge to `main` deploys with no pause. That is
+the same exposure as the manual `wrangler deploy` it replaces, minus the laptop,
+and closing it needs a billing plan that allows required reviewers.
 
 ## Rolling back
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -108,7 +108,10 @@ permissions on the Brevilabs account: **Workers Scripts: Edit** to deploy, and
 **D1: Edit** to read the `d1_migrations` table. Not a Global API Key, which
 would also reach DNS and every other zone setting. Create it under My Profile →
 API Tokens → Create Token; the *Edit Cloudflare Workers* template is a fine
-starting point, but confirm D1 is in its permission list and add it if not.
+starting point, but it does **not** include D1, so add that row by hand. Scope
+Account Resources to the one account and Zone Resources to `symposium.site` and
+`symposium.md` specifically, which is what authorizes the custom-domain routes.
+Leave Client IP filtering empty: GitHub's runners have no stable egress IPs.
 
 D1: Edit is broader than the guard needs — it only runs a `SELECT` — but the
 query endpoint takes arbitrary SQL, so a read-only permission may not authorize
@@ -134,9 +137,11 @@ Two things the workflow deliberately does not do:
   on both hosts is the liveness check instead. Run `scripts/smoke.sh` by hand
   when the change warrants it.
 
-Gate it further by adding a required reviewer to the `production` environment in
-Settings → Environments, which turns a merge into "merged, and someone approved
-the deploy".
+Gate it further in Settings → Environments on the `production` environment. A
+required reviewer turns a merge into "merged, and someone approved the deploy".
+A deployment branch policy limited to `main` enforces at the platform level what
+the workflow's first step already enforces in code, and unlike the workflow it
+cannot be changed by a pull request.
 
 ## Rolling back
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -175,11 +175,13 @@ Locally, secrets come from `.dev.vars` (gitignored; copy `.dev.vars.example`).
 The `database_id` in `wrangler.jsonc` looks like a credential and is not. It is
 an identifier, the binding will not resolve without it, and it is committed.
 
-## Deploys are explicit
+## Deploys come from CI
 
-Pushing to `main` deploys nothing. `wrangler deploy` uploads the current working
-tree, from whoever runs it. Cloudflare does offer a git integration; we have not
-set one up, so shipping is a deliberate act.
+Merging to `main` runs `.github/workflows/deploy.yml`, which holds the only
+credential allowed to deploy. `wrangler deploy` still uploads whoever's working
+tree when run by hand, which is how the first deploy happened; it is the
+fallback now, not the practice. Cloudflare's own git integration is a third
+option we have not set up. `docs/deploying.md` has the mechanics.
 
 Every deploy is retained as a version, and `wrangler rollback` returns to an
 earlier one. There are no per-PR preview URLs unless we configure them.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -102,18 +102,14 @@ reader → Cloudflare edge → Worker (src/index.ts)
 
 The Worker's first decision is which of two surfaces a request belongs to:
 `/api/v1/*` is the publisher API and needs a key, `/d/*` is public reading. They
-are split so they can later sit on separate domains — user content on a
-throwaway one, the API on the brand one — for reasons in
+sit on separate domains — user content on `symposium.site`, a domain chosen to be
+disposable, the API on `api.symposium.md` — for reasons in
 [cost-at-scale.md](cost-at-scale.md) §5.
 
-**Nothing is cached today**, and attaching a domain would not by itself change
-that. Two independent reasons:
-
-1. Nothing is reachable yet — `workers_dev` is off and no custom domain is
-   attached, so there is no hostname for a cache to sit in front of.
-2. Cloudflare does not cache HTML by default *on any domain*. Eligibility is
-   decided by file extension — not MIME type, and not the `Cache-Control` the
-   Worker sends — and `/d/{docId}` has no extension.
+**Nothing is cached today**, and attaching the domains did not by itself change
+that: Cloudflare does not cache HTML by default *on any domain*. Eligibility is
+decided by file extension — not MIME type, and not the `Cache-Control` the
+Worker sends — and `/d/{docId}` has no extension.
 
 Caching therefore needs an explicit **Cache Rule** on the serving zone, or the
 Cache API inside the Worker. Until one exists, every read invokes the Worker and

--- a/docs/serving-domain.md
+++ b/docs/serving-domain.md
@@ -79,26 +79,25 @@ insuring against is one occurrence.
 
 ## Status
 
-**Both domains are registered as of 2026-07-25** — `symposium.md` for the brand,
-`symposium.site` for documents — and both are delegated to Cloudflare. Neither is
-attached to the Worker yet, so nothing is reachable: `workers_dev` is `false`
-precisely because the path-prefix fallback would otherwise serve `/d/*` on a
-`workers.dev` url, which is the mistake this whole document argues against. The
-fallback stays in the router for the window where one host var is set and the
-other is not.
+**The split is live.** `symposium.site` serves documents and `api.symposium.md`
+serves the API, both attached as Worker custom domains, with `SERVING_HOST` and
+`API_HOST` set to match. `workers_dev` is `false` and stays that way: the
+path-prefix fallback would otherwise serve `/d/*` on a `workers.dev` url, which
+is the mistake this whole document argues against. The fallback stays in the
+router for the window where one host var is set and the other is not.
 
-Three things become true together when the real domains land, and
-[`CLAUDE.md`](../CLAUDE.md) carries the detail:
+Three things had to land together. One has;
+[`CLAUDE.md`](../CLAUDE.md) carries the detail on the rest:
 
-1. **Set `SERVING_HOST` and `API_HOST`.** The router resolves surface by host
-   first and only falls back to path prefixes while both are empty. Leaving them
-   unset means `/api/v1` stays reachable on the serving domain, which defeats the
-   split.
-2. **Add a Cache Rule.** Cloudflare does not cache HTML by default, and `/d/{docId}`
-   has no file extension, so attaching a domain alone changes nothing.
-3. **Purge on delete, in the same change.** Once there is an edge cache, an
-   unshared doc keeps being served from it. Shipping caching without purging is
-   how a withdrawn document stays readable.
+1. **Set `SERVING_HOST` and `API_HOST`.** Done. The router resolves surface by
+   host first and only falls back to path prefixes while both are empty.
+2. **Add a Cache Rule.** Outstanding. Cloudflare does not cache HTML by default,
+   and `/d/{docId}` has no file extension, so attaching the domains changed
+   nothing about caching.
+3. **Purge on delete, in the same change.** Outstanding, and coupled to the one
+   above. Once there is an edge cache, an unshared doc keeps being served from
+   it. Shipping caching without purging is how a withdrawn document stays
+   readable.
 
 ## What changes when reading stops being anonymous
 


### PR DESCRIPTION
Fixes #21

## Problem

Deploys are `npx wrangler deploy` from a laptop, and the GitHub deployment
records behind the repo page's production status were created by hand. They had
already drifted before this PR was written: the page said `54b7534`, `main` was
`16ddea3`, and the version actually serving traffic was deployed after both. A
badge that says "production: active" and names the wrong commit is worse than no
badge, because people trust it.

Three consequences beyond the stale label:

- Anyone with a wrangler session can ship, from any working tree including a
  dirty one, and nothing checks that what deployed matches what merged.
- No record of who deployed what, beyond Cloudflare's own version list.
- `wrangler d1 migrations apply --remote` is a separate manual step, so a merged
  migration and a deployed Worker can disagree with nothing noticing.

## Fix

A workflow on merge to `main`: typecheck, test, refuse to deploy over an
unapplied migration, ship, check both hosts answer, record the SHA that shipped.

Naming the `production` environment is what creates the deployment record and
what lets a required reviewer gate the job — so the audit trail the repo page is
currently faking becomes real.

Four things chosen rather than defaulted:

**Tests run here even though CI runs them on the same push.** The two workflows
run in parallel, so a deploy that trusted CI could finish before CI went red and
ship the build that failed.

**Migrations fail the build; they are not applied.** Applying from CI would let
a merged PR silently alter the production database. Failing cannot corrupt
anything and turns a code/schema mismatch into a red build instead of a 500 at
runtime. The check compares filenames against the `d1_migrations` table rather
than matching wrangler's console wording, which would break silently the next
time that string changes.

**Paths are filtered** to what changes the deployed Worker, so a docs-only merge
does not redeploy identical bytes and overwrite the recorded SHA with a commit
that changed nothing about production.

**`--message` carries the commit into Cloudflare's Deployments tab**, which is
otherwise a list of uuids and timestamps. That column is what makes a rollback
decision possible without cross-referencing GitHub.

## Scope

Budget gate: PASS — 6 files, +420/−69. The workflow, plus every place
(`README.md`, `CLAUDE.md`, `docs/deploying.md`, `docs/hosting.md`,
`docs/serving-domain.md`) that still described a pre-CI, pre-deploy world.

## Changes

- `44c4d29` — `.github/workflows/deploy.yml`, plus `docs/deploying.md` gaining
  *Later deploys happen in CI* and *Rolling back*. The rollback section records
  two things that are easy to assume otherwise: rollback reverts code only, so
  D1 rows and R2 objects written by a bad version stay written, and nothing
  records a rollback, so the deployment records name the commit deployed forward
  until the next merge corrects them.

## Verification

- The JSON bodies for the deployments API were built and validated by running
  the exact `jq` invocations from the workflow, not by reading them.
- `--message` confirmed to exist on `wrangler deploy --help`; `d1_migrations`
  confirmed to be the applied-migrations table, currently holding
  `0001_init.sql`.
- `npm test` 210 passed, `npm run typecheck` clean, on the branch.
- **Not verified: the workflow has never run.** It cannot until
  `CLOUDFLARE_API_TOKEN` exists as a repository secret, and the first real run
  is the only thing that proves the migration guard, the deploy step and the
  recording step work together. I would rather say that than imply a green run.

## Notes

- **Needs a secret before it can do anything.** `CLOUDFLARE_API_TOKEN`, scoped
  to *Workers Scripts: Edit* on account `960579f222ad237394703bd52f28114c` —
  not a Global API Key, which would also reach DNS, R2 and D1.
- Even scoped, this makes `.github/workflows/` as sensitive as the token:
  anyone who can merge a change there can deploy arbitrary code or print it.
- Merging this changes nothing until the secret exists. Deploys stay manual and
  the records stay stale, which is the current state, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRafoVj3si41TSWvU5Jffq

