### PR TITLE
Give shared documents a tab icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,10 @@ These are day-one decisions, not retrofits:
   rows only — never content — and must be rebuildable by scanning R2 manifests.
   **This does not hold yet — see below. Do not rely on it.**
 - Every push mints an **immutable version** served with `cache-control: immutable`.
-  R2 stores the publisher's own bytes; Symposium's additions (the robots meta and
-  the two bylines) are injected on the way out by `renderServedHtml`, so a byline
-  change — or a plan that removes one — reaches documents already published.
+  R2 stores the publisher's own bytes; Symposium's additions (the robots meta,
+  the favicon and the two bylines) are injected on the way out by
+  `renderServedHtml`, so a byline change — or a plan that removes one — reaches
+  documents already published.
   Nothing else is composed per read: the additions are a pure function of the
   stored version, so the page stays cacheable.
 - **No per-MAU or per-seat priced dependency** anywhere in the serving path.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -191,10 +191,13 @@ why the client uploads HTML at all. What the policy forbids is a doc using the
 origin against its readers: no form submission, no framing, no `<base>`
 retargeting. The origin is cookieless and holds nothing but already-public docs.
 
-Three things are injected as the document is served: a
+Four things are injected as the document is served: a
 `<meta name="robots" content="noindex,nofollow">` in the head, a
+`<link rel="icon">` beside it carrying the Symposium mark as a `data:` URI, a
 `Shared from Copilot for Obsidian` byline at the top of the body, and a
-`Powered by symposium.md` byline before `</body>`. Nothing else is touched — the
+`Powered by symposium.md` byline before `</body>`. A document that ships its own
+icon keeps that markup — both links are then in the head, and which one the tab
+shows is the browser's choice. Nothing else is touched — the
 markup is never sanitized, rewritten or reformatted, and what R2 stores is the
 publisher's document exactly as it was pushed.
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -146,6 +146,7 @@ expect_status 200 "GET $DOC_URL"
 expect_body "$MARKER" "the page serves the bytes that were pushed"
 expect_body "Copilot for Obsidian</span>" "the page carries the header byline"
 expect_body "symposium.md</a>" "the page carries the footer byline, linked"
+expect_body 'rel="icon"' "the page carries a tab icon"
 
 api_request GET "$BASE_URL/api/v1/docs?limit=100"
 expect_status 200 "GET /api/v1/docs"

--- a/src/render.ts
+++ b/src/render.ts
@@ -23,8 +23,8 @@
  * and embedded interactive figures, and stripping or escaping any of it would
  * destroy the fidelity that is the whole reason the client renders HTML. Safety
  * comes from the serving headers and a cookieless sacrificial origin, not from
- * rewriting the publisher's markup. The only edits made here are the two
- * additions below.
+ * rewriting the publisher's markup. The only edits made here are the additions
+ * below.
  *
  * HTMLRewriter rather than string surgery, because it is a real HTML tokenizer:
  * a `<head>` written inside a comment or emitted by `document.write("<head>")`
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 1;
+export const RENDER_REVISION = 2;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
@@ -54,6 +54,33 @@ export const RENDER_REVISION = 1;
  * served from anywhere else keeps asking not to be indexed.
  */
 export const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
