### PR TITLE
File documents under the account, not the license key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,12 @@ These are day-one decisions, not retrofits:
 - Shared docs are **`noindex` + `nofollow` by default**.
 - **Publisher-gated, reader-open**: publishing requires a key; reading requires
   nothing.
+- **Documents belong to an account, not to the credential that published them.**
+  `docs.owner` is an app-sites `User.id`, and it is always *derived* — from a
+  validated license key, later from a signed session — and **never accepted as
+  input**. An endpoint that took an owner id as a parameter would turn every id
+  into a password, and would not look like a security change when written.
+  `docs/identity.md` is the whole model.
 - **R2 is the system of record**, and the stored format is HTML. D1 holds pointer
   rows only — never content — and must be rebuildable by scanning R2 manifests.
   **This does not hold yet — see below. Do not rely on it.**

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ back.
 | [HTTP API](docs/http-api.md) | Every endpoint, in full. The frozen contract Obsidian Copilot is built against. |
 | [Hosting](docs/hosting.md) | How this runs on Cloudflare. **Start here if you know Vercel but not Workers.** |
 | [Serving domain](docs/serving-domain.md) | Why user content lives on `symposium.site` and never on the brand domain. |
+| [Identity](docs/identity.md) | Who owns a document, why it is the account and not the license key, and how symposium.md sign-in slots in. |
 | [Private sharing](docs/private-sharing.md) | How reader identity works, and the phases from public links to agents. Designed, not built. |
 | [Deploying](docs/deploying.md) | Provisioning the resources and shipping. |
 | [Development](docs/development.md) | Running it locally, including the license-server workaround. |

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -157,6 +157,18 @@ also the recovery path if the token is ever revoked.
 Migrations remain manual in every case. Step 3, then merge — the workflow fails
 rather than applying one.
 
+**That order leaves the old Worker running against the new schema**, from the
+moment the migration lands until the deploy that follows the merge finishes.
+Whatever the old code reads or writes that the migration changed will fail for
+those few minutes. A migration must therefore be **backward compatible with the
+Worker already deployed**: add nullable columns, do not drop or rename ones the
+live code still uses, and split anything else into two releases — widen, deploy,
+backfill, then narrow in a later migration.
+
+The one migration that ignores this is `0002`, which drops and recreates every
+table. It was applied before there were users or data, where a few minutes of
+`500`s cost nothing. That licence expires the day someone else is publishing.
+
 Two things the workflow deliberately does not do:
 
 - **It does not apply migrations.** It compares `migrations/` against the

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,10 +21,15 @@ wrangler@latest`.
 
 There is no license server locally, so the first push against `wrangler dev`
 fails with `internal`. Warm the validation cache by hand — the worker trusts a
-`publishers` row younger than an hour whose plan may publish, and a publisher id
-is just the SHA-256 of the key. The plan has to be `believer`: any other value
-is not entitled to publish, so the row is skipped and the push falls through to
-a license server that is not there.
+`publishers` row younger than an hour whose plan may publish, and a key is
+identified by the SHA-256 of itself. The plan has to be `believer`: any other
+value is not entitled to publish, so the row is skipped and the push falls
+through to a license server that is not there.
+
+`owner` is the account the documents get filed under — in production the
+`accountId` the license server returns, and locally any string you like, since
+nothing checks it against a real account. Use the same one twice to see two keys
+share a shelf.
 
 ```bash
 KEY=any-string-you-like
@@ -32,8 +37,8 @@ HASH=$(printf '%s' "$KEY" | shasum -a 256 | cut -d' ' -f1)
 
 npx wrangler d1 migrations apply symposium --local
 npx wrangler d1 execute symposium --local --command \
-  "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at)
-   VALUES ('$HASH', 'believer', $(($(date +%s) * 1000)))"
+  "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
+   VALUES ('$HASH', 'believer', $(($(date +%s) * 1000)), 'local-account')"
 
 SYMPOSIUM_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
 ```

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -33,7 +33,13 @@ Authorization: Bearer <license key>
 
 The key is validated against the Brevilabs license server and cached for an hour.
 Only the key's SHA-256 is ever stored; the raw key is never persisted or logged.
-A publisher *is* that hash, so the same key always sees the same docs.
+
+**Documents belong to the Brevilabs account, not to the key.** Validation
+resolves the key to the account that holds it, and that account owns everything
+published with it. So every key on one account sees one list, and any of them
+can push a new version of, or unshare, a document another one created. Replacing
+a key changes nothing about which documents you have. Nothing in this API takes
+an account id as input, and none is ever returned.
 
 **A valid key is not sufficient to publish.** Publishing requires an entitled
 plan, and in phase 1 that is **the lifetime tier only** (`BELIEVER` on the
@@ -111,7 +117,7 @@ it does on `POST`.
 The `url` never changes. `version` increments by one and the previous version
 stays readable forever at `/d/{docId}/v{n}`.
 
-`404 not_found` if the doc does not exist, belongs to another publisher, or was
+`404 not_found` if the doc does not exist, belongs to another account, or was
 deleted — see [Not found, never forbidden](#not-found-never-forbidden).
 
 ### `DELETE /api/v1/docs/{docId}` — unshare
@@ -130,14 +136,15 @@ holding one will go on serving it without asking us again. Unshare stops new
 readers, not readers who already fetched — the same way it cannot un-download a
 file. Treat it as withdrawing the link, not as revoking the content.
 
-`404 not_found` if the doc does not exist, belongs to another publisher, **or was
+`404 not_found` if the doc does not exist, belongs to another account, **or was
 already deleted**. A retry after a timeout therefore sees `404`, not `204`; what
 is idempotent is the outcome, which is the part a client cares about. Treat
 `404` from a delete as success.
 
 ### `GET /api/v1/docs` — list my docs
 
-Only the calling publisher's live docs, newest first by creation time.
+Every live doc the calling account holds, newest first by creation time —
+whichever of its keys published them.
 
 | Query | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -244,7 +251,7 @@ Two of these are worth handling deliberately in a client:
   internal`, never `401`, precisely so the client does not prompt for a new key
   over a key that is perfectly good. Retry instead.
 - <a id="not-found-never-forbidden"></a>**Not found, never forbidden.** There is
-  no `403`. A doc belonging to another publisher answers exactly like a doc that
+  no `403`. A doc belonging to another account answers exactly like a doc that
   never existed, because a distinguishable reply would confirm the id is real.
 
 ## Quotas
@@ -257,6 +264,9 @@ one.
 | HTML per doc | 10 MB | `413 too_large` |
 | Pushes per day | 100 (UTC day, rolls at midnight) | `429 quota_exceeded` |
 | Live docs held | 500 | `429 quota_exceeded` |
+
+Both limits are **per account, not per key**: two keys on one account share one
+daily allowance and one 500-document ceiling rather than getting two.
 
 Both `POST` and `PUT` spend one push. A rejected push spends nothing: a `413`,
 a `400`, or a `PUT` at a doc you do not own leaves the day's allowance intact.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,120 @@
+# Who owns a document
+
+**The rule: a document belongs to a Brevilabs account, never to the credential
+used to publish it.**
+
+A license key is a way of proving who you are. It is not who you are. Keeping
+those two apart is what lets someone replace a key, hold two of them, or sign in
+to symposium.md having never made one — and see the same documents throughout.
+
+[← README](../README.md) · [HTTP API](http-api.md) · [Private sharing](private-sharing.md)
+
+## The owner id
+
+`docs.owner` holds an **app-sites `User.id`** — the uuid in the Brevilabs
+Postgres that identifies a person across every Brevilabs product. Symposium
+stores no email and keeps no account table of its own. The id is opaque here:
+nothing parses it, and every query only ever compares it for equality.
+
+Two facts make that enough:
+
+- **The license server already resolves a key to it.**
+  `license.validateLicenseKey` returns `accountId: LicenseKeyConfig.authUserId`
+  on every valid response, alongside the plan.
+- **A symposium.md session already carries it.** NextAuth's session callback
+  sets `session.user.id` to the same uuid.
+
+So both sides arrive at the identical value without deriving anything. There is
+no hashing rule, no email normalisation, and therefore no way for two codebases
+to compute it differently and quietly split one person into two.
+
+## How a request resolves to an owner
+
+Today there is one credential, and one day there will be two. They meet at
+`Publisher.owner`, and nothing downstream can tell which was used:
+
+```
+Authorization: Bearer <license key>   →  license server  →  accountId  ┐
+                                                                       ├→  Publisher.owner  →  docs.owner
+symposium.md session (JWT)            →  session.user.id              ┘
+```
+
+`src/auth.ts` is the only module that sees a license key at all. It hashes the
+key immediately, uses that hash as its own validation-cache key, and hands the
+rest of the system nothing but an owner and a plan.
+
+### Why `publishers` is still keyed by the key hash
+
+A fair question, since ownership no longer is. Three reasons:
+
+1. **It is the only thing derivable from a request without a network call.** The
+   request carries a license key; the account is on the far side of the license
+   server. A cache keyed by account could not be read without first making the
+   call the cache exists to avoid.
+2. **Revocation and plan are per key.** `LicenseKeyConfig` carries `plan` and
+   `delete` per license key, not per user. If two keys shared one row they would
+   share one `validated_at`, so validating a good key would refresh the row a
+   revoked key reads — and the revoked one would keep publishing until the TTL
+   expired.
+3. **They answer different questions.** `publishers.key_hash` is "what do I know
+   about this credential"; `docs.owner` is "whose document is this";
+   `publishers.owner` is the mapping between them.
+
+The hash never leaves that module. It is an index, not an identity.
+
+## What happens when symposium.md gains sign-in
+
+Almost nothing, which is the point. `User` is one NextAuth table shared by every
+app-sites product, so a symposium.md sign-up resolves through the same
+`authOptions` Copilot already uses:
+
+| On sign-in | Result |
+| --- | --- |
+| An `Account` row already links this provider identity | that existing `User.id` |
+| Different provider, same verified email | the **same** `User.id` — GitHub and Google both set `allowDangerousEmailAccountLinking: true` |
+| Neither matches | the adapter mints a new `User` row |
+
+In all three cases `session.user.id` is the owner. A Copilot user signing in sees
+the documents they published from the plugin, with no linking step and no key to
+paste. Someone who has never held a license key gets a working, empty list rather
+than a dead end. **No join, and no branch on "is this person a Copilot user."**
+
+### The join is for entitlement, not identity
+
+*Who* needs no lookup. *May they publish* does. That gate is currently the
+license key's plan, and a symposium.md-only user has no `LicenseKeyConfig` row at
+all — so it needs a per-product table, following the shape already in the schema:
+`Customer` for Copilot, `MiyoCustomer` for miyo, and a Symposium equivalent keyed
+by `authUserId`. Joined on the account, answering *what plan*, never *who*.
+
+Keeping that split is what stops the identity model growing a special case per
+product.
+
+## Two properties that are load-bearing
+
+**An owner id is an identifier, never a credential.** It is safe to store, log
+and pass between services only because holding one grants nothing: the owner is
+always *derived*, from a validated license key or a signed session, and never
+accepted as input. Nothing in `docs/http-api.md` takes or returns one. An
+endpoint that accepted an owner id as a parameter would silently turn every id
+into a password — this is the easiest way to undo the model, and it would not
+look like a security change when it was written.
+
+**Cross-provider linking rests on the provider's email verification.** With
+`allowDangerousEmailAccountLinking` on, a provider asserting an address it does
+not own would be handed the matching account. The `signIn` callback blocks any
+OAuth sign-in whose email the provider has not verified, which is what makes it
+sound. That check is load-bearing for document ownership, not only for login, and
+should not be relaxed without knowing that.
+
+## What this does not do
+
+- **It does not follow an email change.** The owner is the account uuid, which is
+  stable across email changes — that is a feature, not an omission.
+- **It does not give a key its own documents.** Two keys on one account share one
+  list, one daily push allowance, and one 500-document ceiling. Isolation is per
+  account, and `docs/http-api.md` says so.
+- **It does not survive the account being deleted.** Nothing in Symposium
+  currently reacts to a `User` row disappearing upstream; the documents would
+  simply stop being reachable by anyone. Worth solving before there are accounts
+  worth deleting.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -100,6 +100,16 @@ endpoint that accepted an owner id as a parameter would silently turn every id
 into a password — this is the easiest way to undo the model, and it would not
 look like a security change when it was written.
 
+**A license key never changes hands, and the validation cache depends on that.**
+`LicenseKeyConfig.authUserId` is written when a key is created and is never
+updated — every write to that table in app-sites sets only `delete`. That is what
+makes it safe to serve a cached owner for an hour without re-asking: the value
+cannot have moved. Introducing key transfer upstream would turn this cache into a
+hole, because a transferred key would keep resolving to its previous account —
+and so keep listing, updating and unsharing that account's documents — until the
+row expired. Transfer needs a cache purge shipped with it, or it must stay
+impossible.
+
 **Cross-provider linking rests on the provider's email verification.** With
 `allowDangerousEmailAccountLinking` on, a provider asserting an address it does
 not own would be handed the matching account. The `signIn` callback blocks any

--- a/migrations/0002_own_docs_by_owner.sql
+++ b/migrations/0002_own_docs_by_owner.sql
@@ -1,58 +1,55 @@
--- Documents belong to an owner, not to a license key.
+-- Documents belong to an account, not to a license key.
 --
--- `docs.publisher` held the SHA-256 of a Copilot license key, which made the key
--- itself the identity: rotate keys and you lose sight of your documents, and
+-- `docs.publisher` held the SHA-256 of a Copilot license key, which made the
+-- key the identity: rotate keys and you lose sight of your documents, and
 -- someone who signs in to symposium.md having never held a key has nothing to
 -- look documents up by. It becomes `docs.owner`, holding the app-sites
--- `User.id` — the account UUID that Copilot and symposium.md already share.
+-- `User.id` — the account that `LicenseKeyConfig.authUserId` attaches a key to,
+-- and that a symposium.md session already carries.
 --
