### PR TITLE
Make missing document updates fail closed

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -290,9 +290,14 @@ symposium: 9f2k4mvq7t0xbz3n
 ---
 ```
 
-If a `PUT` answers `404`, the stored id is stale — the doc was deleted, or the
-note travelled to a vault signed in with a different license key. Fall back to
-`POST` and replace the id in frontmatter with the new one.
+If a `PUT` answers `404 not_found`, treat the update as terminal: stop and
+surface the failure for identity reconciliation. Do not automatically `POST` a
+replacement or remove or overwrite the saved `docId`. The response deliberately
+does not reveal whether the id is unknown, deleted, or belongs to another
+account.
+
+Publishing as a new document is a separate action that requires explicit user
+confirmation.
 
 ## A whole round trip
 

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -123,6 +123,18 @@ const quotaRows = async () =>
 
 const allObjects = async () => (await env.DOCS.list()).objects;
 
+/** Every persistence surface a rejected PUT must leave unchanged. */
+async function pushPersistence() {
+  return {
+    docs: (await env.DB.prepare("SELECT * FROM docs ORDER BY id").all<DocRow>()).results,
+    versions: (
+      await env.DB.prepare("SELECT * FROM versions ORDER BY doc_id, n").all<VersionRow>()
+    ).results,
+    quota: await quotaRows(),
+    objectKeys: (await allObjects()).map((object) => object.key),
+  };
+}
+
 async function pushedOk(response: Response, status: number): Promise<PushResponse> {
   expect(response.status).toBe(status);
   return (await response.json()) as PushResponse;
@@ -270,27 +282,30 @@ describe("PUT /api/v1/docs/{docId}", () => {
       await post(KEY_A, { title: "Private", html: page("<p>x</p>") }),
       201,
     );
+    const before = await pushPersistence();
 
     const response = await put(KEY_B, created.docId, { html: page("<p>hijacked</p>") });
 
     // 404, never 403: a 403 would confirm the id is real.
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: { code: "not_found", message: expect.any(String) },
+      error: { code: "not_found", message: `No doc with id ${created.docId}.` },
     });
 
-    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+    expect(await pushPersistence()).toEqual(before);
     expect(await stored(created.docId, 1)).toContain("<p>x</p>");
-    expect(await docRow(created.docId)).toMatchObject({ latest_version: 1, owner: ownerA });
-    // And it cost the caller nothing: a push that never happened is not a push.
-    expect(await quotaRows()).toMatchObject([{ owner: ownerA, pushes: 1 }]);
   });
 
   it("404s a doc that does not exist", async () => {
+    const before = await pushPersistence();
+
     const response = await put(KEY_A, UNKNOWN_DOC_ID, { html: page("<p>x</p>") });
 
     expect(response.status).toBe(404);
-    expect(await allObjects()).toHaveLength(0);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "not_found", message: `No doc with id ${UNKNOWN_DOC_ID}.` },
+    });
+    expect(await pushPersistence()).toEqual(before);
   });
 
   it("404s an id that could never be a doc id, without touching D1", async () => {
@@ -336,11 +351,15 @@ describe("PUT /api/v1/docs/{docId}", () => {
     await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?")
       .bind(Date.now(), created.docId)
       .run();
+    const before = await pushPersistence();
 
     const response = await put(KEY_A, created.docId, { html: page("<p>y</p>") });
 
     expect(response.status).toBe(404);
-    expect(await env.DOCS.head(versionObjectKey(created.docId, 2))).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "not_found", message: `No doc with id ${created.docId}.` },
+    });
+    expect(await pushPersistence()).toEqual(before);
   });
 });
 


### PR DESCRIPTION
Fixes #36

Related: [logancyang/obsidian-copilot-preview#257](https://github.com/logancyang/obsidian-copilot-preview/issues/257).

## Problem

`docs/http-api.md` told clients to recover a `PUT` `404` by publishing a new document and replacing the saved `docId`. Because the same response intentionally covers unknown, deleted, and other-account targets, that fallback converted an ambiguous terminal update failure into a duplicate public link and defeated the server's existing fail-closed behavior.

## Fix

Define `PUT 404 not_found` as terminal client behavior: stop, surface the failure for identity reconciliation, preserve the saved `docId`, and never automatically `POST` a replacement. Publishing as a new document is now explicitly a separate, user-confirmed action.

Strengthen the three existing rejected-PUT tests with before/after snapshots of document rows, version rows, push quota, and R2 keys. Their shared generic error message is pinned as well, preserving the non-disclosure boundary.

## Scope

Budget gate: PASS — 2 files, +34/−10; one contract correction and one shared persistence snapshot strengthen the existing PUT 404 cases without changing runtime behavior.

No Worker runtime, endpoint, request or response shape, authentication, quota, ownership, tombstone, public URL, or database schema code changed.

## Changes

- `docs/http-api.md` removes the automatic PUT-to-POST fallback and requires explicit confirmation to publish as new.
- `test/push.test.ts` proves unknown, deleted, and other-account PUT targets create no replacement document, version, quota spend, or R2 object while preserving identity and non-disclosure.

## Verification

- `npm test` — passed: 8 test files, 253 tests.
- `npm run typecheck` — passed.
- `git diff --check` — passed.
- No lint or formatting script is defined in `package.json`.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)