### PR TITLE
Unfurl shared document links with a social card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ These are day-one decisions, not retrofits:
   **This does not hold yet — see below. Do not rely on it.**
 - Every push mints an **immutable version** served with `cache-control: immutable`.
   R2 stores the publisher's own bytes; Symposium's additions (the robots meta,
-  the favicon and the two bylines) are injected on the way out by
+  the favicon, the social card and the two bylines) are injected on the way out by
   `renderServedHtml`, so a byline change — or a plan that removes one — reaches
   documents already published.
   Nothing else is composed per read: the additions are a pure function of the

--- a/src/render.ts
+++ b/src/render.ts
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 2;
+export const RENDER_REVISION = 3;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
@@ -81,6 +81,98 @@ export const FAVICON_LINK =
       'stroke-linecap="round"/></svg>',
   ) +
   '">';
+
+/**
+ * The card image every shared doc unfurls with, on the brand domain.
+ *
+ * It is the one Symposium addition that cannot be inlined. A data URI is not a
+ * valid `og:image` — every unfurler fetches the value over http(s) from its own
+ * infrastructure, never from the reader's browser — so this is a hard
+ * dependency on a url staying alive, which is exactly the dependency the
+ * favicon and the Copilot mark were inlined to avoid.
+ *
+ * Given that, `symposium.md` rather than the marketing site's Vercel
+ * deployment url: pinned `/v{n}` pages are served `immutable` for a year, so a
+ * document published today is still handing this url to crawlers long after
+ * this deploy, and a preview deployment's hostname is not a thing to bet that
+ * on. It is the same 1200×630 image the product site's own card uses.
+ *
+ * It loads on the *unfurler's* side, so nothing about it touches the serving
+ * origin's CSP or costs a reader a request.
+ */
+export const OG_IMAGE_URL = "https://symposium.md/og-image.png";
+
+/**
+ * The part of the card that is the same for every document: which image, how
+ * big it is, and that it should be shown full-bleed rather than as a thumbnail.
+ *
+ * `og:image:width`/`height` matter more than they look. Without them a crawler
+ * that has not yet fetched the image has to guess whether it is large enough
+ * for a big card, and several of them render a small square — or nothing — on
+ * the first unfurl and only correct it on a later scrape. Stating the real
+ * dimensions makes the first paste render right.
+ *
+ * `twitter:card` is the only `twitter:` tag carried: X falls back to the `og:`
+ * tags for everything else, and duplicating them would be two strings to keep
+ * in step for no gain. `og:type` is absent for the same reason in reverse —
+ * nothing that unfurls these links renders anything differently for it.
+ *
+ * `og:site_name` does earn its place: it is the small label Discord and Slack
+ * put above the title, and naming Symposium there is the branding this exists
+ * for.
+ */
+export const SOCIAL_CARD_META =
+  '<meta property="og:site_name" content="Symposium">' +
+  `<meta property="og:image" content="${OG_IMAGE_URL}">` +
+  '<meta property="og:image:width" content="1200">' +
+  '<meta property="og:image:height" content="630">' +
+  '<meta property="og:image:alt" content="Where people and agents get on the same page">' +
+  '<meta name="twitter:card" content="summary_large_image">';
+
+/** How much of a document's title the card carries. Every unfurler truncates
+ * well before this; the cap is here so an unclosed `<title>` — which makes the
+ * parser treat the rest of the document as title text — cannot put a whole
+ * document into a meta tag. */
+const MAX_CARD_TITLE = 300;
+
+/**
+ * A title read out of the document is publisher-controlled text going back into
+ * markup, so it is escaped rather than trusted. `&` first, or it would re-escape
+ * the ampersands the later replacements introduce.
+ *
+ * All four of `&<>"` and not just the quote that closes the attribute: the
+ * injection is handed to HTMLRewriter as markup (`AS_HTML`), so a `<` in a title
+ * would open an element rather than sit in a `content=""`.
+ */
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * The per-document half of the card: `og:title`, taken from the document's own
+ * `<title>`.
+ *
+ * A static title would be worse than none — every doc would unfurl under the
+ * same words, and a link to a specific document would say nothing about which
+ * one. Taking it from the document keeps this a pure function of the stored
+ * bytes, which is what lets the served etag stay a per-object validator: no D1
+ * read, and nothing that can drift out from under a pinned `/v{n}` url.
+ *
+ * Whitespace is collapsed because a pretty-printed `<title>` spans lines, and
+ * the newlines would reach the card as-is.
+ *
+ * Empty means no tag rather than an empty one: unfurlers fall back to the
+ * `<title>` element on their own, and an empty `content` would stop them.
+ */
+export function socialTitleMeta(rawTitle: string): string {
+  const title = rawTitle.replace(/\s+/g, " ").trim();
+  if (title.length === 0) return "";
+  return `<meta property="og:title" content="${escapeAttribute(title)}">`;
+}
 
 /**
  * Shared between the two bylines (D9).
@@ -207,17 +299,26 @@ export const SYMPOSIUM_FOOTER =
 const AS_HTML = { html: true } as const;
 
 /**
- * Inject the robots meta, the favicon and the two bylines, and change nothing
- * else.
+ * Inject the robots meta, the favicon, the social card and the two bylines, and
+ * change nothing else.
  *
  * Every injection has a fallback, because a document is not guaranteed to have
  * the tag we want to hang it on:
  *
- * - The meta and the favicon go first inside `<head>`. A document with no
- *   `<head>` gets them at the end instead, where the parser hoists them into
- *   the body — weaker for the meta, since a robots meta outside the head is not
- *   honoured, which is exactly why the `X-Robots-Tag` header carries the real
- *   signal, and best-effort for the icon.
+ * - The meta, the favicon and the static half of the social card go first
+ *   inside `<head>`. A document with no `<head>` gets them at the end instead,
+ *   where the parser hoists them into the body — weaker for the meta, since a
+ *   robots meta outside the head is not honoured, which is exactly why the
+ *   `X-Robots-Tag` header carries the real signal, and best-effort for the icon
+ *   and the card.
+ * - `og:title` cannot go with them, because it is read out of the document's
+ *   own `<title>` and that tag has not been seen yet when `<head>` opens. It is
+ *   injected before `</head>` instead, by which point it has. A document that
+ *   never closes its head keeps the image tags — they were prepended — and
+ *   loses only this one, and losing it costs little: an unfurler with no
+ *   `og:title` falls back to the `<title>` element, which is the same string.
+ *   That is why the split is worth a second injection site rather than moving
+ *   the whole card to the end tag.
  * - The header byline is prepended inside `<body>`. A document with no `<body>`
  *   start tag gets it at the document end instead, which puts the header below
  *   the content: wrong, but present. Hanging it on `<html>` would be no better,
@@ -246,26 +347,66 @@ const AS_HTML = { html: true } as const;
  * it did when serving was a passthrough.
  *
  * `branding` will be false for plans that pay to remove the bylines. It takes
- * the favicon with them — a Symposium mark in the reader's tab is branding too.
+ * the favicon and the social card with them — a Symposium mark in the reader's
+ * tab is branding too, and a card carrying Symposium's own image is the most
+ * visible branding of the lot: it is what a paying customer's link shows in
+ * somebody else's Discord. `og:title` goes with it rather than being kept on
+ * its own, because a card with a title and no image is a worse unfurl than the
+ * one an unfurler builds from `<title>` by itself.
  * It does not reach the robots meta, and must not: `noindex` is policy, and a flag that
  * switched it off would make paid customers' documents indexable — the worst
  * possible bug to ship attached to an upgrade.
  */
 export function renderServedHtml(response: Response, branding = true): Response {
-  const head = branding ? NOINDEX_META + FAVICON_LINK : NOINDEX_META;
+  const head = branding ? NOINDEX_META + FAVICON_LINK + SOCIAL_CARD_META : NOINDEX_META;
   let headPlaced = false;
+  let cardTitlePlaced = false;
   let headerPlaced = false;
   let footerPlaced = false;
 
+  // The document's own `<title>`, accumulated as it streams past. Text arrives
+  // in chunks, and an entity in the middle of one splits it into more, so this
+  // cannot stop at the first chunk — it stops at the element's end tag.
+  let documentTitle = "";
+  let titleClosed = false;
+
   return new HTMLRewriter()
-    // One `prepend()` for both, because each prepend goes *ahead* of the last:
-    // two calls would have to be written in the reverse of the order they
-    // produce, which is a trap for the next edit.
+    // `head > title` and not `title`: an inline `<svg>` may carry a `<title>`
+    // of its own as its accessible name, and a chart's "Revenue by quarter" is
+    // not what the document is called.
+    .on("head > title", {
+      element(element) {
+        // First title wins, matching every other injection here. A second one
+        // is marked closed on sight so its text is never accumulated.
+        if (titleClosed || documentTitle.length > 0) {
+          titleClosed = true;
+          return;
+        }
+        element.onEndTag(() => {
+          titleClosed = true;
+        });
+      },
+      text(chunk) {
+        if (titleClosed) return;
+        documentTitle = (documentTitle + chunk.text).slice(0, MAX_CARD_TITLE);
+      },
+    })
     .on("head", {
       element(element) {
         if (headPlaced) return;
         headPlaced = true;
+        // One `prepend()` for all three, because each prepend goes *ahead* of
+        // the last: separate calls would have to be written in the reverse of
+        // the order they produce, which is a trap for the next edit.
         element.prepend(head, AS_HTML);
+        // Registered on the head that got the prepend, for the reason the
+        // footer's callback is registered on the body that got the header.
+        element.onEndTag((endTag) => {
+          cardTitlePlaced = true;
+          if (!branding) return;
+          const titleMeta = socialTitleMeta(documentTitle);
+          if (titleMeta.length > 0) endTag.before(titleMeta, AS_HTML);
+        });
       },
     })
     .on("body", {
@@ -289,6 +430,10 @@ export function renderServedHtml(response: Response, branding = true): Response 
     .onDocument({
       end(end) {
         if (!headPlaced) end.append(head, AS_HTML);
+        if (branding && !cardTitlePlaced) {
+          const titleMeta = socialTitleMeta(documentTitle);
+          if (titleMeta.length > 0) end.append(titleMeta, AS_HTML);
+        }
         if (branding && !headerPlaced) end.append(SYMPOSIUM_HEADER, AS_HTML);
         if (branding && !footerPlaced) end.append(SYMPOSIUM_FOOTER, AS_HTML);
       },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,9 +1,9 @@
 /**
  * The public serving surface: `GET /d/{docId}` and `GET /d/{docId}/v{n}`.
  *
- * R2 holds the publisher's own bytes; Symposium's additions — the robots meta
- * and the two bylines — are injected here, on the way out, by
- * `renderServedHtml`. That is what lets a byline change, or a plan that removes
+ * R2 holds the publisher's own bytes; Symposium's additions — the robots meta,
+ * the favicon, the social card and the two bylines — are injected here, on the
+ * way out, by `renderServedHtml`. That is what lets a byline change, or a plan that removes
  * one, reach documents already published, and it is why the stored object and
  * the served page are no longer byte-identical. `immutable` on `/v{n}` stays
  * honest: the version's content never changes, and the additions are a pure

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   FAVICON_LINK,
   NOINDEX_META,
+  OG_IMAGE_URL,
   renderServedHtml,
+  SOCIAL_CARD_META,
+  socialTitleMeta,
   SYMPOSIUM_FOOTER,
   SYMPOSIUM_HEADER,
 } from "../src/render.js";
@@ -42,6 +45,94 @@ describe("renderServedHtml — what gets injected", () => {
     const href = FAVICON_LINK.slice(FAVICON_LINK.indexOf('href="') + 6, -2);
     expect(href).not.toContain('"');
     expect(decodeURIComponent(href.slice("data:image/svg+xml,".length))).toContain("<svg ");
+  });
+
+  // The card image is the one addition that cannot be inlined: an `og:image` is
+  // fetched by the unfurler over http(s), so a data URI is not a value any of
+  // them accept. Pinned on the brand domain rather than a deployment url,
+  // because `/v{n}` pages hand this string to crawlers for a year.
+  it("points the card image at a stable brand-domain url", () => {
+    expect(OG_IMAGE_URL).toBe("https://symposium.md/og-image.png");
+    expect(SOCIAL_CARD_META).toContain(`<meta property="og:image" content="${OG_IMAGE_URL}">`);
+  });
+
+  // Without the dimensions a crawler that has not fetched the image yet has to
+  // guess whether it is big enough for a full-bleed card, and several of them
+  // render a thumbnail — or nothing — on the first paste. They are the actual
+  // size of the file at the url above.
+  it("states the image size and asks for a full-bleed card", () => {
+    expect(SOCIAL_CARD_META).toContain('<meta property="og:image:width" content="1200">');
+    expect(SOCIAL_CARD_META).toContain('<meta property="og:image:height" content="630">');
+    expect(SOCIAL_CARD_META).toContain('<meta name="twitter:card" content="summary_large_image">');
+  });
+
+  // A static title would unfurl every document under the same words, which is
+  // worse than none: the fallback an unfurler reaches for is the document's own
+  // `<title>`, and that at least names the document.
+  it("takes the card title from the document, not from a constant", async () => {
+    const baked = await bake(page("<p>hello</p>"));
+
+    expect(baked).toContain('<meta property="og:title" content="A note">');
+    expect(SOCIAL_CARD_META).not.toContain("og:title");
+  });
+
+  // Publisher-controlled text going back into markup, injected as HTML. A `<`
+  // that survived would open an element inside the head rather than sit in a
+  // `content=""`.
+  //
+  // The count is what carries the claim. Inside `<title>` the sequence is text
+  // — RCDATA, which the parser never treats as a tag — and those are the
+  // publisher's own bytes, so it stays exactly as uploaded. What must not
+  // happen is a *second* copy arriving from our injection, where it would be
+  // markup.
+  it("escapes a title that would otherwise close the tag it sits in", async () => {
+    const hostile = '"><script>alert(1)</script><meta x="';
+    const baked = await bake(
+      `<!doctype html><html><head><title>${hostile}</title></head><body><p>hi</p></body></html>`,
+    );
+
+    expect(baked).toContain(`<title>${hostile}</title>`);
+    expect(occurrences(baked, "<script>alert(1)</script>")).toBe(1);
+    expect(headOf(baked)).toContain(
+      '<meta property="og:title" content="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;' +
+        '&lt;meta x=&quot;">',
+    );
+  });
+
+  it("collapses the whitespace a pretty-printed title spans lines with", () => {
+    expect(socialTitleMeta("  Weekly\n  review  ")).toBe(
+      '<meta property="og:title" content="Weekly review">',
+    );
+  });
+
+  // An empty `content` stops an unfurler from falling back to `<title>`, so a
+  // document with nothing to say gets no tag rather than an empty one.
+  it("emits no title tag at all when the document has no title text", async () => {
+    const baked = await bake(
+      "<!doctype html><html><head><title>  </title></head><body><p>hi</p></body></html>",
+    );
+
+    expect(baked).not.toContain("og:title");
+  });
+
+  // An unclosed `<title>` makes the parser treat the rest of the document as
+  // title text. Bounded, so that cannot put a whole document in a meta tag.
+  it("caps the title rather than letting an unclosed one swallow the document", async () => {
+    const baked = await bake(
+      `<!doctype html><html><head><title>${"x".repeat(2000)}</title></head>` +
+        "<body><p>hi</p></body></html>",
+    );
+
+    const content = /<meta property="og:title" content="(x+)">/.exec(baked)?.[1] ?? "";
+    expect(content.length).toBe(300);
+  });
+
+  // `<svg><title>` is a chart's accessible name, not the document's.
+  it("ignores a title that belongs to an inline SVG", async () => {
+    const baked = await bake(page('<svg><title>Revenue by quarter</title></svg>'));
+
+    expect(baked).toContain('<meta property="og:title" content="A note">');
+    expect(baked).toContain("<title>Revenue by quarter</title>");
   });
 
   it("says where the document came from, in text a reader can see", async () => {
@@ -131,12 +222,22 @@ describe("renderServedHtml — what gets injected", () => {
 });
 
 describe("renderServedHtml — where the injections land", () => {
-  it("puts the robots meta and the icon inside the head, and the bylines around the body", async () => {
+  it("puts the robots meta, the icon and the card inside the head, and the bylines around the body", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
-    expect(baked).toContain(`<head>${NOINDEX_META}${FAVICON_LINK}`);
+    expect(baked).toContain(`<head>${NOINDEX_META}${FAVICON_LINK}${SOCIAL_CARD_META}`);
     expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
     expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
+  });
+
+  // `og:title` is read out of the document's own `<title>`, which has not been
+  // seen when `<head>` opens — so it is the one head injection that lands at the
+  // end tag instead of the start. It still has to be *in* the head.
+  it("puts the card title inside the head even though it is injected last", async () => {
+    const baked = await bake(page("<p>hello</p>"));
+
+    expect(headOf(baked)).toContain('<meta property="og:title" content="A note">');
+    expect(baked).toContain('<meta property="og:title" content="A note"></head>');
   });
 
   it("puts the header above the document's own content, not below it", async () => {
@@ -151,8 +252,23 @@ describe("renderServedHtml — where the injections land", () => {
 
     expect(occurrences(baked, NOINDEX_META)).toBe(1);
     expect(occurrences(baked, FAVICON_LINK)).toBe(1);
+    expect(occurrences(baked, SOCIAL_CARD_META)).toBe(1);
+    expect(occurrences(baked, "og:title")).toBe(1);
     expect(occurrences(baked, SYMPOSIUM_HEADER)).toBe(1);
     expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
+  });
+
+  // A repeated head is the shape that catches a card title accumulated across
+  // both of them, or injected once per head. First one wins, like everything
+  // else here.
+  it("takes the card title from the first head, once, when the document has two", async () => {
+    const baked = await bake(
+      "<!doctype html><html><head><title>first</title></head><body><p>one</p></body>" +
+        "<head><title>second</title></head><body><p>two</p></body></html>",
+    );
+
+    expect(occurrences(baked, "og:title")).toBe(1);
+    expect(baked).toContain('<meta property="og:title" content="first">');
   });
 
   // The case the test above is named for but does not reach: the handlers hang
@@ -220,6 +336,18 @@ describe("renderServedHtml — documents missing the tags to hang them on", () =
     expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
     expect(baked).toContain(SYMPOSIUM_FOOTER);
     expect(baked).toContain("<p>hi</p>");
+  });
+
+  // The documented cost of the split: a head with no end tag keeps the image
+  // tags, because those are prepended, and the title meta falls out of the head.
+  // Pinned so that cost stays a decision on record — and because losing it is
+  // survivable, the unfurler falling back to `<title>` for the same string.
+  it("keeps the card image when the head is never closed", async () => {
+    const baked = await bake("<!doctype html><html><head><title>t</title><body><p>hi</p>");
+
+    expect(headOf(baked)).toContain(SOCIAL_CARD_META);
+    expect(baked).toContain("og:title");
+    expect(baked).toContain("<title>t</title>");
   });
 
   it("still injects into a document with no head", async () => {
@@ -306,12 +434,17 @@ describe("renderServedHtml — branding off", () => {
   // bylines must not also lose `noindex`, which is policy rather than branding.
   // The tab icon goes with them: a Symposium mark in the reader's tab is
   // branding too. The robots meta is policy and stays.
-  it("drops both bylines and the icon but keeps the robots meta", async () => {
+  it("drops both bylines, the icon and the card but keeps the robots meta", async () => {
     const bare = await bake(page("<p>hello</p>"), false);
 
     expect(bare).not.toContain(SYMPOSIUM_HEADER);
     expect(bare).not.toContain(SYMPOSIUM_FOOTER);
     expect(bare).not.toContain(FAVICON_LINK);
+    // The card carries Symposium's own image into somebody else's Discord,
+    // which is the most visible branding of the lot. `og:title` goes with it:
+    // a title with no image unfurls worse than the fallback would.
+    expect(bare).not.toContain(SOCIAL_CARD_META);
+    expect(bare).not.toContain("og:");
     expect(headOf(bare)).toContain(NOINDEX_META);
     expect(bare).toContain("<p>hello</p>");
   });


### PR DESCRIPTION
Fixes #34

## Problem

A `https://symposium.site/d/{id}` link pasted into Discord, Slack or X unfurls
as a bare url. `renderServedHtml` in `src/render.ts` injects the robots meta,
the favicon and the two bylines — nothing an unfurler reads. Fetching a live
document confirms it: the head carries the publisher's own `<meta charset>`,
`<title>` and nothing with an `og:` prefix.

A `symposium.md` link in the same channel shows the product card, so the
difference is visible side by side. Sharing a link is the product's whole
distribution path.

## Fix

The card is injected at serve time, alongside the other additions, so it
reaches documents already published rather than only ones pushed after this
deploy — the same reason the bylines are composed on the way out.

It lands in two pieces, which is the one design choice worth defending:

- **Static half prepended into `<head>`** — `og:image` with its real 1200×630
  dimensions, `og:site_name`, `twitter:card: summary_large_image`. Stating the
  dimensions is what makes the *first* paste render full-bleed; without them a
  crawler that has not fetched the image yet guesses, and several render a
  thumbnail until a later scrape.
- **`og:title` injected before `</head>`** — read out of the document's own
  `<title>`, which has not been seen when `<head>` opens. A static title was
  the alternative and is worse than none: every document would unfurl under
  the same words, and the fallback an unfurler already reaches for is the
  `<title>` element, which at least names the document. Reading it from the
  document also keeps the rendering a pure function of the stored bytes — no
  D1 read, so the served etag stays a per-object validator.

The split means a document that never closes its head keeps the image and
loses only `og:title`, where the unfurler's own fallback is the same string.

`OG_IMAGE_URL` points at `https://symposium.md/og-image.png` rather than the
marketing site's Vercel deployment url. `og:image` is the one Symposium
addition that cannot be inlined — an unfurler fetches it over http(s) from its
own infrastructure, so a data URI is not a valid value — and pinned `/v{n}`
pages are served `immutable` for a year, so a document published today hands
that url to crawlers long after this deploy.

The whole card is gated on `branding`, like the favicon: a card carrying
Symposium's own image is what a paying customer's link would show in somebody
else's Discord. `og:title` goes with it rather than being kept alone, since a
title with no image unfurls worse than the fallback.

`RENDER_REVISION` moves 2 → 3, so a reader or cache holding the previous
rendering revalidates into this one instead of renewing a 304 indefinitely.

## Scope

Budget gate: PASS — 4 files, +298/−20; the only production logic added is one
`<title>` text accumulator and one `</head>` hook, both on the single pass that
already composes served output — there is no second place a card could be
injected and still reach published documents.

Most of the diff is this repo's comment density and `test/render.test.ts`
(+139). `og:type` was cut in the gate pass: nothing that unfurls these links
renders differently for it.

## Changes

- `src/render.ts` — `OG_IMAGE_URL`, `SOCIAL_CARD_META`, `socialTitleMeta()`
  and an `escapeAttribute()` helper; a `head > title` handler accumulating the
  document title; a `</head>` hook and a document-end fallback for the title
  meta; `RENDER_REVISION` 2 → 3.
- `test/render.test.ts` — the injected tags and their placement, title
  escaping, whitespace collapsing, the length cap, first-title-wins across
  repeated heads, the inline-SVG `<title>` case, the unclosed-head fallback,
  and the branding-off path.
- `src/serve.ts`, `CLAUDE.md` — the two places that enumerate what gets
  injected now name the card.

## Verification

- `npm test` — 253 passed, 8 files. (The `R2 is down` stderr in `push.test.ts`
  is a deliberate failure-path fixture, present on `main` too.)
- `npm run typecheck` — clean.
- Ten new tests in `test/render.test.ts`, including the one that carries the
  escaping claim: a title of `"><script>alert(1)</script><meta x="` appears
  exactly once in the output — as the publisher's own RCDATA, unchanged — and
  the injected meta is fully entity-escaped.

Not verified, and stated rather than asserted: **no deployed document has been
pasted into Discord or X yet.** Two things are worth checking against a real
post before this is marked ready.

- `https://symposium.md/og-image.png` answers `200 image/png`, 1200×630
  (checked with `curl` + `file`). But `symposium.md`'s *own* `og:image` points
  at `symposium-site-git-site-symposium-landing-...vercel.app/og-image.png`,
  which answers `302` to `vercel.com/sso-api` — so the brand site's card is
  likely not rendering today either. That is a separate fix on the marketing
  site; this PR deliberately does not depend on that url.
- Documents are served `X-Robots-Tag: noindex, nofollow`. Discord, Slack and
  Facebook's crawlers unfurl regardless; X's behaviour under a robots signal is
  worth confirming empirically rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