--- Reusing that id is what keeps this small. Accounts live in the Brevilabs
--- Postgres, not here; this schema stores no email, no account row and no link
--- table. `LicenseKeyConfig.authUserId` already maps a key to the id, and a
--- symposium.md session already carries it, so nothing is derived on either side
--- and the two cannot disagree.
+-- **This replaces the v0 tables rather than migrating them.** Nothing is live:
+-- every row is development test data and the R2 objects behind it are
+-- disposable. Carrying rows across would mean keeping documents filed under key
+-- hashes, which under the new rule are owned by an account id that does not
+-- exist — rows no dashboard could ever show and no publisher could ever delete.
+-- Dropping them is not a shortcut around a migration; it is the migration.
 --
--- Nothing reads the column's value — it is only ever compared for equality — so
--- `owner` staying opaque is what lets the identity behind it change without the
--- query layer noticing.
+-- Orphaned R2 objects under `docs/` are the one loose end, and they are
+-- development bytes with no row pointing at them. Empty the bucket alongside
+-- this if you want it tidy.
 --
--- The foreign key from `docs.publisher` onto `publishers(key_hash)` has to go:
--- a `User.id` has no `publishers` row to point at. SQLite cannot drop a
--- constraint in place, hence the table rebuild below, done now while `docs` is
--- small — the rebuild copies every row, so its cost only grows.
---
--- What that foreign key used to guarantee, no doc without a publisher row we had
--- validated, is now the auth path's job alone. No version of this design keeps
--- it as a database constraint.
+-- `publishers` is a validation cache, so it is dropped for free: every row
+-- rebuilds on its key's next request.
 
--- The resolved account id, cached beside the plan on the row that already caches
--- license validation. Null while the license server does not return one — which
--- is every row on the day this ships, since that field does not exist yet.
--- `Publisher.owner` falls back to the key hash for those, which is exactly the
--- behaviour they have now, so nothing observable changes on deploy and this can
--- land before the license server catches up.
-ALTER TABLE publishers ADD COLUMN owner TEXT;
-
--- `versions.doc_id` cascades on delete from `docs`, so the version log is moved
--- aside before `docs` is dropped — dropping the parent with that child still
--- attached would take every version row with it. Rebuilding `versions` at the
--- end is also what re-points its foreign key at the new table.
-CREATE TABLE versions_carry (
-  doc_id     TEXT    NOT NULL,
-  n          INTEGER NOT NULL,
-  size       INTEGER NOT NULL,
-  title      TEXT,
-  created_at INTEGER NOT NULL
-);
-INSERT INTO versions_carry (doc_id, n, size, title, created_at)
-  SELECT doc_id, n, size, title, created_at FROM versions;
 DROP TABLE versions;
+DROP TABLE push_quota;
+DROP TABLE docs;
+DROP TABLE publishers;
 