+
+/**
+ * What the reader's tab shows. Without it a shared doc carries the browser's
+ * blank-page glyph, which is the least identifiable thing in a row of tabs.
+ *
+ * The mark is `favicon.svg` from the product site, inlined as a data URI for
+ * the reasons the Copilot mark below is: no second request, and nothing to
+ * break when these bytes are read from a mirror long after this deploy.
+ * `img-src` — the directive favicons load under — already admits `data:`.
+ * `encodeURIComponent` escapes the `"` and `#` in the markup, so nothing in
+ * the value can close the `href` around it.
+ *
+ * A document that declares its own icon keeps that markup; ours is prepended
+ * ahead of it, and which one the tab shows is then the browser's choice.
+ * Detecting the case to stay out of it would cost a second pass over the head,
+ * and neither outcome is wrong: the page is the publisher's, and it is served
+ * by us.
+ */
+export const FAVICON_LINK =
+  '<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+      '<rect width="32" height="32" rx="7" fill="#121413"/>' +
+      '<path d="M9 11.5h14M9 16h14M9 20.5h9" stroke="#46d17f" stroke-width="2.4" ' +
+      'stroke-linecap="round"/></svg>',
+  ) +
+  '">';
 
 /**
  * Shared between the two bylines (D9).
@@ -180,15 +207,17 @@ export const SYMPOSIUM_FOOTER =
 const AS_HTML = { html: true } as const;
 
 /**
- * Inject the robots meta and the two bylines, and change nothing else.
+ * Inject the robots meta, the favicon and the two bylines, and change nothing
+ * else.
  *
  * Every injection has a fallback, because a document is not guaranteed to have
  * the tag we want to hang it on:
  *
- * - The meta goes first inside `<head>`. A document with no `<head>` gets it at
- *   the end instead, where the parser hoists it into the body — weaker, since a
- *   robots meta outside the head is not honoured, which is exactly why the
- *   `X-Robots-Tag` header carries the real signal.
+ * - The meta and the favicon go first inside `<head>`. A document with no
+ *   `<head>` gets them at the end instead, where the parser hoists them into
+ *   the body — weaker for the meta, since a robots meta outside the head is not
+ *   honoured, which is exactly why the `X-Robots-Tag` header carries the real
+ *   signal, and best-effort for the icon.
  * - The header byline is prepended inside `<body>`. A document with no `<body>`
  *   start tag gets it at the document end instead, which puts the header below
  *   the content: wrong, but present. Hanging it on `<html>` would be no better,
@@ -216,22 +245,27 @@ const AS_HTML = { html: true } as const;
  * passes through the worker without ever being a 10MB string in it, exactly as
  * it did when serving was a passthrough.
  *
- * `branding` will be false for plans that pay to remove the bylines. It does not
- * reach the robots meta, and must not: `noindex` is policy, and a flag that
+ * `branding` will be false for plans that pay to remove the bylines. It takes
+ * the favicon with them — a Symposium mark in the reader's tab is branding too.
+ * It does not reach the robots meta, and must not: `noindex` is policy, and a flag that
  * switched it off would make paid customers' documents indexable — the worst
  * possible bug to ship attached to an upgrade.
  */
 export function renderServedHtml(response: Response, branding = true): Response {
-  let metaPlaced = false;
+  const head = branding ? NOINDEX_META + FAVICON_LINK : NOINDEX_META;
+  let headPlaced = false;
   let headerPlaced = false;
   let footerPlaced = false;
 
   return new HTMLRewriter()
+    // One `prepend()` for both, because each prepend goes *ahead* of the last:
+    // two calls would have to be written in the reverse of the order they
+    // produce, which is a trap for the next edit.
     .on("head", {
-      element(head) {
-        if (metaPlaced) return;
-        metaPlaced = true;
-        head.prepend(NOINDEX_META, AS_HTML);
+      element(element) {
+        if (headPlaced) return;
+        headPlaced = true;
+        element.prepend(head, AS_HTML);
       },
     })
     .on("body", {
@@ -254,7 +288,7 @@ export function renderServedHtml(response: Response, branding = true): Response 
     })
     .onDocument({
       end(end) {
-        if (!metaPlaced) end.append(NOINDEX_META, AS_HTML);
+        if (!headPlaced) end.append(head, AS_HTML);
         if (branding && !headerPlaced) end.append(SYMPOSIUM_HEADER, AS_HTML);
         if (branding && !footerPlaced) end.append(SYMPOSIUM_FOOTER, AS_HTML);
       },

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  FAVICON_LINK,
   NOINDEX_META,
   renderServedHtml,
   SYMPOSIUM_FOOTER,
@@ -25,6 +26,22 @@ describe("renderServedHtml — what gets injected", () => {
   // came from, and both claims are about literal bytes, not about a symbol.
   it("asks robots not to index or follow", () => {
     expect(NOINDEX_META).toBe('<meta name="robots" content="noindex,nofollow">');
+  });
+
+  // Inline for the reason the Copilot mark is: an icon fetched from another
+  // host is a blank tab whenever that host is unreachable, and these bytes
+  // outlive the deploy that produced them.
+  it("carries the tab icon inline, in the brand's own colours", () => {
+    expect(FAVICON_LINK).toContain('rel="icon"');
+    expect(FAVICON_LINK).toContain('href="data:image/svg+xml,');
+    for (const colour of ["#121413", "#46d17f"]) {
+      expect(FAVICON_LINK).toContain(encodeURIComponent(colour));
+    }
+    // Escaped, so the `"` on every attribute inside the SVG cannot close the
+    // `href` around it.
+    const href = FAVICON_LINK.slice(FAVICON_LINK.indexOf('href="') + 6, -2);
+    expect(href).not.toContain('"');
+    expect(decodeURIComponent(href.slice("data:image/svg+xml,".length))).toContain("<svg ");
   });
 
   it("says where the document came from, in text a reader can see", async () => {
@@ -114,10 +131,10 @@ describe("renderServedHtml — what gets injected", () => {
 });
 
 describe("renderServedHtml — where the injections land", () => {
-  it("puts the robots meta inside the head, and the bylines around the body", async () => {
+  it("puts the robots meta and the icon inside the head, and the bylines around the body", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
-    expect(headOf(baked)).toContain(NOINDEX_META);
+    expect(baked).toContain(`<head>${NOINDEX_META}${FAVICON_LINK}`);
     expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
     expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
   });
@@ -133,6 +150,7 @@ describe("renderServedHtml — where the injections land", () => {
     const baked = await bake(page("<div><p>one</p></div><div><p>two</p></div>"));
 
     expect(occurrences(baked, NOINDEX_META)).toBe(1);
+    expect(occurrences(baked, FAVICON_LINK)).toBe(1);
     expect(occurrences(baked, SYMPOSIUM_HEADER)).toBe(1);
     expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
   });
@@ -208,6 +226,7 @@ describe("renderServedHtml — documents missing the tags to hang them on", () =
     const baked = await bake("<!doctype html>\n<html>\n<body>\n<p>hi</p>\n</body>\n</html>");
 
     expect(baked).toContain(NOINDEX_META);
+    expect(baked).toContain(FAVICON_LINK);
     expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
     expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
     // The doctype has to stay first: a meta ahead of it would put the page into
@@ -285,11 +304,14 @@ describe("renderServedHtml — the document's own content", () => {
 describe("renderServedHtml — branding off", () => {
   // The separation the tier work depends on: a plan that pays to lose the
   // bylines must not also lose `noindex`, which is policy rather than branding.
-  it("drops both bylines but keeps the robots meta", async () => {
+  // The tab icon goes with them: a Symposium mark in the reader's tab is
+  // branding too. The robots meta is policy and stays.
+  it("drops both bylines and the icon but keeps the robots meta", async () => {
     const bare = await bake(page("<p>hello</p>"), false);
 
     expect(bare).not.toContain(SYMPOSIUM_HEADER);
     expect(bare).not.toContain(SYMPOSIUM_FOOTER);
+    expect(bare).not.toContain(FAVICON_LINK);
     expect(headOf(bare)).toContain(NOINDEX_META);
     expect(bare).toContain("<p>hello</p>");
   });


### PR DESCRIPTION
Fixes #27

## Problem

A shared document shows the browser's blank-page glyph in the tab. The served
HTML carries no `<link rel="icon">`: `renderServedHtml` in `src/render.ts`
injects the robots meta and the two bylines and nothing else. A tab with no icon
is the least identifiable thing in a row of twenty, which matters most for the
documents people leave open to come back to.

The icon itself did not exist when #27 was filed. It does now:
`apps/symposium/public/favicon.svg` in `app-sites`.

## Fix

One constant, prepended into the head with the robots meta already going there.
A data URI rather than a hosted file, matching the Copilot mark in the byline:
no second request, and it survives being read from a mirror or a cache long
after this deploy. `img-src` — the directive favicons load under — already
admits `data:`.

`RENDER_REVISION` moves to `2`: the served `ETag` names the rendering, so
without the bump a cache holding the icon-less rendering would revalidate into
`304` and keep it indefinitely.

#27 was rewritten to this scope before this PR was opened, and two things it
originally asked for are deliberately out:

- **No `/favicon.ico` route.** The injected link is what a browser uses. The
  cases a route would add — a branding-off document, an error page, the bare
  host — are not worth a second mechanism today.
- **No deference to a document's own icon.** Ours is prepended; a document that
  ships its own ends up with both, and which the tab shows is the browser's
  business. Detecting the case would cost a second pass over the head.

The issue's original premise that injection cannot reach published documents is
also stale: `renderServedHtml` runs on the response stream, not at push time, so
existing docs get the icon with no re-push.

## Scope

Budget gate: PASS — 5 files, +85/−24. 16 lines of it are code (the constant, one
`prepend`, one fallback); the rest is a comment in this file's density, four
test assertions, and the two docs that enumerate what serving injects.

## Changes

- `src/render.ts` — `FAVICON_LINK`, prepended with the meta in a single
  `prepend()` (a second call would have to be written in reverse order to the
  output); dropped with the bylines when `branding` is false; document-end
  fallback for a headless document; `RENDER_REVISION` → 2.
- `test/render.test.ts` — the constant's shape and escaping, placement at the
  head of the head, injected exactly once, present in the no-head fallback, and
  gone when branding is off.
- `docs/http-api.md`, `CLAUDE.md` — the fourth injection, additive to the frozen
  contract.
- `scripts/smoke.sh` — one assertion that a served page carries a tab icon.

## Verification

- `npm test` → 231 passed (8 files), one more than before. `npm run typecheck`
  clean.
- Rendered a document through `renderServedHtml` inside workerd and read the
  head back: `<head><meta name="robots" …><link rel="icon"
  type="image/svg+xml" href="data:image/svg+xml,%3Csvg…"><title>Note</title></head>`.
- `scripts/smoke.sh` is `bash -n` checked, **not executed** — it needs a real
  license key and a live deployment, so "an existing doc shows the icon without
  a re-push" is verifiable only after this merges and deploys.
- Not verified: how a browser resolves two competing icon links when a document
  ships its own. That is the documented, accepted behaviour here, not a claim
  the PR makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T5wTv4EzJSg2ZWjuZ67ey