-CREATE TABLE docs_new (
+-- Publishers, keyed by the SHA-256 of their license key. Raw keys are never
+-- stored. This table doubles as the license-validation cache: `validated_at` is
+-- the last successful check, and a row younger than the TTL skips the license
+-- server round trip.
+CREATE TABLE publishers (
+  key_hash     TEXT    PRIMARY KEY,
+  -- The app-sites `User.id` this key belongs to, from the license server's
+  -- `accountId`. Not null on purpose: a key we cannot attribute to an account
+  -- cannot publish, because there would be nobody to file the document under.
+  -- Auth refuses such a response rather than inventing an owner for it.
+  owner        TEXT    NOT NULL,
+  plan         TEXT    NOT NULL,
+  validated_at INTEGER NOT NULL
+);
+
+-- One row per shared doc. `latest_version` is the version counter; it is
+-- incremented with a single `UPDATE ... RETURNING`, which is the only atomicity
+-- this design needs.
+CREATE TABLE docs (
   id             TEXT    PRIMARY KEY,
-  -- An app-sites `User.id`, or the SHA-256 of a license key for a doc published
-  -- before account ids were available. Opaque either way: no query interprets
-  -- it, and none should start.
+  -- An app-sites `User.id`. Deliberately not a foreign key onto `publishers`:
+  -- that table is keyed by license key, and an account is not one. The
+  -- invariant it used to carry — no doc without a publisher we validated — is
+  -- the auth path's, since only a resolved publisher reaches a write.
   owner          TEXT    NOT NULL,
   title          TEXT    NOT NULL,
   latest_version INTEGER NOT NULL DEFAULT 0,
@@ -60,18 +57,15 @@ CREATE TABLE docs_new (
   updated_at     INTEGER NOT NULL,
   deleted_at     INTEGER
 );
-INSERT INTO docs_new (id, owner, title, latest_version, created_at, updated_at, deleted_at)
-  SELECT id, publisher, title, latest_version, created_at, updated_at, deleted_at FROM docs;
-DROP TABLE docs;
-ALTER TABLE docs_new RENAME TO docs;
 
--- Unchanged in shape from `docs_by_publisher_live`, which went with the old
--- table: it still supplies both the filter and the ordering for the keyset walk
--- in `listPublisherDocs`, and is still partial so soft-deleted docs cost nothing.
+-- Serves both the cursor-paged "list my docs" scan and the live-doc count the
+-- per-account doc quota checks. Partial, so soft-deleted docs cost nothing.
 CREATE INDEX docs_by_owner_live
   ON docs (owner, created_at DESC, id DESC)
   WHERE deleted_at IS NULL;
 
+-- Immutable version log. One row per push; the R2 object for (doc_id, n) is
+-- written before the row, so a row always has bytes behind it.
 CREATE TABLE versions (
   doc_id     TEXT    NOT NULL REFERENCES docs(id) ON DELETE CASCADE,
   n          INTEGER NOT NULL,
@@ -80,10 +74,13 @@ CREATE TABLE versions (
   created_at INTEGER NOT NULL,
   PRIMARY KEY (doc_id, n)
 );
-INSERT INTO versions (doc_id, n, size, title, created_at)
-  SELECT doc_id, n, size, title, created_at FROM versions_carry;
-DROP TABLE versions_carry;
 
--- The daily push counter is keyed on the same id, so it follows the same rename.
--- A plain rename rather than a rebuild: nothing references this table.
-ALTER TABLE push_quota RENAME COLUMN publisher TO owner;
+-- Daily push counter per account. `day` is a UTC `YYYY-MM-DD` string, so the
+-- window rolls without a scheduled reset. Per account rather than per key: two
+-- keys on one account share one allowance, which is what the limit means.
+CREATE TABLE push_quota (
+  owner  TEXT    NOT NULL,
+  day    TEXT    NOT NULL,
+  pushes INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (owner, day)
+);

--- a/migrations/0002_own_docs_by_owner.sql
+++ b/migrations/0002_own_docs_by_owner.sql
@@ -1,0 +1,89 @@
+-- Documents belong to an owner, not to a license key.
+--
+-- `docs.publisher` held the SHA-256 of a Copilot license key, which made the key
+-- itself the identity: rotate keys and you lose sight of your documents, and
+-- someone who signs in to symposium.md having never held a key has nothing to
+-- look documents up by. It becomes `docs.owner`, holding the app-sites
+-- `User.id` — the account UUID that Copilot and symposium.md already share.
+--
+-- Reusing that id is what keeps this small. Accounts live in the Brevilabs
+-- Postgres, not here; this schema stores no email, no account row and no link
+-- table. `LicenseKeyConfig.authUserId` already maps a key to the id, and a
+-- symposium.md session already carries it, so nothing is derived on either side
+-- and the two cannot disagree.
+--
+-- Nothing reads the column's value — it is only ever compared for equality — so
+-- `owner` staying opaque is what lets the identity behind it change without the
+-- query layer noticing.
+--
+-- The foreign key from `docs.publisher` onto `publishers(key_hash)` has to go:
+-- a `User.id` has no `publishers` row to point at. SQLite cannot drop a
+-- constraint in place, hence the table rebuild below, done now while `docs` is
+-- small — the rebuild copies every row, so its cost only grows.
+--
+-- What that foreign key used to guarantee, no doc without a publisher row we had
+-- validated, is now the auth path's job alone. No version of this design keeps
+-- it as a database constraint.
+
+-- The resolved account id, cached beside the plan on the row that already caches
+-- license validation. Null while the license server does not return one — which
+-- is every row on the day this ships, since that field does not exist yet.
+-- `Publisher.owner` falls back to the key hash for those, which is exactly the
+-- behaviour they have now, so nothing observable changes on deploy and this can
+-- land before the license server catches up.
+ALTER TABLE publishers ADD COLUMN owner TEXT;
+
+-- `versions.doc_id` cascades on delete from `docs`, so the version log is moved
+-- aside before `docs` is dropped — dropping the parent with that child still
+-- attached would take every version row with it. Rebuilding `versions` at the
+-- end is also what re-points its foreign key at the new table.
+CREATE TABLE versions_carry (
+  doc_id     TEXT    NOT NULL,
+  n          INTEGER NOT NULL,
+  size       INTEGER NOT NULL,
+  title      TEXT,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO versions_carry (doc_id, n, size, title, created_at)
+  SELECT doc_id, n, size, title, created_at FROM versions;
+DROP TABLE versions;
+
+CREATE TABLE docs_new (
+  id             TEXT    PRIMARY KEY,
+  -- An app-sites `User.id`, or the SHA-256 of a license key for a doc published
+  -- before account ids were available. Opaque either way: no query interprets
+  -- it, and none should start.
+  owner          TEXT    NOT NULL,
+  title          TEXT    NOT NULL,
+  latest_version INTEGER NOT NULL DEFAULT 0,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL,
+  deleted_at     INTEGER
+);
+INSERT INTO docs_new (id, owner, title, latest_version, created_at, updated_at, deleted_at)
+  SELECT id, publisher, title, latest_version, created_at, updated_at, deleted_at FROM docs;
+DROP TABLE docs;
+ALTER TABLE docs_new RENAME TO docs;
+
+-- Unchanged in shape from `docs_by_publisher_live`, which went with the old
+-- table: it still supplies both the filter and the ordering for the keyset walk
+-- in `listPublisherDocs`, and is still partial so soft-deleted docs cost nothing.
+CREATE INDEX docs_by_owner_live
+  ON docs (owner, created_at DESC, id DESC)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE versions (
+  doc_id     TEXT    NOT NULL REFERENCES docs(id) ON DELETE CASCADE,
+  n          INTEGER NOT NULL,
+  size       INTEGER NOT NULL,
+  title      TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (doc_id, n)
+);
+INSERT INTO versions (doc_id, n, size, title, created_at)
+  SELECT doc_id, n, size, title, created_at FROM versions_carry;
+DROP TABLE versions_carry;
+
+-- The daily push counter is keyed on the same id, so it follows the same rename.
+-- A plain rename rather than a rebuild: nothing references this table.
+ALTER TABLE push_quota RENAME COLUMN publisher TO owner;

--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -92,7 +92,7 @@ export async function deleteDoc(
   // An id that cannot exist is answered without touching D1.
   if (!isDocId(docId)) return docNotFound(docId);
 
-  if (!(await softDeleteDoc(env.DB, docId, publisher.id, Date.now()))) {
+  if (!(await softDeleteDoc(env.DB, docId, publisher.owner, Date.now()))) {
     return docNotFound(docId);
   }
 
@@ -220,7 +220,7 @@ export async function listDocs(
     );
   }
 
-  const rows = await listPublisherDocs(env.DB, publisher.id, after, limit + 1);
+  const rows = await listPublisherDocs(env.DB, publisher.owner, after, limit + 1);
   const page = rows.slice(0, limit);
 
   const body: ListResponse = {

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -229,7 +229,7 @@ export async function createDoc(
     env.DB,
     {
       id: docId,
-      publisher: publisher.id,
+      owner: publisher.owner,
       title,
       created_at: now,
       updated_at: now,
@@ -244,7 +244,7 @@ export async function createDoc(
   }
 
   const day = utcDay(now);
-  if (!(await reserveDailyPush(env.DB, publisher.id, day))) {
+  if (!(await reserveDailyPush(env.DB, publisher.owner, day))) {
     await deleteDocRow(env.DB, docId);
     return dailyQuotaExceeded();
   }
@@ -255,7 +255,7 @@ export async function createDoc(
   // that loses that race — the doc is gone, and the push is given back rather
   // than spent on a url that would serve 410.
   if (!(await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now))) {
-    await refundDailyPush(env.DB, publisher.id, day);
+    await refundDailyPush(env.DB, publisher.owner, day);
     return docNotFound(docId);
   }
   return pushed(env, requestUrl, docId, FIRST_VERSION, 201);
@@ -278,22 +278,22 @@ export async function updateDoc(
   // so it must not spend one of today's. `reserveNextVersion` re-checks both
   // atomically, which is what actually guarantees it — this read only fixes
   // which error a rejected push gets.
-  if (!(await ownsLiveDoc(env.DB, docId, publisher.id))) {
+  if (!(await ownsLiveDoc(env.DB, docId, publisher.owner))) {
     return docNotFound(docId);
   }
 
   const now = Date.now();
   const day = utcDay(now);
-  if (!(await reserveDailyPush(env.DB, publisher.id, day))) {
+  if (!(await reserveDailyPush(env.DB, publisher.owner, day))) {
     return dailyQuotaExceeded();
   }
 
   // Past this point the push is paid for, and a delete can still land at either
   // of the two steps below. Both give the push back: a rejected push costs the
   // caller nothing, which is the same promise the ownership check above makes.
-  const version = await reserveNextVersion(env.DB, docId, publisher.id);
+  const version = await reserveNextVersion(env.DB, docId, publisher.owner);
   if (version === null) {
-    await refundDailyPush(env.DB, publisher.id, day);
+    await refundDailyPush(env.DB, publisher.owner, day);
     return docNotFound(docId);
   }
 
@@ -306,7 +306,7 @@ export async function updateDoc(
   // 200 would hand back a url that serves 410, so a lost race reads as what it
   // is from the caller's side: the doc is gone.
   if (!(await storeVersion(env, docId, version, parsed.body.html, title, now))) {
-    await refundDailyPush(env.DB, publisher.id, day);
+    await refundDailyPush(env.DB, publisher.owner, day);
     return docNotFound(docId);
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -338,16 +338,11 @@ async function validateLicense(token: string, env: Env, deps: AuthDeps): Promise
  * ownership stays on the key hash, where the worst case is a shelf that looks
  * like today's.
  *
- * `authUserId` is the column name in app-sites (`LicenseKeyConfig`); `userId` is
- * accepted too so the license server can name the field either way without a
- * lockstep release here.
+ * `authUserId` after the app-sites column that holds it, `LicenseKeyConfig`.
  */
 function readOwner(payload: Record<string, unknown>): string | null {
-  for (const field of ["authUserId", "userId"]) {
-    const value = payload[field];
-    if (typeof value === "string" && value.trim() !== "") return value;
-  }
-  return null;
+  const value = payload.authUserId;
+  return typeof value === "string" && value.trim() !== "" ? value : null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,12 +1,17 @@
 /**
  * Publisher authentication.
  *
- * A publisher is a Copilot Plus license key, and the only identifier the rest of
- * the system ever sees is that key's SHA-256 (D2). The raw key exists inside this
- * module for exactly as long as it takes to hash it and hand it to the license
- * server — it is never stored, logged, or returned, not even a prefix of it.
- * Everything downstream depends on `Publisher.id`, so swapping in a free-tier
- * identity later means adding a branch here and touching nothing else.
+ * A publisher presents a Copilot Plus license key, and the only identifier the
+ * rest of the system ever sees is that key's SHA-256 (D2). The raw key exists
+ * inside this module for exactly as long as it takes to hash it and hand it to
+ * the license server — it is never stored, logged, or returned, not even a
+ * prefix of it.
+ *
+ * The key identifies a *credential*; `Publisher.owner` identifies whose
+ * documents it publishes, and every doc query keys off that. Today the license
+ * server resolves it to an app-sites `User.id`, and to the key's own hash when
+ * it names none. Nothing downstream reads the value, so a different identity —
+ * a free tier, a dashboard session — is a branch here and nothing else.
  *
  * This module answers *who*, never *may they*. The plan rides along on the
  * resolved publisher and the router decides what it entitles them to, because
@@ -77,8 +82,19 @@ export const INELIGIBLE_PLAN: { reason: PublisherFailure; message: string } = {
 };
 
 export interface Publisher {
-  /** SHA-256 hex of the license key. The only publisher identity in the system. */
+  /** SHA-256 hex of the license key. Identifies the *credential*, not the person. */
   id: string;
+  /**
+   * Who owns the documents this key publishes: the app-sites `User.id` the
+   * license server named, or the key's own hash while it names none. Every doc
+   * query keys off this, never off `id` — that is what makes two keys on one
+   * account see one shelf, and what lets a dashboard session find the same docs
+   * from `session.user.id` alone.
+   *
+   * The fallback is why this ships before the license server returns the field:
+   * with no account id anywhere, every key owns exactly what it owns today.
+   */
+  owner: string;
   plan: string;
 }
 
@@ -147,20 +163,25 @@ export async function resolvePublisher(
   const checkedAt = now();
 
   if (cached && checkedAt - cached.validated_at < LICENSE_CACHE_TTL_MS) {
-    return { ok: true, publisher: { id, plan: cached.plan } };
+    return { ok: true, publisher: { id, owner: cached.owner ?? id, plan: cached.plan } };
   }
 
   const check = await validateLicense(token, env, deps);
 
   switch (check.status) {
-    case "valid":
-      await store.save({ key_hash: id, plan: check.plan, validated_at: checkedAt });
-      return { ok: true, publisher: { id, plan: check.plan } };
+    case "valid": {
+      // A fresh answer wins, but a fresh answer that named no account must not
+      // discard one we already had — the same asymmetry `save` encodes, applied
+      // to what this request goes on to use.
+      const owner = check.owner ?? cached?.owner ?? null;
+      await store.save({ key_hash: id, plan: check.plan, validated_at: checkedAt, owner });
+      return { ok: true, publisher: { id, owner: owner ?? id, plan: check.plan } };
+    }
 
     case "denied":
       // Deliberately no row write and no row delete: a previously valid key that
-      // has since lapsed keeps its `publishers` row, because `docs.publisher`
-      // still references it. It just stops resolving.
+      // has since lapsed keeps its `publishers` row: it is the only record of
+      // which account their documents belong to. It just stops resolving.
       return {
         ok: false,
         reason: "invalid_license",
@@ -172,8 +193,9 @@ export async function resolvePublisher(
         // Stale but real. An outage must not lock out a publisher who has
         // published before. The plan rides along, so a publisher downgraded
         // since their last successful validation loses publishing here too
-        // while keeping list and delete.
-        return { ok: true, publisher: { id, plan: cached.plan } };
+        // while keeping list and delete. So does the owner, which is what keeps
+        // an outage from showing them somebody else's shelf — or an empty one.
+        return { ok: true, publisher: { id, owner: cached.owner ?? id, plan: cached.plan } };
       }
       return {
         ok: false,
@@ -206,7 +228,17 @@ export function publisherErrorResponse(failure: {
 }
 
 type LicenseCheck =
-  | { status: "valid"; plan: string }
+  | {
+      status: "valid";
+      plan: string;
+      /**
+       * The app-sites `User.id` behind the key (`LicenseKeyConfig.authUserId`),
+       * or null when the server does not name one — which is every response
+       * until that field is added there. Null is not a failure: it means
+       * ownership stays on the key hash, exactly as it is today.
+       */
+      owner: string | null;
+    }
   | { status: "denied" }
   | { status: "unreachable" };
 
@@ -294,7 +326,28 @@ async function validateLicense(token: string, env: Env, deps: AuthDeps): Promise
   // The plan is carried, never judged here. `UNKNOWN_PLAN` is not in
   // PUBLISHING_PLANS, so a response whose plan we cannot read authenticates but
   // cannot publish — the safe direction.
-  return { status: "valid", plan };
+  return { status: "valid", plan, owner: readOwner(payload) };
+}
+
+/**
+ * The account id from a validation response, or null when it names none.
+ *
+ * Blank is treated as absent rather than as an owner: an empty string would be a
+ * single shared owner id that every key with a misconfigured response falls
+ * into, which is one publisher seeing another's documents. Null instead means
+ * ownership stays on the key hash, where the worst case is a shelf that looks
+ * like today's.
+ *
+ * `authUserId` is the column name in app-sites (`LicenseKeyConfig`); `userId` is
+ * accepted too so the license server can name the field either way without a
+ * lockstep release here.
+ */
+function readOwner(payload: Record<string, unknown>): string | null {
+  for (const field of ["authUserId", "userId"]) {
+    const value = payload[field];
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,10 +8,10 @@
  * prefix of it.
  *
  * The key identifies a *credential*; `Publisher.owner` identifies whose
- * documents it publishes, and every doc query keys off that. Today the license
- * server resolves it to an app-sites `User.id`, and to the key's own hash when
- * it names none. Nothing downstream reads the value, so a different identity —
- * a free tier, a dashboard session — is a branch here and nothing else.
+ * documents it publishes, and every doc query keys off that. The license server
+ * resolves one to the other, returning the app-sites `User.id` that owns the
+ * key. Nothing downstream reads the value, so a different identity — a free
+ * tier, a dashboard session — is a branch here and nothing else.
  *
  * This module answers *who*, never *may they*. The plan rides along on the
  * resolved publisher and the router decides what it entitles them to, because
@@ -82,17 +82,14 @@ export const INELIGIBLE_PLAN: { reason: PublisherFailure; message: string } = {
 };
 
 export interface Publisher {
-  /** SHA-256 hex of the license key. Identifies the *credential*, not the person. */
-  id: string;
   /**
-   * Who owns the documents this key publishes: the app-sites `User.id` the
-   * license server named, or the key's own hash while it names none. Every doc
-   * query keys off this, never off `id` — that is what makes two keys on one
-   * account see one shelf, and what lets a dashboard session find the same docs
-   * from `session.user.id` alone.
+   * The app-sites `User.id` whose documents these are. Every doc query keys off
+   * it, which is what makes two keys on one account see one shelf and lets a
+   * symposium.md session find the same documents from `session.user.id` alone.
    *
-   * The fallback is why this ships before the license server returns the field:
-   * with no account id anywhere, every key owns exactly what it owns today.
+   * The license key itself appears nowhere outside this module: it identifies a
+   * credential, and nothing downstream has any business knowing which one was
+   * used.
    */
   owner: string;
   plan: string;
@@ -163,25 +160,26 @@ export async function resolvePublisher(
   const checkedAt = now();
 
   if (cached && checkedAt - cached.validated_at < LICENSE_CACHE_TTL_MS) {
-    return { ok: true, publisher: { id, owner: cached.owner ?? id, plan: cached.plan } };
+    return { ok: true, publisher: { owner: cached.owner, plan: cached.plan } };
   }
 
   const check = await validateLicense(token, env, deps);
 
   switch (check.status) {
-    case "valid": {
-      // A fresh answer wins, but a fresh answer that named no account must not
-      // discard one we already had — the same asymmetry `save` encodes, applied
-      // to what this request goes on to use.
-      const owner = check.owner ?? cached?.owner ?? null;
-      await store.save({ key_hash: id, plan: check.plan, validated_at: checkedAt, owner });
-      return { ok: true, publisher: { id, owner: owner ?? id, plan: check.plan } };
-    }
+    case "valid":
+      await store.save({
+        key_hash: id,
+        plan: check.plan,
+        validated_at: checkedAt,
+        owner: check.owner,
+      });
+      return { ok: true, publisher: { owner: check.owner, plan: check.plan } };
 
     case "denied":
-      // Deliberately no row write and no row delete: a previously valid key that
-      // has since lapsed keeps its `publishers` row: it is the only record of
-      // which account their documents belong to. It just stops resolving.
+      // Deliberately no row write and no row delete. A previously valid key that
+      // has since lapsed keeps its `publishers` row — that row is what an
+      // outage falls back to, and throwing it away would turn a revoked key
+      // into a lost account. It simply stops resolving.
       return {
         ok: false,
         reason: "invalid_license",
@@ -193,9 +191,8 @@ export async function resolvePublisher(
         // Stale but real. An outage must not lock out a publisher who has
         // published before. The plan rides along, so a publisher downgraded
         // since their last successful validation loses publishing here too
-        // while keeping list and delete. So does the owner, which is what keeps
-        // an outage from showing them somebody else's shelf — or an empty one.
-        return { ok: true, publisher: { id, owner: cached.owner ?? id, plan: cached.plan } };
+        // while keeping list and delete.
+        return { ok: true, publisher: { owner: cached.owner, plan: cached.plan } };
       }
       return {
         ok: false,
@@ -232,12 +229,11 @@ type LicenseCheck =
       status: "valid";
       plan: string;
       /**
-       * The app-sites `User.id` behind the key (`LicenseKeyConfig.authUserId`),
-       * or null when the server does not name one — which is every response
-       * until that field is added there. Null is not a failure: it means
-       * ownership stays on the key hash, exactly as it is today.
+       * The app-sites `User.id` behind the key, which the license server returns
+       * as `accountId`. Never null: a response that names no account does not
+       * reach here — see `validateLicense`.
        */
-      owner: string | null;
+      owner: string;
     }
   | { status: "denied" }
   | { status: "unreachable" };
@@ -322,28 +318,26 @@ async function validateLicense(token: string, env: Env, deps: AuthDeps): Promise
 
   // The server plan is an uppercase enum (`PLUS`, `BELIEVER`); store it folded
   // so nothing downstream has to guess the casing, as the reference does too.
+  // The account that owns the key, which the license server sends as
+  // `accountId`. Unlike the plan, this cannot degrade to a placeholder: it is
+  // the identity every document is filed under, so a response we cannot read it
+  // from is a response we cannot act on. Blank counts as unreadable — an empty
+  // string would be one shared owner that every such key falls into, which is
+  // one publisher reading another's documents.
+  //
+  // `unreachable`, not `denied`: the key may be perfectly good and the fault
+  // ours, so this lands on the cached-validation path and answers 500 rather
+  // than telling a paying customer their key is bad.
+  const owner = payload.accountId;
+  if (typeof owner !== "string" || owner.trim() === "") return UNREACHABLE;
+
   const plan = typeof payload.plan === "string" ? payload.plan.toLowerCase() : UNKNOWN_PLAN;
   // The plan is carried, never judged here. `UNKNOWN_PLAN` is not in
   // PUBLISHING_PLANS, so a response whose plan we cannot read authenticates but
   // cannot publish — the safe direction.
-  return { status: "valid", plan, owner: readOwner(payload) };
+  return { status: "valid", plan, owner };
 }
 
-/**
- * The account id from a validation response, or null when it names none.
- *
- * Blank is treated as absent rather than as an owner: an empty string would be a
- * single shared owner id that every key with a misconfigured response falls
- * into, which is one publisher seeing another's documents. Null instead means
- * ownership stays on the key hash, where the worst case is a shelf that looks
- * like today's.
- *
- * `authUserId` after the app-sites column that holds it, `LicenseKeyConfig`.
- */
-function readOwner(payload: Record<string, unknown>): string | null {
-  const value = payload.authUserId;
-  return typeof value === "string" && value.trim() !== "" ? value : null;
-}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,5 @@
 /**
- * Row types for the D1 pointer index, one per table in 0001_init.sql.
+ * Row types for the D1 pointer index, one per table in `migrations/`.
  *
  * D1 holds pointers only — ids, sizes, timestamps. The bytes live in R2, and
  * every row here is reconstructible from it, so a lost D1 is a rebuild rather
@@ -13,12 +13,22 @@ export interface PublisherRow {
   plan: string;
   /** Epoch ms of the last successful license-server validation. */
   validated_at: number;
+  /**
+   * The app-sites `User.id` this key belongs to, cached from the last
+   * validation. Null while the license server returns none; `Publisher.owner`
+   * falls back to the key hash for those.
+   */
+  owner: string | null;
 }
 
 export interface DocRow {
   id: string;
-  /** `publishers.key_hash` of the owner. */
-  publisher: string;
+  /**
+   * An app-sites `User.id`, or the SHA-256 of a license key for a doc published
+   * before account ids were available. Opaque — only ever compared for equality,
+   * which is what lets the identity behind it change freely.
+   */
+  owner: string;
   title: string;
   /**
    * Highest version number *reserved*; 0 before the first push lands.
@@ -47,7 +57,8 @@ export interface VersionRow {
 }
 
 export interface PushQuotaRow {
-  publisher: string;
+  /** The owner id from `docs.owner`, so the ceiling follows the documents. */
+  owner: string;
   /** UTC day, `YYYY-MM-DD`. */
   day: string;
   pushes: number;
@@ -70,21 +81,27 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
   return {
     read(keyHash) {
       return db
-        .prepare("SELECT key_hash, plan, validated_at FROM publishers WHERE key_hash = ?")
+        .prepare("SELECT key_hash, plan, validated_at, owner FROM publishers WHERE key_hash = ?")
         .bind(keyHash)
         .first<PublisherRow>();
     },
 
-    // `docs.publisher` is a foreign key onto this table, so this upsert is also
-    // what guarantees a row exists before the first push inserts a doc.
+    // A resolved `owner` overwrites the cached one, so a key reassigned to
+    // another account lands here on the next validation with no migration step.
+    // A *missing* one does not: `COALESCE` keeps what we already knew. The
+    // difference matters because the two are not the same event — a license
+    // server that has stopped returning account ids, or a response we could not
+    // read, would otherwise silently move every doc back under the key hash and
+    // empty the publisher's shelf.
     async save(row) {
       await db
         .prepare(
-          `INSERT INTO publishers (key_hash, plan, validated_at) VALUES (?, ?, ?)
+          `INSERT INTO publishers (key_hash, plan, validated_at, owner) VALUES (?, ?, ?, ?)
            ON CONFLICT(key_hash) DO UPDATE SET plan = excluded.plan,
-                                               validated_at = excluded.validated_at`,
+                                               validated_at = excluded.validated_at,
+                                               owner = COALESCE(excluded.owner, publishers.owner)`,
         )
-        .bind(row.key_hash, row.plan, row.validated_at)
+        .bind(row.key_hash, row.plan, row.validated_at, row.owner)
         .run();
     },
   };
@@ -104,12 +121,13 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
  * ceiling firing concurrent creates would otherwise have every one of them read
  * the same count and every one of them insert. A quota documented as a hard
  * number has to behave like one under the concurrency an agent produces.
- * `docs_by_publisher_live` covers the subquery, so it is an index scan of only
- * this publisher's live rows.
+ * `docs_by_owner_live` covers the subquery, so it is an index scan of only this
+ * owner's live rows.
  *
- * `publisher` is a foreign key onto `publishers`, so this fails unless auth has
- * already written that row. That is the intended coupling: no doc without a
- * publisher we validated.
+ * `owner` used to be a foreign key onto `publishers`, which made "no doc without
+ * a publisher we validated" a database constraint. It cannot be one any more —
+ * a `User.id` has no `publishers` row to point at — so that invariant now rests
+ * entirely on auth having resolved a publisher before this is reached.
  */
 export async function insertDocWithinQuota(
   db: D1Database,
@@ -118,18 +136,18 @@ export async function insertDocWithinQuota(
 ): Promise<boolean> {
   const result = await db
     .prepare(
-      `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+      `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
        SELECT ?, ?, ?, ?, ?, ?
-        WHERE (SELECT COUNT(*) FROM docs WHERE publisher = ? AND deleted_at IS NULL) < ?`,
+        WHERE (SELECT COUNT(*) FROM docs WHERE owner = ? AND deleted_at IS NULL) < ?`,
     )
     .bind(
       doc.id,
-      doc.publisher,
+      doc.owner,
       doc.title,
       FIRST_VERSION,
       doc.created_at,
       doc.updated_at,
-      doc.publisher,
+      doc.owner,
       maxDocs,
     )
     .run();
@@ -195,16 +213,16 @@ export async function deleteVersionRow(
 export async function reserveNextVersion(
   db: D1Database,
   docId: string,
-  publisher: string,
+  owner: string,
 ): Promise<number | null> {
   const reserved = await db
     .prepare(
       `UPDATE docs
           SET latest_version = latest_version + 1
-        WHERE id = ? AND publisher = ? AND deleted_at IS NULL
+        WHERE id = ? AND owner = ? AND deleted_at IS NULL
         RETURNING latest_version`,
     )
-    .bind(docId, publisher)
+    .bind(docId, owner)
     .first<{ latest_version: number }>();
 
   return reserved?.latest_version ?? null;
@@ -329,7 +347,7 @@ export async function findServableVersion(
 }
 
 /**
- * Whether this publisher owns a live doc with that id — the same conflation of
+ * Whether this owner has a live doc with that id — the same conflation of
  * "missing", "someone else's" and "deleted" that `reserveNextVersion` makes,
  * for the same reason, and answered identically for all three so the shape of
  * the reply cannot confirm another publisher's doc exists.
@@ -337,11 +355,11 @@ export async function findServableVersion(
 export async function ownsLiveDoc(
   db: D1Database,
   docId: string,
-  publisher: string,
+  owner: string,
 ): Promise<boolean> {
   const row = await db
-    .prepare("SELECT 1 FROM docs WHERE id = ? AND publisher = ? AND deleted_at IS NULL")
-    .bind(docId, publisher)
+    .prepare("SELECT 1 FROM docs WHERE id = ? AND owner = ? AND deleted_at IS NULL")
+    .bind(docId, owner)
     .first();
 
   return row !== null;
@@ -364,17 +382,17 @@ export async function ownsLiveDoc(
 export async function softDeleteDoc(
   db: D1Database,
   docId: string,
-  publisher: string,
+  owner: string,
   atMs: number,
 ): Promise<boolean> {
   const deleted = await db
     .prepare(
       `UPDATE docs
           SET deleted_at = ?
-        WHERE id = ? AND publisher = ? AND deleted_at IS NULL
+        WHERE id = ? AND owner = ? AND deleted_at IS NULL
         RETURNING id`,
     )
-    .bind(atMs, docId, publisher)
+    .bind(atMs, docId, owner)
     .first<{ id: string }>();
 
   return deleted !== null;
@@ -407,10 +425,10 @@ export interface DocListCursor {
 }
 
 /**
- * A page of one publisher's live docs, newest first.
+ * A page of one owner's live docs, newest first.
  *
- * Keyset, not OFFSET. The `docs_by_publisher_live` partial index is
- * `(publisher, created_at DESC, id DESC)`, and it supplies both the filter and
+ * Keyset, not OFFSET. The `docs_by_owner_live` partial index is
+ * `(owner, created_at DESC, id DESC)`, and it supplies both the filter and
  * the ordering, so no page is ever sorted in a temp b-tree. It is also the only
  * paging that stays correct while the publisher keeps pushing: OFFSET renumbers
  * the moment a newer doc appears, so a doc would shift onto a page the caller
@@ -423,8 +441,8 @@ export interface DocListCursor {
  * The resume predicate is a row-value comparison rather than the expanded
  * `a < ? OR (a = ? AND b < ?)`. The two mean the same thing, but only the row
  * value becomes an index range constraint — `EXPLAIN QUERY PLAN` shows
- * `(publisher=? AND (created_at,id)<(?,?))` against the expanded form's
- * `(publisher=?)`, which walks from the newest doc and discards rows until it
+ * `(owner=? AND (created_at,id)<(?,?))` against the expanded form's
+ * `(owner=?)`, which walks from the newest doc and discards rows until it
  * passes the cursor. Both are correct; one seeks.
  *
  * The two statements differ only in that predicate. Written out rather than
@@ -433,7 +451,7 @@ export interface DocListCursor {
  */
 export async function listPublisherDocs(
   db: D1Database,
-  publisher: string,
+  owner: string,
   after: DocListCursor | null,
   limit: number,
 ): Promise<DocListRow[]> {
@@ -447,18 +465,18 @@ export async function listPublisherDocs(
       ? db
           .prepare(
             `SELECT ${columns} FROM docs d
-              WHERE d.publisher = ? AND d.deleted_at IS NULL
+              WHERE d.owner = ? AND d.deleted_at IS NULL
               ${order}`,
           )
-          .bind(publisher, limit)
+          .bind(owner, limit)
       : db
           .prepare(
             `SELECT ${columns} FROM docs d
-              WHERE d.publisher = ? AND d.deleted_at IS NULL
+              WHERE d.owner = ? AND d.deleted_at IS NULL
                 AND (d.created_at, d.id) < (?, ?)
               ${order}`,
           )
-          .bind(publisher, after.created_at, after.id, limit);
+          .bind(owner, after.created_at, after.id, limit);
 
   return (await statement.all<DocListRow>()).results;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -78,9 +78,11 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
         .first<PublisherRow>();
     },
 
-    // `owner` is refreshed like `plan` is: both describe the account behind the
-    // key, so a key reassigned to another account follows it on the next
-    // validation without a migration step.
+    // `owner` is written on every validation, like `plan` is. That is a refresh,
+    // not a transfer: a license key's `authUserId` is set when the key is
+    // created and never updated in app-sites, so the value cannot change under
+    // us. If key transfer is ever added there, this cache becomes a hole — see
+    // the note in `docs/identity.md`.
     async save(row) {
       await db
         .prepare(

--- a/src/db.ts
+++ b/src/db.ts
@@ -13,21 +13,13 @@ export interface PublisherRow {
   plan: string;
   /** Epoch ms of the last successful license-server validation. */
   validated_at: number;
-  /**
-   * The app-sites `User.id` this key belongs to, cached from the last
-   * validation. Null while the license server returns none; `Publisher.owner`
-   * falls back to the key hash for those.
-   */
-  owner: string | null;
+  /** The app-sites `User.id` this key belongs to. */
+  owner: string;
 }
 
 export interface DocRow {
   id: string;
-  /**
-   * An app-sites `User.id`, or the SHA-256 of a license key for a doc published
-   * before account ids were available. Opaque — only ever compared for equality,
-   * which is what lets the identity behind it change freely.
-   */
+  /** The app-sites `User.id` that owns the doc. */
   owner: string;
   title: string;
   /**
@@ -86,20 +78,16 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
         .first<PublisherRow>();
     },
 
-    // A resolved `owner` overwrites the cached one, so a key reassigned to
-    // another account lands here on the next validation with no migration step.
-    // A *missing* one does not: `COALESCE` keeps what we already knew. The
-    // difference matters because the two are not the same event — a license
-    // server that has stopped returning account ids, or a response we could not
-    // read, would otherwise silently move every doc back under the key hash and
-    // empty the publisher's shelf.
+    // `owner` is refreshed like `plan` is: both describe the account behind the
+    // key, so a key reassigned to another account follows it on the next
+    // validation without a migration step.
     async save(row) {
       await db
         .prepare(
           `INSERT INTO publishers (key_hash, plan, validated_at, owner) VALUES (?, ?, ?, ?)
            ON CONFLICT(key_hash) DO UPDATE SET plan = excluded.plan,
                                                validated_at = excluded.validated_at,
-                                               owner = COALESCE(excluded.owner, publishers.owner)`,
+                                               owner = excluded.owner`,
         )
         .bind(row.key_hash, row.plan, row.validated_at, row.owner)
         .run();
@@ -124,10 +112,10 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
  * `docs_by_owner_live` covers the subquery, so it is an index scan of only this
  * owner's live rows.
  *
- * `owner` used to be a foreign key onto `publishers`, which made "no doc without
- * a publisher we validated" a database constraint. It cannot be one any more —
- * a `User.id` has no `publishers` row to point at — so that invariant now rests
- * entirely on auth having resolved a publisher before this is reached.
+ * `owner` is not a foreign key onto `publishers`: that table is keyed by license
+ * key, and an account is not one. "No doc without a publisher we validated" is
+ * therefore the auth path's invariant rather than the database's — only a
+ * resolved publisher reaches this.
  */
 export async function insertDocWithinQuota(
   db: D1Database,

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -94,17 +94,17 @@ export function utcDay(atMs: number): string {
  */
 export async function reserveDailyPush(
   db: D1Database,
-  publisher: string,
+  owner: string,
   day: string,
 ): Promise<boolean> {
   const claimed = await db
     .prepare(
-      `INSERT INTO push_quota (publisher, day, pushes) VALUES (?, ?, 1)
-       ON CONFLICT(publisher, day) DO UPDATE SET pushes = push_quota.pushes + 1
+      `INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, 1)
+       ON CONFLICT(owner, day) DO UPDATE SET pushes = push_quota.pushes + 1
          WHERE push_quota.pushes < ?
        RETURNING pushes`,
     )
-    .bind(publisher, day, MAX_PUSHES_PER_DAY)
+    .bind(owner, day, MAX_PUSHES_PER_DAY)
     .first<{ pushes: number }>();
 
   return claimed !== null;
@@ -129,14 +129,14 @@ export async function reserveDailyPush(
  */
 export async function refundDailyPush(
   db: D1Database,
-  publisher: string,
+  owner: string,
   day: string,
 ): Promise<void> {
   await db
     .prepare(
       `UPDATE push_quota SET pushes = pushes - 1
-        WHERE publisher = ? AND day = ? AND pushes > 0`,
+        WHERE owner = ? AND day = ? AND pushes > 0`,
     )
-    .bind(publisher, day)
+    .bind(owner, day)
     .run();
 }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -59,7 +59,7 @@ const validatedAt = (msAgo: number): PublisherRow => ({
   key_hash: KEY_HASH,
   plan: "believer",
   validated_at: NOW - msAgo,
-  owner: null,
+  owner: ACCOUNT,
 });
 
 interface LicenseStub {
@@ -96,7 +96,13 @@ const trpcError = (code: string, httpStatus: number) => () =>
     { status: httpStatus },
   );
 
-const validBeliever = answers({ isValid: true, plan: "believer", backendAccess: true });
+/** A full valid response, shaped as the license server actually sends one. */
+const validBeliever = answers({
+  isValid: true,
+  plan: "believer",
+  backendAccess: true,
+  accountId: ACCOUNT,
+});
 
 const headerOf = (init: RequestInit, name: string) =>
   new Headers(init.headers as HeadersInit).get(name);
@@ -125,7 +131,7 @@ describe("parseBearerToken", () => {
 });
 
 describe("resolvePublisher — a valid key", () => {
-  it("resolves to the key's SHA-256 and caches the validation", async () => {
+  it("resolves to the account the license server names, and caches it", async () => {
     const store = memoryStore();
     const license = licenseServer(validBeliever);
 
@@ -133,49 +139,41 @@ describe("resolvePublisher — a valid key", () => {
 
     expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+      publisher: { owner: ACCOUNT, plan: "believer" },
     });
     expect(license.calls).toHaveLength(1);
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
       plan: "believer",
       validated_at: NOW,
-      owner: null,
+      owner: ACCOUNT,
     });
   });
 
-  it("owns documents by the account the license server names", async () => {
-    const store = memoryStore();
-    const license = licenseServer(
-      answers({ isValid: true, plan: "believer", backendAccess: true, authUserId: ACCOUNT }),
-    );
-
-    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
-
-    expect(result).toEqual({
-      ok: true,
-      publisher: { id: KEY_HASH, owner: ACCOUNT, plan: "believer" },
-    });
-    expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
-  });
-
-  // A blank id would be a single owner that every misconfigured key falls into,
-  // which is one publisher reading another's shelf. Falling back to the key hash
-  // is the failure that keeps them apart.
+  /**
+   * The account is the identity every document is filed under, so a response we
+   * cannot read it from is one we cannot act on. Refusing beats inventing an
+   * owner: a blank id would be a single owner that every such key falls into,
+   * which is one publisher reading another's documents.
+   *
+   * Refused as *unavailable* rather than as a bad key — the fault is ours, and
+   * the publisher's key may be perfectly good.
+   */
   it.each([
-    ["a blank account id", ""],
-    ["a whitespace account id", "   "],
-    ["a non-string account id", 42],
-  ])("treats %s as none, leaving the key owning its own docs", async (_label, authUserId) => {
+    ["a blank account", ""],
+    ["a whitespace account", "   "],
+    ["a non-string account", 42],
+    ["no account at all", undefined],
+  ])("refuses a response naming %s", async (_label, accountId) => {
     const store = memoryStore();
     const license = licenseServer(
-      answers({ isValid: true, plan: "believer", backendAccess: true, authUserId }),
+      answers({ isValid: true, plan: "believer", backendAccess: true, accountId }),
     );
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
-    expect(result).toMatchObject({ publisher: { id: KEY_HASH, owner: KEY_HASH } });
-    expect(store.rows.get(KEY_HASH)?.owner).toBeNull();
+    expect(result).toMatchObject({ ok: false, reason: "license_unavailable" });
+    expect(store.rows.size).toBe(0);
   });
 
   it("resolves a cached account without asking the license server", async () => {
@@ -185,14 +183,14 @@ describe("resolvePublisher — a valid key", () => {
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
-    expect(result).toMatchObject({ publisher: { id: KEY_HASH, owner: ACCOUNT } });
+    expect(result).toMatchObject({ publisher: { owner: ACCOUNT } });
     expect(license.calls).toHaveLength(0);
   });
 
-  // The regression this guards: a license server that stops returning the field
-  // would otherwise move every doc back under the key hash on the next
-  // validation, and empty the publisher's shelf without an error anywhere.
-  it("keeps a known account when a later validation names none", async () => {
+  // A response with no account is refused rather than acted on, and a refusal
+  // is an outage — so a key that has validated before keeps working, on the
+  // account it already resolved to. Anything else would empty its shelf.
+  it("falls back to the cached account when a later validation names none", async () => {
     const store = memoryStore();
     store.rows.set(KEY_HASH, {
       ...validatedAt(LICENSE_CACHE_TTL_MS + 1),
@@ -237,7 +235,7 @@ describe("resolvePublisher — a valid key", () => {
       store,
       now,
       fetch: licenseServer(
-        answers({ isValid: true, plan: "believer", backendAccess: true, authUserId: moved }),
+        answers({ isValid: true, plan: "believer", backendAccess: true, accountId: moved }),
       ).fetch,
     });
 
@@ -290,12 +288,12 @@ describe("resolvePublisher — a valid key", () => {
     const result = await resolvePublisher(KEY, env(), {
       store,
       now,
-      fetch: licenseServer(answers({ isValid: true, plan: "BELIEVER", backendAccess: true })).fetch,
+      fetch: licenseServer(answers({ isValid: true, plan: "BELIEVER", backendAccess: true, accountId: ACCOUNT })).fetch,
     });
 
     expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+      publisher: { owner: ACCOUNT, plan: "believer" },
     });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("believer");
   });
@@ -304,7 +302,7 @@ describe("resolvePublisher — a valid key", () => {
     const result = await resolvePublisher(KEY, env(), {
       store: memoryStore(),
       now,
-      fetch: licenseServer(answers({ isValid: true, plan: "believer" })).fetch,
+      fetch: licenseServer(answers({ isValid: true, plan: "believer", accountId: ACCOUNT })).fetch,
     });
 
     expect(result.ok).toBe(true);
@@ -320,27 +318,27 @@ describe("resolvePublisher — the one-hour cache", () => {
 
     expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+      publisher: { owner: ACCOUNT, plan: "believer" },
     });
     expect(license.calls).toHaveLength(0);
   });
 
   it("revalidates once the row reaches the TTL, and refreshes the row", async () => {
     const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
-    const license = licenseServer(answers({ isValid: true, plan: "believer", backendAccess: true }));
+    const license = licenseServer(answers({ isValid: true, plan: "believer", backendAccess: true, accountId: ACCOUNT }));
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
     expect(license.calls).toHaveLength(1);
     expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+      publisher: { owner: ACCOUNT, plan: "believer" },
     });
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
       plan: "believer",
       validated_at: NOW,
-      owner: null,
+      owner: ACCOUNT,
     });
   });
 
@@ -366,7 +364,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
     // Nothing is written, so an unauthorized key never gets a publishers row a
-    // later doc insert could hang a foreign key off.
+    // later doc insert records as its owner.
     expect(store.rows.size).toBe(0);
   };
 
@@ -379,7 +377,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
 
   it(
     "denies a valid key without backend access",
-    denied(answers({ isValid: true, plan: "free", backendAccess: false })),
+    denied(answers({ isValid: true, plan: "free", backendAccess: false, accountId: ACCOUNT })),
   );
 
   it(
@@ -398,7 +396,8 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    // The row stays: docs.publisher references it. It simply stops resolving.
+    // The row stays: it is the only record of which account owns the docs.
+    // It simply stops resolving.
     expect(store.rows.get(KEY_HASH)).toEqual(stale);
   });
 
@@ -419,7 +418,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
 });
 
 describe("a plan that may not publish", () => {
-  const validPlus = answers({ isValid: true, plan: "plus", backendAccess: true });
+  const validPlus = answers({ isValid: true, plan: "plus", backendAccess: true, accountId: ACCOUNT });
 
   it("still authenticates — entitlement is not authentication", async () => {
     const store = memoryStore();
@@ -434,7 +433,7 @@ describe("a plan that may not publish", () => {
     // other. What it cannot do is publish, and that is the router's call.
     expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "plus" },
+      publisher: { owner: ACCOUNT, plan: "plus" },
     });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("plus");
   });
@@ -444,7 +443,7 @@ describe("a plan that may not publish", () => {
       store: memoryStore(),
       now,
       // `isValid` is readable, `plan` is not.
-      fetch: licenseServer(answers({ isValid: true, backendAccess: true })).fetch,
+      fetch: licenseServer(answers({ isValid: true, backendAccess: true, accountId: ACCOUNT })).fetch,
     });
 
     expect(result.ok).toBe(true);
@@ -461,7 +460,7 @@ describe("a plan that may not publish", () => {
     // is refreshed like anyone else's and the stale `believer` is gone.
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
-      owner: null,
+      owner: ACCOUNT,
       plan: "plus",
       validated_at: NOW,
     });
@@ -489,7 +488,7 @@ describe("the gate is on publishing, not on the publisher", () => {
   /** A warm row, so auth resolves off the cache and never touches the network. */
   const seeded = (plan: string) => {
     const db = fakeD1();
-    db.rows.set(KEY_HASH, { key_hash: KEY_HASH, plan, validated_at: Date.now(), owner: null });
+    db.rows.set(KEY_HASH, { key_hash: KEY_HASH, plan, validated_at: Date.now(), owner: ACCOUNT });
     return db;
   };
 
@@ -564,7 +563,7 @@ describe("resolvePublisher — the license server is down", () => {
 
       expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+      publisher: { owner: ACCOUNT, plan: "believer" },
     });
     });
 
@@ -638,7 +637,7 @@ describe("authenticateRequest", () => {
 
     expect(result).toEqual({
       ok: true,
-      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+      publisher: { owner: ACCOUNT, plan: "believer" },
     });
   });
 
@@ -685,7 +684,7 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
           key_hash: String(args[0]),
           plan: String(args[1]),
           validated_at: Number(args[2]),
-          owner: args[3] === null ? null : String(args[3]),
+          owner: String(args[3]),
         });
         return { success: true };
       },
@@ -748,7 +747,7 @@ describe("/api/v1 is gated on a publisher", () => {
     // for a publisher holding nothing.
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ docs: [] });
-    // The row every doc insert hangs its foreign key off.
+    // The row every doc insert reads its owner from.
     expect(db.rows.get(KEY_HASH)?.plan).toBe("believer");
   });
 
@@ -763,7 +762,7 @@ describe("/api/v1 is gated on a publisher", () => {
       key_hash: KEY_HASH,
       plan: "believer",
       validated_at: Date.now() - 5 * 60 * 60 * 1000,
-      owner: null,
+      owner: ACCOUNT,
     });
 
     const res = await call(`Bearer ${KEY}`, db);

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -21,6 +21,13 @@ const KEY = "cplus_live_9f4c1a77e0b24d3e";
 /** Computed independently of the implementation. */
 const KEY_HASH = createHash("sha256").update(KEY).digest("hex");
 
+/**
+ * An app-sites `User.id`. Shaped like the real thing — a `gen_random_uuid()`
+ * — and deliberately nothing like a key hash, so an assertion cannot pass by
+ * confusing the two.
+ */
+const ACCOUNT = "e2b7a0c4-1f3d-4a6b-9c8e-2d5f7a1b3c9d";
+
 const NOW = 1_800_000_000_000;
 const now = () => NOW;
 
@@ -52,6 +59,7 @@ const validatedAt = (msAgo: number): PublisherRow => ({
   key_hash: KEY_HASH,
   plan: "believer",
   validated_at: NOW - msAgo,
+  owner: null,
 });
 
 interface LicenseStub {
@@ -123,13 +131,126 @@ describe("resolvePublisher — a valid key", () => {
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
     expect(license.calls).toHaveLength(1);
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
       plan: "believer",
       validated_at: NOW,
+      owner: null,
     });
+  });
+
+  it("owns documents by the account the license server names", async () => {
+    const store = memoryStore();
+    const license = licenseServer(
+      answers({ isValid: true, plan: "believer", backendAccess: true, authUserId: ACCOUNT }),
+    );
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: ACCOUNT, plan: "believer" },
+    });
+    expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
+  });
+
+  it("accepts `userId` as well, so the license server may name the field either way", async () => {
+    const store = memoryStore();
+    const license = licenseServer(
+      answers({ isValid: true, plan: "believer", backendAccess: true, userId: ACCOUNT }),
+    );
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(result).toMatchObject({ publisher: { owner: ACCOUNT } });
+  });
+
+  // A blank id would be a single owner that every misconfigured key falls into,
+  // which is one publisher reading another's shelf. Falling back to the key hash
+  // is the failure that keeps them apart.
+  it.each([
+    ["a blank account id", ""],
+    ["a whitespace account id", "   "],
+    ["a non-string account id", 42],
+  ])("treats %s as none, leaving the key owning its own docs", async (_label, authUserId) => {
+    const store = memoryStore();
+    const license = licenseServer(
+      answers({ isValid: true, plan: "believer", backendAccess: true, authUserId }),
+    );
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(result).toMatchObject({ publisher: { id: KEY_HASH, owner: KEY_HASH } });
+    expect(store.rows.get(KEY_HASH)?.owner).toBeNull();
+  });
+
+  it("resolves a cached account without asking the license server", async () => {
+    const store = memoryStore();
+    store.rows.set(KEY_HASH, { ...validatedAt(0), owner: ACCOUNT });
+    const license = licenseServer(validBeliever);
+
+    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
+
+    expect(result).toMatchObject({ publisher: { id: KEY_HASH, owner: ACCOUNT } });
+    expect(license.calls).toHaveLength(0);
+  });
+
+  // The regression this guards: a license server that stops returning the field
+  // would otherwise move every doc back under the key hash on the next
+  // validation, and empty the publisher's shelf without an error anywhere.
+  it("keeps a known account when a later validation names none", async () => {
+    const store = memoryStore();
+    store.rows.set(KEY_HASH, {
+      ...validatedAt(LICENSE_CACHE_TTL_MS + 1),
+      owner: ACCOUNT,
+    });
+
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(validBeliever).fetch,
+    });
+
+    expect(result).toMatchObject({ publisher: { owner: ACCOUNT } });
+    expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
+  });
+
+  it("keeps a known account through an outage", async () => {
+    const store = memoryStore();
+    store.rows.set(KEY_HASH, {
+      ...validatedAt(LICENSE_CACHE_TTL_MS + 1),
+      owner: ACCOUNT,
+    });
+
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(() => Promise.reject(new Error("down"))).fetch,
+    });
+
+    expect(result).toMatchObject({ publisher: { owner: ACCOUNT } });
+  });
+
+  it("moves the docs when the license server reassigns the key", async () => {
+    const store = memoryStore();
+    store.rows.set(KEY_HASH, {
+      ...validatedAt(LICENSE_CACHE_TTL_MS + 1),
+      owner: ACCOUNT,
+    });
+    const moved = "0f9e8d7c-6b5a-4392-8170-a1b2c3d4e5f6";
+
+    const result = await resolvePublisher(KEY, env(), {
+      store,
+      now,
+      fetch: licenseServer(
+        answers({ isValid: true, plan: "believer", backendAccess: true, authUserId: moved }),
+      ).fetch,
+    });
+
+    expect(result).toMatchObject({ publisher: { owner: moved } });
+    expect(store.rows.get(KEY_HASH)?.owner).toBe(moved);
   });
 
   it("asks the license server with our own credential, not the publisher's key", async () => {
@@ -180,7 +301,7 @@ describe("resolvePublisher — a valid key", () => {
       fetch: licenseServer(answers({ isValid: true, plan: "BELIEVER", backendAccess: true })).fetch,
     });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("believer");
   });
 
@@ -202,7 +323,7 @@ describe("resolvePublisher — the one-hour cache", () => {
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
     expect(license.calls).toHaveLength(0);
   });
 
@@ -213,11 +334,12 @@ describe("resolvePublisher — the one-hour cache", () => {
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
     expect(license.calls).toHaveLength(1);
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
       plan: "believer",
       validated_at: NOW,
+      owner: null,
     });
   });
 
@@ -309,7 +431,7 @@ describe("a plan that may not publish", () => {
 
     // The key is real, so it resolves to a publisher and gets a row like any
     // other. What it cannot do is publish, and that is the router's call.
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "plus" } });
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "plus" } });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("plus");
   });
 
@@ -335,6 +457,7 @@ describe("a plan that may not publish", () => {
     // is refreshed like anyone else's and the stale `believer` is gone.
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
+      owner: null,
       plan: "plus",
       validated_at: NOW,
     });
@@ -362,7 +485,7 @@ describe("the gate is on publishing, not on the publisher", () => {
   /** A warm row, so auth resolves off the cache and never touches the network. */
   const seeded = (plan: string) => {
     const db = fakeD1();
-    db.rows.set(KEY_HASH, { key_hash: KEY_HASH, plan, validated_at: Date.now() });
+    db.rows.set(KEY_HASH, { key_hash: KEY_HASH, plan, validated_at: Date.now(), owner: null });
     return db;
   };
 
@@ -435,7 +558,7 @@ describe("resolvePublisher — the license server is down", () => {
         fetch: licenseServer(reply as () => Response).fetch,
       });
 
-      expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+      expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
     });
 
     it(`refuses an unknown key when ${label}`, async () => {
@@ -506,7 +629,7 @@ describe("authenticateRequest", () => {
       fetch: licenseServer(validBeliever).fetch,
     });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
   });
 
   it("fails on a missing or malformed header without consulting anything", async () => {
@@ -552,6 +675,7 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
           key_hash: String(args[0]),
           plan: String(args[1]),
           validated_at: Number(args[2]),
+          owner: args[3] === null ? null : String(args[3]),
         });
         return { success: true };
       },
@@ -629,6 +753,7 @@ describe("/api/v1 is gated on a publisher", () => {
       key_hash: KEY_HASH,
       plan: "believer",
       validated_at: Date.now() - 5 * 60 * 60 * 1000,
+      owner: null,
     });
 
     const res = await call(`Bearer ${KEY}`, db);

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -223,26 +223,6 @@ describe("resolvePublisher — a valid key", () => {
     expect(result).toMatchObject({ publisher: { owner: ACCOUNT } });
   });
 
-  it("moves the docs when the license server reassigns the key", async () => {
-    const store = memoryStore();
-    store.rows.set(KEY_HASH, {
-      ...validatedAt(LICENSE_CACHE_TTL_MS + 1),
-      owner: ACCOUNT,
-    });
-    const moved = "0f9e8d7c-6b5a-4392-8170-a1b2c3d4e5f6";
-
-    const result = await resolvePublisher(KEY, env(), {
-      store,
-      now,
-      fetch: licenseServer(
-        answers({ isValid: true, plan: "believer", backendAccess: true, accountId: moved }),
-      ).fetch,
-    });
-
-    expect(result).toMatchObject({ publisher: { owner: moved } });
-    expect(store.rows.get(KEY_HASH)?.owner).toBe(moved);
-  });
-
   it("asks the license server with our own credential, not the publisher's key", async () => {
     const license = licenseServer(validBeliever);
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -131,7 +131,10 @@ describe("resolvePublisher — a valid key", () => {
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+    });
     expect(license.calls).toHaveLength(1);
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
@@ -154,17 +157,6 @@ describe("resolvePublisher — a valid key", () => {
       publisher: { id: KEY_HASH, owner: ACCOUNT, plan: "believer" },
     });
     expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
-  });
-
-  it("accepts `userId` as well, so the license server may name the field either way", async () => {
-    const store = memoryStore();
-    const license = licenseServer(
-      answers({ isValid: true, plan: "believer", backendAccess: true, userId: ACCOUNT }),
-    );
-
-    const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
-
-    expect(result).toMatchObject({ publisher: { owner: ACCOUNT } });
   });
 
   // A blank id would be a single owner that every misconfigured key falls into,
@@ -301,7 +293,10 @@ describe("resolvePublisher — a valid key", () => {
       fetch: licenseServer(answers({ isValid: true, plan: "BELIEVER", backendAccess: true })).fetch,
     });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+    });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("believer");
   });
 
@@ -323,7 +318,10 @@ describe("resolvePublisher — the one-hour cache", () => {
 
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+    });
     expect(license.calls).toHaveLength(0);
   });
 
@@ -334,7 +332,10 @@ describe("resolvePublisher — the one-hour cache", () => {
     const result = await resolvePublisher(KEY, env(), { store, now, fetch: license.fetch });
 
     expect(license.calls).toHaveLength(1);
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+    });
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
       plan: "believer",
@@ -431,7 +432,10 @@ describe("a plan that may not publish", () => {
 
     // The key is real, so it resolves to a publisher and gets a row like any
     // other. What it cannot do is publish, and that is the router's call.
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "plus" } });
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "plus" },
+    });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("plus");
   });
 
@@ -558,7 +562,10 @@ describe("resolvePublisher — the license server is down", () => {
         fetch: licenseServer(reply as () => Response).fetch,
       });
 
-      expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
+      expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+    });
     });
 
     it(`refuses an unknown key when ${label}`, async () => {
@@ -629,7 +636,10 @@ describe("authenticateRequest", () => {
       fetch: licenseServer(validBeliever).fetch,
     });
 
-    expect(result).toEqual({ ok: true, publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" } });
+    expect(result).toEqual({
+      ok: true,
+      publisher: { id: KEY_HASH, owner: KEY_HASH, plan: "believer" },
+    });
   });
 
   it("fails on a missing or malformed header without consulting anything", async () => {

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -38,31 +38,28 @@ async function sha256Hex(value: string): Promise<string> {
  * authenticating, so the license cache is warm and no license server is ever
  * reached.
  *
- * `owner` is the account the key belongs to, left null by default so the key
- * owns its own docs: the state every key is in until the license server starts
- * naming accounts. Passing one is how a test says "these two keys are the same
- * person".
- *
- * Returns the owner the key will resolve to, which is what the doc rows will
- * carry — not the key hash, once the two differ.
+ * Each key gets its own account by default; passing one explicitly is how a test
+ * says "these two keys are the same person". Returns that account, which is what
+ * the key's doc rows will carry.
  */
-async function seedPublisher(key: string, owner: string | null = null): Promise<string> {
-  const id = await sha256Hex(key);
+async function seedPublisher(key: string, owner?: string): Promise<string> {
+  const keyHash = await sha256Hex(key);
+  const account = owner ?? `account-${keyHash.slice(0, 8)}`;
   await env.DB.prepare(
     `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
      VALUES (?, 'believer', ?, ?)`,
   )
-    .bind(id, Date.now(), owner)
+    .bind(keyHash, Date.now(), account)
     .run();
-  return owner ?? id;
+  return account;
 }
 
-let publisherA = "";
-let publisherB = "";
+let ownerA = "";
+let ownerB = "";
 
 beforeEach(async () => {
-  publisherA = await seedPublisher(KEY_A);
-  publisherB = await seedPublisher(KEY_B);
+  ownerA = await seedPublisher(KEY_A);
+  ownerB = await seedPublisher(KEY_B);
 });
 
 /** Statuses whose responses may not carry a body, per the Response constructor. */
@@ -164,7 +161,7 @@ const allObjectKeys = async () => (await env.DOCS.list()).objects.map((o) => o.k
  * the millisecond — which is what the cursor's tie-break is about.
  */
 async function seedDoc(
-  publisher: string,
+  owner: string,
   id: string,
   createdAt: number,
   options: { versions?: number } = {},
@@ -174,7 +171,7 @@ async function seedDoc(
     `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?)`,
   )
-    .bind(id, publisher, `seeded ${id}`, versions, createdAt, createdAt)
+    .bind(id, owner, `seeded ${id}`, versions, createdAt, createdAt)
     .run();
 
   for (let n = 1; n <= versions; n++) {
@@ -249,7 +246,7 @@ describe("DELETE /api/v1/docs/{docId}", () => {
   });
 
   it("clears a doc holding more objects than one R2 listing returns", async () => {
-    const docId = await seedDoc(publisherA, seededId(1), Date.now());
+    const docId = await seedDoc(ownerA, seededId(1), Date.now());
     // 100 pushes a day compounds: a long-lived doc outgrows R2's 1000-key
     // listing page, and a delete that read only the first page would leave the
     // rest of the doc sitting in the bucket forever.
@@ -260,7 +257,7 @@ describe("DELETE /api/v1/docs/{docId}", () => {
     // point here, and every other delete test covers the route.
     for (let n = 1; n <= 3; n++) await env.DOCS.put(versionObjectKey(docId, n), "x");
 
-    const publisher: Publisher = { id: publisherA, owner: publisherA, plan: "believer" };
+    const publisher: Publisher = { owner: ownerA, plan: "believer" };
     const response = await deleteDoc(env, publisher, docId, { objectBatch: 2 });
 
     expect(response.status).toBe(204);
@@ -289,7 +286,7 @@ describe("DELETE /api/v1/docs/{docId}", () => {
     });
 
     expect(await docRow(created.docId)).toMatchObject({
-      owner: publisherA,
+      owner: ownerA,
       deleted_at: null,
     });
     expect(await objectKeys(created.docId)).toEqual([versionObjectKey(created.docId, 1)]);
@@ -424,9 +421,9 @@ describe("GET /api/v1/docs", () => {
 
   it("orders newest first", async () => {
     const ids = [3, 1, 2].map((i) => seededId(i));
-    await seedDoc(publisherA, ids[0]!, 3_000);
-    await seedDoc(publisherA, ids[1]!, 1_000);
-    await seedDoc(publisherA, ids[2]!, 2_000);
+    await seedDoc(ownerA, ids[0]!, 3_000);
+    await seedDoc(ownerA, ids[1]!, 1_000);
+    await seedDoc(ownerA, ids[2]!, 2_000);
 
     const body = await listed(await list(KEY_A));
 
@@ -443,7 +440,7 @@ describe("GET /api/v1/docs", () => {
     // The crash artifact push.ts documents: a row with no versions and no
     // object, whose id was never returned to anyone. It still counts against
     // the 500-doc ceiling, so hiding it would make it unclearable.
-    const stranded = await seedDoc(publisherA, seededId(1), Date.now(), { versions: 0 });
+    const stranded = await seedDoc(ownerA, seededId(1), Date.now(), { versions: 0 });
 
     const body = await listed(await list(KEY_A));
 
@@ -452,7 +449,7 @@ describe("GET /api/v1/docs", () => {
   });
 
   it("defaults to 50 docs a page", async () => {
-    for (let i = 1; i <= 51; i++) await seedDoc(publisherA, seededId(i), i);
+    for (let i = 1; i <= 51; i++) await seedDoc(ownerA, seededId(i), i);
 
     const body = await listed(await list(KEY_A));
 
@@ -461,7 +458,7 @@ describe("GET /api/v1/docs", () => {
   });
 
   it("honours a limit, and omits the cursor on the last page", async () => {
-    for (let i = 1; i <= 3; i++) await seedDoc(publisherA, seededId(i), i);
+    for (let i = 1; i <= 3; i++) await seedDoc(ownerA, seededId(i), i);
 
     const first = await listed(await list(KEY_A, "?limit=2"));
     expect(first.docs).toHaveLength(2);
@@ -522,7 +519,7 @@ describe("paging through the list", () => {
   it("yields every doc exactly once, with no duplicates and no gaps", async () => {
     const expected: string[] = [];
     for (let i = 1; i <= 7; i++) {
-      expected.push(await seedDoc(publisherA, seededId(i), 1_000 + i));
+      expected.push(await seedDoc(ownerA, seededId(i), 1_000 + i));
     }
     expected.reverse();
 
@@ -537,14 +534,14 @@ describe("paging through the list", () => {
     // `created_at` alone is not a cursor. Without the id tie-break these five
     // docs would repeat or vanish across page boundaries.
     const ids: string[] = [];
-    for (let i = 1; i <= 5; i++) ids.push(await seedDoc(publisherA, seededId(i), 42));
+    for (let i = 1; i <= 5; i++) ids.push(await seedDoc(ownerA, seededId(i), 42));
     ids.reverse();
 
     expect(await walk(KEY_A, 2)).toEqual(ids);
   });
 
   it("never repeats a doc when a newer one is pushed mid-walk", async () => {
-    for (let i = 1; i <= 4; i++) await seedDoc(publisherA, seededId(i), 1_000 + i);
+    for (let i = 1; i <= 4; i++) await seedDoc(ownerA, seededId(i), 1_000 + i);
 
     const first = await listed(await list(KEY_A, "?limit=2"));
     // OFFSET paging renumbers here and page 2 would re-serve a doc from page 1.
@@ -559,7 +556,7 @@ describe("paging through the list", () => {
   });
 
   it("skips a doc deleted mid-walk and keeps the rest whole", async () => {
-    for (let i = 1; i <= 6; i++) await seedDoc(publisherA, seededId(i), 1_000 + i);
+    for (let i = 1; i <= 6; i++) await seedDoc(ownerA, seededId(i), 1_000 + i);
 
     // Page one takes 6 and 5.
     const first = await listed(await list(KEY_A, "?limit=2"));
@@ -586,8 +583,8 @@ describe("paging through the list", () => {
   });
 
   it("stops walking a publisher's page at their own docs", async () => {
-    for (let i = 1; i <= 4; i++) await seedDoc(publisherA, seededId(i), 1_000 + i);
-    for (let i = 5; i <= 8; i++) await seedDoc(publisherB, seededId(i), 1_000 + i);
+    for (let i = 1; i <= 4; i++) await seedDoc(ownerA, seededId(i), 1_000 + i);
+    for (let i = 5; i <= 8; i++) await seedDoc(ownerB, seededId(i), 1_000 + i);
 
     // B's docs are newer, so a scan that ignored the publisher predicate on the
     // resume step would walk straight into them.
@@ -651,14 +648,14 @@ describe("two keys belonging to one account", () => {
  */
 describe("a publisher whose plan may no longer publish", () => {
   /** Downgrade in place, with the cache left warm so no license server is reached. */
-  const downgrade = (publisher: string) =>
+  const downgrade = async (key: string) =>
     env.DB.prepare("UPDATE publishers SET plan = 'plus', validated_at = ? WHERE key_hash = ?")
-      .bind(Date.now(), publisher)
+      .bind(Date.now(), await sha256Hex(key))
       .run();
 
   it("can still unshare a doc it published while it was entitled", async () => {
     const created = await publish(KEY_A, "Published while entitled");
-    await downgrade(publisherA);
+    await downgrade(KEY_A);
 
     expect((await del(KEY_A, created.docId)).status).toBe(204);
 
@@ -671,7 +668,7 @@ describe("a publisher whose plan may no longer publish", () => {
 
   it("can still list what it has published, which is how it finds what to unshare", async () => {
     const created = await publish(KEY_A, "Still mine");
-    await downgrade(publisherA);
+    await downgrade(KEY_A);
 
     const { docs } = await listed(await list(KEY_A));
 
@@ -679,7 +676,7 @@ describe("a publisher whose plan may no longer publish", () => {
   });
 
   it("cannot publish a new doc", async () => {
-    await downgrade(publisherA);
+    await downgrade(KEY_A);
 
     const response = await send("POST", "/api/v1/docs", KEY_A, { html: page("<p>new</p>") });
 
@@ -695,7 +692,7 @@ describe("a publisher whose plan may no longer publish", () => {
 
   it("cannot push a new version over a doc it already owns", async () => {
     const created = await publish(KEY_A, "Frozen at v1");
-    await downgrade(publisherA);
+    await downgrade(KEY_A);
 
     const response = await send("PUT", `/api/v1/docs/${created.docId}`, KEY_A, {
       html: page("<p>v2</p>"),

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -34,18 +34,27 @@ async function sha256Hex(value: string): Promise<string> {
 
 /**
  * Give a key a publisher row validated just now — what a real request leaves
- * behind after auth, and what `docs.publisher` needs as a foreign key. These
- * tests are about managing docs, not about authenticating, so the license cache
- * is warm and no license server is ever reached.
+ * behind after auth. These tests are about managing docs, not about
+ * authenticating, so the license cache is warm and no license server is ever
+ * reached.
+ *
+ * `owner` is the account the key belongs to, left null by default so the key
+ * owns its own docs: the state every key is in until the license server starts
+ * naming accounts. Passing one is how a test says "these two keys are the same
+ * person".
+ *
+ * Returns the owner the key will resolve to, which is what the doc rows will
+ * carry — not the key hash, once the two differ.
  */
-async function seedPublisher(key: string): Promise<string> {
+async function seedPublisher(key: string, owner: string | null = null): Promise<string> {
   const id = await sha256Hex(key);
   await env.DB.prepare(
-    "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at) VALUES (?, 'believer', ?)",
+    `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
+     VALUES (?, 'believer', ?, ?)`,
   )
-    .bind(id, Date.now())
+    .bind(id, Date.now(), owner)
     .run();
-  return id;
+  return owner ?? id;
 }
 
 let publisherA = "";
@@ -162,7 +171,7 @@ async function seedDoc(
 ): Promise<string> {
   const versions = options.versions ?? 1;
   await env.DB.prepare(
-    `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+    `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?)`,
   )
     .bind(id, publisher, `seeded ${id}`, versions, createdAt, createdAt)
@@ -251,7 +260,7 @@ describe("DELETE /api/v1/docs/{docId}", () => {
     // point here, and every other delete test covers the route.
     for (let n = 1; n <= 3; n++) await env.DOCS.put(versionObjectKey(docId, n), "x");
 
-    const publisher: Publisher = { id: publisherA, plan: "believer" };
+    const publisher: Publisher = { id: publisherA, owner: publisherA, plan: "believer" };
     const response = await deleteDoc(env, publisher, docId, { objectBatch: 2 });
 
     expect(response.status).toBe(204);
@@ -280,7 +289,7 @@ describe("DELETE /api/v1/docs/{docId}", () => {
     });
 
     expect(await docRow(created.docId)).toMatchObject({
-      publisher: publisherA,
+      owner: publisherA,
       deleted_at: null,
     });
     expect(await objectKeys(created.docId)).toEqual([versionObjectKey(created.docId, 1)]);
@@ -584,6 +593,54 @@ describe("paging through the list", () => {
     // resume step would walk straight into them.
     expect(await walk(KEY_A, 2)).toEqual([4, 3, 2, 1].map((i) => seededId(i)));
     expect(await walk(KEY_B, 3)).toEqual([8, 7, 6, 5].map((i) => seededId(i)));
+  });
+});
+
+/**
+ * The point of owning documents by account rather than by key: which key you
+ * happen to be holding stops deciding what you can see.
+ */
+describe("two keys belonging to one account", () => {
+  const ACCOUNT = "e2b7a0c4-1f3d-4a6b-9c8e-2d5f7a1b3c9d";
+
+  beforeEach(async () => {
+    // Re-seed both keys onto the same account, over the per-key rows the outer
+    // `beforeEach` wrote.
+    await seedPublisher(KEY_A, ACCOUNT);
+    await seedPublisher(KEY_B, ACCOUNT);
+  });
+
+  it("list one merged shelf, whichever key asks", async () => {
+    const fromA = await publish(KEY_A, "Pushed with A");
+    const fromB = await publish(KEY_B, "Pushed with B");
+
+    for (const key of [KEY_A, KEY_B]) {
+      const body = await listed(await list(key));
+      expect(body.docs.map((doc) => doc.docId).sort()).toEqual([fromA.docId, fromB.docId].sort());
+    }
+  });
+
+  it("can each unshare what the other published", async () => {
+    const fromA = await publish(KEY_A, "Pushed with A");
+
+    expect((await del(KEY_B, fromA.docId)).status).toBe(204);
+  });
+
+  it("store the account id on the doc, not the key hash", async () => {
+    const created = await publish(KEY_A, "A note");
+
+    expect(await docRow(created.docId)).toMatchObject({ owner: ACCOUNT });
+  });
+
+  it("stay invisible to a key on a different account", async () => {
+    const other = "9a1c3e5f-7b9d-4f2a-8c6e-0d4b8f2a6c1e";
+    await seedPublisher(KEY_B, other);
+    const fromA = await publish(KEY_A, "Mine");
+
+    expect(await listed(await list(KEY_B))).toEqual({ docs: [] });
+    // 404, never 403: another account's doc is indistinguishable from one that
+    // never existed, on every endpoint.
+    expect((await del(KEY_B, fromA.docId)).status).toBe(404);
   });
 });
 

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -37,26 +37,29 @@ async function sha256Hex(value: string): Promise<string> {
  * Give a key a publisher row validated just now.
  *
  * This is what a real request leaves behind after auth (phase 2), and it is
- * also what the `docs.publisher` foreign key needs. A fresh `validated_at`
- * means the license cache is warm, so no test here ever needs the license
- * server — these tests are about pushing, not about authenticating.
+ * A fresh `validated_at` means the license cache is warm, so no test here ever
+ * needs the license server — these tests are about pushing, not authenticating.
+ *
+ * Returns the account the key resolves to, which is what its doc rows carry.
  */
 async function seedPublisher(key: string): Promise<string> {
-  const id = await sha256Hex(key);
+  const keyHash = await sha256Hex(key);
+  const account = `account-${keyHash.slice(0, 8)}`;
   await env.DB.prepare(
-    "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at) VALUES (?, 'believer', ?)",
+    `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
+     VALUES (?, 'believer', ?, ?)`,
   )
-    .bind(id, Date.now())
+    .bind(keyHash, Date.now(), account)
     .run();
-  return id;
+  return account;
 }
 
-let publisherA = "";
-let publisherB = "";
+let ownerA = "";
+let ownerB = "";
 
 beforeEach(async () => {
-  publisherA = await seedPublisher(KEY_A);
-  publisherB = await seedPublisher(KEY_B);
+  ownerA = await seedPublisher(KEY_A);
+  ownerB = await seedPublisher(KEY_B);
 });
 
 interface PushResponse {
@@ -171,7 +174,7 @@ describe("POST /api/v1/docs", () => {
 
     // D1 is a pointer index: it has to agree with what R2 actually holds.
     expect(await docRow(body.docId)).toMatchObject({
-      owner: publisherA,
+      owner: ownerA,
       title: "A note",
       latest_version: 1,
       deleted_at: null,
@@ -278,9 +281,9 @@ describe("PUT /api/v1/docs/{docId}", () => {
 
     expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
     expect(await stored(created.docId, 1)).toContain("<p>x</p>");
-    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1, owner: publisherA });
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1, owner: ownerA });
     // And it cost the caller nothing: a push that never happened is not a push.
-    expect(await quotaRows()).toMatchObject([{ owner: publisherA, pushes: 1 }]);
+    expect(await quotaRows()).toMatchObject([{ owner: ownerA, pushes: 1 }]);
   });
 
   it("404s a doc that does not exist", async () => {
@@ -385,7 +388,7 @@ describe("the daily push quota", () => {
       .run();
 
   it("429s a publisher who has used today's pushes", async () => {
-    await spend(publisherA, MAX_PUSHES_PER_DAY);
+    await spend(ownerA, MAX_PUSHES_PER_DAY);
 
     const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") });
 
@@ -397,7 +400,7 @@ describe("the daily push quota", () => {
   });
 
   it("429s the update path too, and only after the last push is spent", async () => {
-    await spend(publisherA, MAX_PUSHES_PER_DAY - 1);
+    await spend(ownerA, MAX_PUSHES_PER_DAY - 1);
 
     // The last push of the day: creating the doc.
     const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
@@ -410,14 +413,14 @@ describe("the daily push quota", () => {
   });
 
   it("counts each publisher separately", async () => {
-    await spend(publisherA, MAX_PUSHES_PER_DAY);
+    await spend(ownerA, MAX_PUSHES_PER_DAY);
 
     expect((await post(KEY_A, { title: "t", html: page("<p>x</p>") })).status).toBe(429);
     expect((await post(KEY_B, { title: "t", html: page("<p>x</p>") })).status).toBe(201);
   });
 
   it("rolls over at the UTC day boundary", async () => {
-    await spend(publisherA, MAX_PUSHES_PER_DAY, utcDay(Date.now() - 24 * 60 * 60 * 1000));
+    await spend(ownerA, MAX_PUSHES_PER_DAY, utcDay(Date.now() - 24 * 60 * 60 * 1000));
 
     expect((await post(KEY_A, { title: "t", html: page("<p>x</p>") })).status).toBe(201);
   });
@@ -427,7 +430,7 @@ describe("the daily push quota", () => {
     await post(KEY_A, { title: "t", html: page("<p>y</p>") });
 
     expect(await quotaRows()).toMatchObject([
-      { owner: publisherA, day: utcDay(Date.now()), pushes: 2 },
+      { owner: ownerA, day: utcDay(Date.now()), pushes: 2 },
     ]);
   });
 
@@ -443,11 +446,11 @@ describe("the daily push quota", () => {
     expect(responses.map((r) => r.status)).toEqual(Array(concurrent).fill(201));
     // Read-then-increment would let two pushes see the same count and one
     // increment vanish, which is the hole a claim-in-one-statement upsert closes.
-    expect(await quotaRows()).toMatchObject([{ owner: publisherA, pushes: concurrent }]);
+    expect(await quotaRows()).toMatchObject([{ owner: ownerA, pushes: concurrent }]);
   });
 
   it("gives the last push of the day to exactly one of two racing pushes", async () => {
-    await spend(publisherA, MAX_PUSHES_PER_DAY - 1);
+    await spend(ownerA, MAX_PUSHES_PER_DAY - 1);
 
     const statuses = (
       await Promise.all([
@@ -498,7 +501,7 @@ describe("a push whose write fails partway", () => {
 
 describe("the live-doc quota", () => {
   it("429s a publisher already holding the maximum", async () => {
-    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER);
+    await seedDocs(ownerA, MAX_DOCS_PER_PUBLISHER);
 
     const response = await post(KEY_A, { title: "one more", html: page("<p>x</p>") });
 
@@ -512,20 +515,20 @@ describe("the live-doc quota", () => {
   });
 
   it("does not count deleted docs, so deleting one makes room", async () => {
-    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER - 1, 5);
+    await seedDocs(ownerA, MAX_DOCS_PER_PUBLISHER - 1, 5);
 
     expect((await post(KEY_A, { title: "one more", html: page("<p>x</p>") })).status).toBe(201);
   });
 
   it("does not limit updates to docs the publisher already holds", async () => {
     const created = await pushedOk(await post(KEY_A, { title: "t", html: page("<p>x</p>") }), 201);
-    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER);
+    await seedDocs(ownerA, MAX_DOCS_PER_PUBLISHER);
 
     expect((await put(KEY_A, created.docId, { html: page("<p>y</p>") })).status).toBe(200);
   });
 
   it("counts each publisher's docs separately", async () => {
-    await seedDocs(publisherB, MAX_DOCS_PER_PUBLISHER);
+    await seedDocs(ownerB, MAX_DOCS_PER_PUBLISHER);
 
     expect((await post(KEY_A, { title: "t", html: page("<p>x</p>") })).status).toBe(201);
   });
@@ -878,7 +881,7 @@ describe("races the review found", () => {
    * publisher at the edge pushes concurrently rather than one at a time.
    */
   it("holds the doc ceiling when creates arrive together", async () => {
-    await seedDocs(publisherA, MAX_DOCS_PER_PUBLISHER - 1);
+    await seedDocs(ownerA, MAX_DOCS_PER_PUBLISHER - 1);
 
     const responses = await Promise.all(
       Array.from({ length: 8 }, () => post(KEY_A, { title: "t", html: page("<p>x</p>") })),
@@ -893,7 +896,7 @@ describe("races the review found", () => {
     const { n } = (await env.DB.prepare(
       "SELECT COUNT(*) AS n FROM docs WHERE owner = ? AND deleted_at IS NULL",
     )
-      .bind(publisherA)
+      .bind(ownerA)
       .first<{ n: number }>()) ?? { n: -1 };
     expect(n).toBe(MAX_DOCS_PER_PUBLISHER);
   });
@@ -902,14 +905,14 @@ describe("races the review found", () => {
     await env.DB.prepare(
       "INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, ?)",
     )
-      .bind(publisherA, utcDay(Date.now()), MAX_PUSHES_PER_DAY)
+      .bind(ownerA, utcDay(Date.now()), MAX_PUSHES_PER_DAY)
       .run();
 
     const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") });
 
     expect(response.status).toBe(429);
     const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM docs WHERE owner = ?")
-      .bind(publisherA)
+      .bind(ownerA)
       .first<{ n: number }>()) ?? { n: -1 };
     expect(n).toBe(0);
     expect(await allObjects()).toHaveLength(0);

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -130,7 +130,7 @@ async function seedDocs(publisher: string, live: number, deleted = 0): Promise<v
   const now = Date.now();
   await env.DB.prepare(
     `WITH RECURSIVE seq(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < ?)
-     INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at, deleted_at)
+     INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at, deleted_at)
      SELECT printf('%0' || ? || 'd', i), ?, 'seeded', 1, ?, ?, CASE WHEN i > ? THEN ? END
        FROM seq`,
   )
@@ -171,7 +171,7 @@ describe("POST /api/v1/docs", () => {
 
     // D1 is a pointer index: it has to agree with what R2 actually holds.
     expect(await docRow(body.docId)).toMatchObject({
-      publisher: publisherA,
+      owner: publisherA,
       title: "A note",
       latest_version: 1,
       deleted_at: null,
@@ -278,9 +278,9 @@ describe("PUT /api/v1/docs/{docId}", () => {
 
     expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
     expect(await stored(created.docId, 1)).toContain("<p>x</p>");
-    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1, publisher: publisherA });
+    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1, owner: publisherA });
     // And it cost the caller nothing: a push that never happened is not a push.
-    expect(await quotaRows()).toMatchObject([{ publisher: publisherA, pushes: 1 }]);
+    expect(await quotaRows()).toMatchObject([{ owner: publisherA, pushes: 1 }]);
   });
 
   it("404s a doc that does not exist", async () => {
@@ -380,7 +380,7 @@ describe("the 10MB body ceiling", () => {
 
 describe("the daily push quota", () => {
   const spend = (publisher: string, pushes: number, day = utcDay(Date.now())) =>
-    env.DB.prepare("INSERT INTO push_quota (publisher, day, pushes) VALUES (?, ?, ?)")
+    env.DB.prepare("INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, ?)")
       .bind(publisher, day, pushes)
       .run();
 
@@ -427,7 +427,7 @@ describe("the daily push quota", () => {
     await post(KEY_A, { title: "t", html: page("<p>y</p>") });
 
     expect(await quotaRows()).toMatchObject([
-      { publisher: publisherA, day: utcDay(Date.now()), pushes: 2 },
+      { owner: publisherA, day: utcDay(Date.now()), pushes: 2 },
     ]);
   });
 
@@ -443,7 +443,7 @@ describe("the daily push quota", () => {
     expect(responses.map((r) => r.status)).toEqual(Array(concurrent).fill(201));
     // Read-then-increment would let two pushes see the same count and one
     // increment vanish, which is the hole a claim-in-one-statement upsert closes.
-    expect(await quotaRows()).toMatchObject([{ publisher: publisherA, pushes: concurrent }]);
+    expect(await quotaRows()).toMatchObject([{ owner: publisherA, pushes: concurrent }]);
   });
 
   it("gives the last push of the day to exactly one of two racing pushes", async () => {
@@ -891,7 +891,7 @@ describe("races the review found", () => {
     expect(refused).toHaveLength(7);
 
     const { n } = (await env.DB.prepare(
-      "SELECT COUNT(*) AS n FROM docs WHERE publisher = ? AND deleted_at IS NULL",
+      "SELECT COUNT(*) AS n FROM docs WHERE owner = ? AND deleted_at IS NULL",
     )
       .bind(publisherA)
       .first<{ n: number }>()) ?? { n: -1 };
@@ -900,7 +900,7 @@ describe("races the review found", () => {
 
   it("does not spend a doc slot on a push refused by the daily quota", async () => {
     await env.DB.prepare(
-      "INSERT INTO push_quota (publisher, day, pushes) VALUES (?, ?, ?)",
+      "INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, ?)",
     )
       .bind(publisherA, utcDay(Date.now()), MAX_PUSHES_PER_DAY)
       .run();
@@ -908,7 +908,7 @@ describe("races the review found", () => {
     const response = await post(KEY_A, { title: "t", html: page("<p>x</p>") });
 
     expect(response.status).toBe(429);
-    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM docs WHERE publisher = ?")
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM docs WHERE owner = ?")
       .bind(publisherA)
       .first<{ n: number }>()) ?? { n: -1 };
     expect(n).toBe(0);

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -9,7 +9,7 @@ import worker from "../src/index.js";
 /**
  * The served page is no longer the stored object: `renderServedHtml` adds the
  * robots meta and the bylines on the way out. What survives is that the
- * publisher's document is carried through untouched, which is what these
+ * owner's document is carried through untouched, which is what these
  * assertions are actually about.
  */
 async function expectServes(response: Response, docId: string, version: number) {
@@ -18,7 +18,7 @@ async function expectServes(response: Response, docId: string, version: number) 
   expect(document).not.toContain(NOINDEX_META);
   expect(html).toContain(NOINDEX_META);
   expect(html).toContain(SYMPOSIUM_FOOTER);
-  // Everything inside the body the publisher sent, in order, still there.
+  // Everything inside the body the owner sent, in order, still there.
   const inner = document.slice(document.indexOf("<body>") + 6, document.indexOf("</body>"));
   expect(html).toContain(inner.trim());
   return html;
@@ -50,18 +50,19 @@ async function sha256Hex(value: string): Promise<string> {
 
 /**
  * A publisher row with a fresh validation, which is what a real request leaves
- * behind after auth and what `docs.publisher` needs as a foreign key. Reading is
- * unauthenticated, so this exists only so the pushes that set up each test can
- * run without a license server.
+ * behind after auth. Reading is unauthenticated, so this exists only so the
+ * pushes that set up each test can run without a license server.
  */
-let publisher = "";
+let owner = "";
 
 beforeEach(async () => {
-  publisher = await sha256Hex(KEY);
+  const keyHash = await sha256Hex(KEY);
+  owner = `account-${keyHash.slice(0, 8)}`;
   await env.DB.prepare(
-    "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at) VALUES (?, 'believer', ?)",
+    `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
+     VALUES (?, 'believer', ?, ?)`,
   )
-    .bind(publisher, Date.now())
+    .bind(keyHash, Date.now(), owner)
     .run();
 });
 
@@ -145,7 +146,7 @@ describe("GET /d/{docId}", () => {
     expect(response.headers.get("set-cookie")).toBeNull();
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
 
-    // Not byte-for-byte any more: the stored object is the publisher's document,
+    // Not byte-for-byte any more: the stored object is the owner's document,
     // and the additions go in on the way out. The reader gets both, the bucket
     // holds neither, which is what lets a byline change reach this document
     // without a re-push.
@@ -160,7 +161,7 @@ describe("GET /d/{docId}", () => {
   });
 
   // End to end, because "injected once" is asserted against the renderer in
-  // isolation elsewhere, and the question a publisher actually asks is about a
+  // isolation elsewhere, and the question a owner actually asks is about a
   // document they pushed. Documents stored before injection moved carry their
   // own baked copy and would show two footers until re-pushed; nothing pushed
   // through this path can, because nothing is ever baked into the bytes.
@@ -424,7 +425,7 @@ describe("a doc that is not there", () => {
       `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
        VALUES (?, ?, 'stranded', 1, ?, ?)`,
     )
-      .bind(UNKNOWN_DOC_ID, publisher, Date.now(), Date.now())
+      .bind(UNKNOWN_DOC_ID, owner, Date.now(), Date.now())
       .run();
 
     expect((await get(`/d/${UNKNOWN_DOC_ID}`)).status).toBe(404);

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -421,7 +421,7 @@ describe("a doc that is not there", () => {
     // The other half of a push that died mid-write: a `docs` row whose id was
     // never returned to anyone, so nothing points at it and nothing has bytes.
     await env.DB.prepare(
-      `INSERT INTO docs (id, publisher, title, latest_version, created_at, updated_at)
+      `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
        VALUES (?, ?, 'stranded', 1, ?, ?)`,
     )
       .bind(UNKNOWN_DOC_ID, publisher, Date.now(), Date.now())


### PR DESCRIPTION
Fixes #31

## ⚠️ Apply the migration before merging

`deploy.yml` does not apply migrations — it fails the deploy when `migrations/`
and the `d1_migrations` table disagree ([docs/deploying.md](docs/deploying.md)).

```bash
npx wrangler d1 migrations apply symposium --remote
```

It **drops and recreates all four tables**. Nothing is live: every row is
development test data, and the R2 objects behind it have already been deleted.

Because the migration lands before the deploy, the currently deployed Worker
runs against the new schema for the few minutes until the merge deploys, and
returns `500` for that window. Taken deliberately here — there are no users and
no data being kept — but it is the one thing about this change that must not be
repeated after launch. `docs/deploying.md` now carries the rule.

## Problem

Documents are filed under a scrambled license key. `docs.publisher` holds the
key's SHA-256, and `GET /api/v1/docs` returns whatever matches the key you
presented. So a new key loses you your documents — still readable by anyone with
the link, but gone from your list and impossible to withdraw. Someone who signs
in to symposium.md having never made a key has nothing to look up at all, and
two keys belonging to one person are two separate shelves.

## Fix

File documents under the app-sites `User.id`. Both sides already hold it:
`LicenseKeyConfig.authUserId` attaches a key to it, and a symposium.md session
carries it as `session.user.id`. The license server already sends it —
`license.validateLicenseKey` returns `accountId` on every valid response — so
there is no cross-repo change and nothing derived or hashed that two codebases
could compute differently.

`docs.publisher` becomes `docs.owner`. Every doc query, the daily push counter
and the document ceiling key off it. `publishers` stays keyed by the key hash,
because that is the only thing derivable from a request without a network call,
and because `plan` and revocation are per key — one shared row per account would
let a revoked key ride on another's validation until the cache expired.

Two decisions worth flagging:

- **A response with no `accountId` is refused** as `license_unavailable` (500),
  not filed under a guessed owner. A blank id would be one shared owner that
  every such key falls into, which is one publisher reading another's documents.
- **The account id is an identifier, never a credential.** Nothing in the API
  accepts or returns one; the owner is always derived from a validated key. The
  contract now says so, so nobody builds an endpoint that takes one.

## Scope

**16 files changed, 658 insertions, 186 deletions.** 86 lines are the migration,
~390 are tests and ~135 are the new identity doc; the production change across
`src/` is a column rename, one added column, and `owner` threaded through the
call sites.

## Changes

- `migrations/0002_own_docs_by_owner.sql` — the account-owned schema.
  `docs.owner` and `publishers.owner` are `NOT NULL`; `docs.owner` has no foreign
  key, since `publishers` is keyed by license key and an account is not one.
- `src/auth.ts` — `Publisher` is `{owner, plan}`; the key hash no longer leaves
  this module. `validateLicense` requires `accountId`.
- `src/db.ts`, `src/api/push.ts`, `src/api/manage.ts`, `src/quota.ts` — queries
  and call sites key off `owner`.
- `docs/http-api.md` — states that documents belong to the account and that
  limits are per account. No wire change: no status code, error code or field
  name moves.
- `docs/identity.md` — new. Who owns a document, why `publishers` stays keyed by
  the key hash, and how symposium.md sign-in resolves to the same id with no join
  and no branch on whether the person is a Copilot user.
- `CLAUDE.md` — records the constraint that an owner id is derived and never
  accepted as input, since an endpoint that took one would turn every id into a
  password without looking like a security change.
- `docs/development.md` — the local seed row needs an `owner`.

## Verification

`npm test` → **242 passed**. `npm run typecheck` → clean.

New coverage: two keys on one account list one merged shelf and can each unshare
the other's documents; documents store the account id, not the key hash; a key on
a different account gets an empty list and a 404, never a 403; a response naming
a blank, whitespace, non-string or absent account is refused and writes no row;
a cached account resolves without a license call, and survives both an outage and
a validation that names none.

The suite applies the real `migrations/` files against Miniflare's D1, so a
migration that would not run is a red build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsYrQbkJeqXk5PZXREEMga
