### PR TITLE
Allow all paid Copilot users to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ where it runs.
   stored files are destroyed. Copies already sitting in someone's browser cache
   can't be recalled — no design can do that.
 - **See your docs.** List everything you've published, newest first.
-- **Publishing is gated to lifetime license holders.** Phase 1 is deliberately
-  narrow: the lifetime tier is a small, known group, which is the right size of
-  audience for the first public-hosting surface we run. A current Plus key
-  authenticates and is still refused, and is told why. Keys are checked against
-  the existing license server and the answer is cached for an hour, so a
-  license-server outage doesn't stop someone who has published before. Only
-  publishing is gated — anyone whose plan lapses keeps listing and unshare, so
-  no one is ever locked out of taking down what they already made public.
+- **Publishing is available to every paid Copilot user.** Active Plus
+  subscriptions and lifetime Supporter/Believer licenses are entitled. Keys are
+  checked against the existing license server and the answer is cached for an
+  hour, so a license-server outage doesn't stop someone who has published
+  before. The entitlement gate applies only to publishing; an authenticated
+  key whose recorded plan no longer qualifies can still list and unshare its
+  documents.
 - **Limits that stop abuse, not people.** 10MB per doc, 100 pushes a day, 500
   docs — generous enough that a real user never notices.
 
@@ -69,12 +68,10 @@ Roughly in order. Nothing below is started.
   there is a lot.
 - **Keeping old versions from piling up.** Every push is kept forever today.
   Fine for people, less fine once agents push on every edit.
-- **Opening publishing beyond lifetime holders.** Plus first, then a standalone
-  subscription around $2.99/mo for people who don't use Copilot at all. Widening
-  it is adding a string to one set in `src/auth.ts`, so the gate moves when the
-  abuse tooling and the support load say it can, not when the code is ready.
-  Publishing stays paid either way — reading is free and always will be, and free
-  publishing is not on the roadmap.
+- **A standalone publishing subscription.** Paid Copilot plans already include
+  publishing; a roughly $2.99/mo standalone option will let people who don't use
+  Copilot publish too. Reading stays free, and free publishing is not on the
+  roadmap.
   [`docs/cost-at-scale.md`](docs/cost-at-scale.md) §8 has the reasoning,
   including what the gate costs us in distribution.
 - **Then the actual product**: comments anchored to passages, agents drafting

--- a/docs/cost-at-scale.md
+++ b/docs/cost-at-scale.md
@@ -157,7 +157,7 @@ Day-one mitigations, all cheap in dollars:
 
 1. **Serve user content from a separate domain** than the product/brand domain (the `notion.site` / `googleusercontent.com` pattern). Reputation damage lands on the sacrificial domain, not on `symposium.md` itself. This is the single highest-leverage decision and it costs $10/yr.
 2. **`noindex` + `nofollow` by default.** Shared docs are for invited readers, not search engines. This deletes the SEO-spam incentive entirely, which is most of the spam volume. (Publishers can opt into indexing later, as a feature, maybe a paid one.)
-3. **Publisher-gated, reader-open.** Publishing requires an entitled plan — the lifetime tier only in phase 1, see §8; reading requires nothing. The abuse funnel is throttled at the account layer: new-account rate limits, velocity checks on pushes.
+3. **Publisher-gated, reader-open.** Publishing requires a paid plan — active Copilot Plus and lifetime licenses today, with a standalone subscription planned; reading requires nothing. The abuse funnel is throttled at the account layer: new-account rate limits, velocity checks on pushes.
 4. **Automated scanning on push**: outbound links against Google Safe Browsing (free API); if/when image upload ships, CSAM hash-matching via Cloudflare's free tool (also a legal obligation, not a nice-to-have).
 5. **Report button + fast takedown path + registered DMCA agent** ($6). At small scale the takedown queue is minutes per week of founder time; budget real tooling for it around 100k users.
 
@@ -250,12 +250,11 @@ forever and gated access control at $5-8/mo. That is no longer the plan — see
   workflows from the positioning doc. This is where Notion-class ARPU lives if the
   thesis holds.
 
-**Phase 1 is narrower than any of that: lifetime license holders only.**
-Everything above is the steady state, not the launch. The lifetime tier is a small and known population,
-which is the right blast radius for the first public-hosting surface we operate —
-[serving-domain.md](serving-domain.md) is what one bad document costs. The gate is
-a single set in `src/auth.ts`, so it widens on operational confidence and support
-capacity rather than on engineering work.
+**The current launch gate includes every paid Copilot license.** Active Plus
+subscriptions and lifetime Supporter/Believer licenses can publish. The
+standalone Symposium subscription above is still planned; until it exists,
+publishing requires a paid Copilot license. The explicit set in `src/auth.ts`
+keeps unknown or future plans closed until their entitlement is deliberate.
 
 ### Break-even, on net receipts
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -68,15 +68,15 @@ npx wrangler deploy
 #    makes it reachable, and by now the running version already knows the hosts.
 
 # 8. Check what just shipped, end to end, against the surface that ships.
-SYMPOSIUM_LICENSE_KEY=<a real lifetime-tier key> \
+SYMPOSIUM_LICENSE_KEY=<a real paid Copilot key> \
   scripts/smoke.sh https://api.symposium.md
 ```
 
 The smoke script publishes a doc, reads it, lists it, deletes it and confirms the
 `410`. It spends one push against that key's daily quota and leaves no live doc
 and no stored bytes behind — only the deleted doc's row, which every delete keeps
-so the url can go on answering `410`. It is not part of CI, which has no lifetime
-key to spend.
+so the url can go on answering `410`. It is not part of CI, which has no paid
+license key to spend.
 
 ## There is no workers.dev url
 
@@ -184,7 +184,7 @@ Two things the workflow deliberately does not do:
   successful production deployment rather than the previous commit — a failed
   deploy leaves the bad file on `main`, where a commit-to-commit check would
   stop noticing it. Once applied, a migration is append-only: add a new file.
-- **It does not smoke-test.** That needs a real lifetime key, spends a push from
+- **It does not smoke-test.** That needs a real paid license key, spends a push from
   its daily quota, and writes to production R2 and D1 on every merge. `/health`
   on both hosts is the liveness check instead. Run `scripts/smoke.sh` by hand
   when the change warrants it.

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,9 +22,8 @@ wrangler@latest`.
 There is no license server locally, so the first push against `wrangler dev`
 fails with `internal`. Warm the validation cache by hand — the worker trusts a
 `publishers` row younger than an hour whose plan may publish, and a key is
-identified by the SHA-256 of itself. The plan has to be `believer`: any other
-value is not entitled to publish, so the row is skipped and the push falls
-through to a license server that is not there.
+identified by the SHA-256 of itself. Use `plus` or `believer`, the two paid plans
+entitled to publish. Any other value is refused by the publishing gate.
 
 `owner` is the account the documents get filed under — in production the
 `accountId` the license server returns, and locally any string you like, since
@@ -38,7 +37,7 @@ HASH=$(printf '%s' "$KEY" | shasum -a 256 | cut -d' ' -f1)
 npx wrangler d1 migrations apply symposium --local
 npx wrangler d1 execute symposium --local --command \
   "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
-   VALUES ('$HASH', 'believer', $(($(date +%s) * 1000)), 'local-account')"
+   VALUES ('$HASH', 'plus', $(($(date +%s) * 1000)), 'local-account')"
 
 SYMPOSIUM_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
 ```

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -41,13 +41,11 @@ can push a new version of, or unshare, a document another one created. Replacing
 a key changes nothing about which documents you have. Nothing in this API takes
 an account id as input, and none is ever returned.
 
-**A valid key is not sufficient to publish.** Publishing requires an entitled
-plan, and in phase 1 that is **the lifetime tier only** (`BELIEVER` on the
-license server, sold as Supporter): a current Plus key authenticates and is
-still refused. The refusal is `401 unauthorized` like every other auth failure,
-so no client change is needed — only the human-readable `message` distinguishes
-it. Widening the entitled set later is a server-side change with no client
-release.
+**Publishing requires a paid plan.** Both current license-server paid plans are
+entitled: `PLUS` subscriptions and the lifetime `BELIEVER` plan (sold as
+Supporter). An unknown or otherwise ineligible plan is refused with `401
+unauthorized` like every other auth failure, so only the human-readable
+`message` distinguishes it.
 
 The entitlement is **per operation, not per key**, and only `POST /api/v1/docs`
 and `PUT /api/v1/docs/{docId}` are gated on it. A publisher whose plan no longer
@@ -303,7 +301,7 @@ confirmation.
 
 ```bash
 BASE=https://api.symposium.md
-KEY=<lifetime license key>
+KEY=<paid Copilot license key>
 
 # publish
 curl -sS -X POST "$BASE/api/v1/docs" \

--- a/docs/private-sharing.md
+++ b/docs/private-sharing.md
@@ -149,7 +149,7 @@ step.
 ### Phase 1 — public links *(shipped)*
 
 The url is the capability. 80 bits of entropy, `noindex`, no reader identity.
-Publishing gated to lifetime license holders.
+Publishing is gated to paid Copilot plans.
 
 ### Phase 2 — reader identity
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -23,13 +23,13 @@ BASE_URL=${1:-${SYMPOSIUM_BASE_URL:-}}
 
 usage() {
   cat >&2 <<'EOF'
-usage: SYMPOSIUM_LICENSE_KEY=<lifetime license key> scripts/smoke.sh <base url>
+usage: SYMPOSIUM_LICENSE_KEY=<paid Copilot license key> scripts/smoke.sh <base url>
 
   <base url>          the API host, e.g. https://api.symposium.md
                       (or set SYMPOSIUM_BASE_URL instead of passing it)
                       Document reads use the url the push returns, so the
                       serving domain is never passed in.
-  SYMPOSIUM_LICENSE_KEY   a lifetime-tier license key with a push quota to spare.
+  SYMPOSIUM_LICENSE_KEY   a paid license key with a push quota to spare.
                       Never passed as an argument, never printed.
 EOF
   exit 2

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 /**
  * Publisher authentication.
  *
- * A publisher presents a Copilot Plus license key, and the only identifier the
+ * A publisher presents a Brevilabs license key, and the only identifier the
  * rest of the system ever sees is that key's SHA-256 (D2). The raw key exists
  * inside this module for exactly as long as it takes to hash it and hand it to
  * the license server — it is never stored, logged, or returned, not even a
@@ -46,16 +46,17 @@ const LICENSE_TIMEOUT_MS = 5_000;
 const UNKNOWN_PLAN = "unknown";
 
 /**
- * The plans entitled to publish. Phase 1 is Believers only.
+ * The paid Copilot plans entitled to publish.
  *
- * This is a product decision rather than a technical one: a lifetime tier is a
- * small and known population, which is the right blast radius for the first
- * public-hosting surface we operate. Widening it is adding a string here.
+ * The license server currently has two paid plans: Plus subscriptions and the
+ * lifetime Believer enum (sold as Supporter). Keep this explicit rather than
+ * treating every plan other than `free` as paid: a new or malformed value must
+ * fail closed until its entitlement is understood.
  *
  * Lowercase because `validateLicense` folds the license server's uppercase enum
  * before it gets here, and because `publishers.plan` stores the folded form.
  */
-const PUBLISHING_PLANS: ReadonlySet<string> = new Set(["believer"]);
+const PUBLISHING_PLANS: ReadonlySet<string> = new Set(["plus", "believer"]);
 
 /**
  * Entitlement is per *operation*, not per identity, so this is deliberately not
@@ -74,11 +75,7 @@ export function mayPublish(plan: string): boolean {
 /** The refusal a route gives a valid key whose plan may not publish. */
 export const INELIGIBLE_PLAN: { reason: PublisherFailure; message: string } = {
   reason: "ineligible_plan",
-  // "lifetime", not "Believer": `BELIEVER` is the license server's database
-  // enum, and the plan customers actually bought is sold as *Supporter*.
-  // Naming the enum here would print a word the reader has never seen. This
-  // mismatch is deliberate — do not "fix" it to match PUBLISHING_PLANS.
-  message: "Publishing is currently limited to lifetime license holders.",
+  message: "Publishing requires a paid plan.",
 };
 
 export interface Publisher {
@@ -316,8 +313,9 @@ async function validateLicense(token: string, env: Env, deps: AuthDeps): Promise
     typeof payload.backendAccess === "boolean" ? payload.backendAccess : isValid;
   if (!isValid || !backendAccess) return { status: "denied" };
 
-  // The server plan is an uppercase enum (`PLUS`, `BELIEVER`); store it folded
-  // so nothing downstream has to guess the casing, as the reference does too.
+  // The server plan is an uppercase enum (`FREE`, `PLUS`, `BELIEVER`); store it
+  // folded so nothing downstream has to guess the casing, as the reference
+  // does too.
   // The account that owns the key, which the license server sends as
   // `accountId`. Unlike the plan, this cannot degrade to a placeholder: it is
   // the identity every document is filed under, so a response we cannot read it

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -397,10 +397,15 @@ describe("resolvePublisher — a key the license server rejects", () => {
   });
 });
 
-describe("a plan that may not publish", () => {
-  const validPlus = answers({ isValid: true, plan: "plus", backendAccess: true, accountId: ACCOUNT });
+describe("publishing plan eligibility", () => {
+  const validPlus = answers({
+    isValid: true,
+    plan: "PLUS",
+    backendAccess: true,
+    accountId: ACCOUNT,
+  });
 
-  it("still authenticates — entitlement is not authentication", async () => {
+  it("authenticates a Plus subscriber and allows it to publish", async () => {
     const store = memoryStore();
 
     const result = await resolvePublisher(KEY, env(), {
@@ -409,13 +414,18 @@ describe("a plan that may not publish", () => {
       fetch: licenseServer(validPlus).fetch,
     });
 
-    // The key is real, so it resolves to a publisher and gets a row like any
-    // other. What it cannot do is publish, and that is the router's call.
     expect(result).toEqual({
       ok: true,
       publisher: { owner: ACCOUNT, plan: "plus" },
     });
     expect(store.rows.get(KEY_HASH)?.plan).toBe("plus");
+    expect(mayPublish("plus")).toBe(true);
+  });
+
+  it("allows every currently paid plan and fails closed for other values", () => {
+    expect(mayPublish("believer")).toBe(true);
+    expect(mayPublish("free")).toBe(false);
+    expect(mayPublish("unknown")).toBe(false);
   });
 
   it("carries a plan it cannot read as one that may not publish", async () => {
@@ -431,13 +441,13 @@ describe("a plan that may not publish", () => {
     expect(mayPublish(result.publisher.plan)).toBe(false);
   });
 
-  it("writes a downgrade back through the ordinary valid path", async () => {
+  it("writes a plan change back through the ordinary valid path", async () => {
     const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
 
     await resolvePublisher(KEY, env(), { store, now, fetch: licenseServer(validPlus).fetch });
 
-    // No special case needed: a downgraded publisher authenticates, so the row
-    // is refreshed like anyone else's and the stale `believer` is gone.
+    // The refreshed cache must carry the current plan so the router makes its
+    // entitlement decision from the latest successful validation.
     expect(store.rows.get(KEY_HASH)).toEqual({
       key_hash: KEY_HASH,
       owner: ACCOUNT,
@@ -446,7 +456,7 @@ describe("a plan that may not publish", () => {
     });
   });
 
-  it("refuses with the frozen code, and says why without naming the DB enum", async () => {
+  it("refuses an ineligible plan with the frozen code and a useful message", async () => {
     const response = publisherErrorResponse(INELIGIBLE_PLAN);
 
     expect(response.status).toBe(401);
@@ -454,11 +464,8 @@ describe("a plan that may not publish", () => {
     expect(await response.json()).toEqual({
       error: { code: "unauthorized", message: INELIGIBLE_PLAN.message },
     });
-    expect(INELIGIBLE_PLAN.message).toContain("lifetime");
+    expect(INELIGIBLE_PLAN.message).toContain("paid plan");
     expect(INELIGIBLE_PLAN.message).not.toContain("not valid");
-    // `BELIEVER` is the license server's DB enum and the plan is *sold* as
-    // Supporter, so neither word means anything to the person reading this.
-    expect(INELIGIBLE_PLAN.message).not.toMatch(/believer/i);
   });
 });
 
@@ -488,7 +495,7 @@ describe("the gate is on publishing, not on the publisher", () => {
       ["POST", "/docs"],
       ["PUT", `/docs/${VALID_DOC_ID}`],
     ] as const) {
-      const res = await call(method, path, seeded("plus"));
+      const res = await call(method, path, seeded("unknown"));
 
       expect(res.status).toBe(401);
       await expect(res.json()).resolves.toEqual({
@@ -504,16 +511,10 @@ describe("the gate is on publishing, not on the publisher", () => {
   // which is a claim about D1 rather than about the gate.
 
   it("leaves the doc list working for a plan that may not publish", async () => {
-    const res = await call("GET", "/docs", seeded("plus"));
+    const res = await call("GET", "/docs", seeded("unknown"));
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ docs: [] });
-  });
-
-  it("lets an entitled plan past the gate", async () => {
-    const res = await call("GET", "/docs", seeded("believer"));
-
-    expect(res.status).toBe(200);
   });
 });
 

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -38,18 +38,19 @@ async function sha256Hex(value: string): Promise<string> {
  * authenticating, so the license cache is warm and no license server is ever
  * reached.
  *
- * Each key gets its own account by default; passing one explicitly is how a test
- * says "these two keys are the same person". Returns that account, which is what
- * the key's doc rows will carry.
+ * Each key gets its own account and a Believer plan by default. Passing an
+ * account explicitly is how a test says "these two keys are the same person";
+ * passing a plan exercises entitlement. Returns the account, which is what the
+ * key's doc rows will carry.
  */
-async function seedPublisher(key: string, owner?: string): Promise<string> {
+async function seedPublisher(key: string, owner?: string, plan = "believer"): Promise<string> {
   const keyHash = await sha256Hex(key);
   const account = owner ?? `account-${keyHash.slice(0, 8)}`;
   await env.DB.prepare(
     `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
-     VALUES (?, 'believer', ?, ?)`,
+     VALUES (?, ?, ?, ?)`,
   )
-    .bind(keyHash, Date.now(), account)
+    .bind(keyHash, plan, Date.now(), account)
     .run();
   return account;
 }
@@ -198,6 +199,27 @@ async function walk(key: string, limit: number): Promise<string[]> {
   }
   throw new Error("the list never ran out of pages");
 }
+
+describe("paid publishing plans", () => {
+  it("lets a Plus subscriber publish and push a new version", async () => {
+    await seedPublisher(KEY_A, ownerA, "plus");
+
+    const created = await publish(KEY_A, "Plus v1");
+    const updated = await push(
+      KEY_A,
+      { title: "Plus v2", html: page("<p>second draft</p>") },
+      created.docId,
+    );
+
+    expect(created.version).toBe(1);
+    expect(updated.version).toBe(2);
+    expect((await read(`/d/${created.docId}`)).status).toBe(200);
+    expect(await objectKeys(created.docId)).toEqual([
+      versionObjectKey(created.docId, 1),
+      versionObjectKey(created.docId, 2),
+    ]);
+  });
+});
 
 describe("DELETE /api/v1/docs/{docId}", () => {
   it("204s a doc I own and turns its public url into a 410", async () => {
@@ -647,15 +669,15 @@ describe("two keys belonging to one account", () => {
  * already put on the internet — most of all the power to take it down.
  */
 describe("a publisher whose plan may no longer publish", () => {
-  /** Downgrade in place, with the cache left warm so no license server is reached. */
-  const downgrade = async (key: string) =>
-    env.DB.prepare("UPDATE publishers SET plan = 'plus', validated_at = ? WHERE key_hash = ?")
+  /** Mark it ineligible, with the cache left warm so no license server is reached. */
+  const makeIneligible = async (key: string) =>
+    env.DB.prepare("UPDATE publishers SET plan = 'unknown', validated_at = ? WHERE key_hash = ?")
       .bind(Date.now(), await sha256Hex(key))
       .run();
 
   it("can still unshare a doc it published while it was entitled", async () => {
     const created = await publish(KEY_A, "Published while entitled");
-    await downgrade(KEY_A);
+    await makeIneligible(KEY_A);
 
     expect((await del(KEY_A, created.docId)).status).toBe(204);
 
@@ -668,7 +690,7 @@ describe("a publisher whose plan may no longer publish", () => {
 
   it("can still list what it has published, which is how it finds what to unshare", async () => {
     const created = await publish(KEY_A, "Still mine");
-    await downgrade(KEY_A);
+    await makeIneligible(KEY_A);
 
     const { docs } = await listed(await list(KEY_A));
 
@@ -676,7 +698,7 @@ describe("a publisher whose plan may no longer publish", () => {
   });
 
   it("cannot publish a new doc", async () => {
-    await downgrade(KEY_A);
+    await makeIneligible(KEY_A);
 
     const response = await send("POST", "/api/v1/docs", KEY_A, { html: page("<p>new</p>") });
 
@@ -686,13 +708,12 @@ describe("a publisher whose plan may no longer publish", () => {
     // The frozen code, so a client matching on `code` is unaffected; only the
     // message carries the distinction.
     expect(body.error.code).toBe("unauthorized");
-    expect(body.error.message).toContain("lifetime");
-    expect(body.error.message).not.toMatch(/believer/i);
+    expect(body.error.message).toContain("paid plan");
   });
 
   it("cannot push a new version over a doc it already owns", async () => {
     const created = await publish(KEY_A, "Frozen at v1");
-    await downgrade(KEY_A);
+    await makeIneligible(KEY_A);
 
     const response = await send("PUT", `/api/v1/docs/${created.docId}`, KEY_A, {
       html: page("<p>v2</p>"),


### PR DESCRIPTION
## Problem

Symposium publishing is currently restricted to the lifetime `BELIEVER` plan, so active Copilot Plus subscribers authenticate successfully but receive a 401 when they try to publish.

## Changes

- Add `PLUS` to the explicit publishing-plan allowlist alongside `BELIEVER`.
- Continue failing closed for free, unknown, and malformed plan values.
- Update the ineligible-plan message and product/API/operations documentation to describe paid-plan access.
- Add unit coverage for both paid plans and a real Worker/D1/R2 round trip that publishes and republishes as a Plus subscriber.

## Impact

After deployment, active Plus subscribers can publish and update Symposium documents. Lifetime Supporter/Believer behavior is unchanged. This requires no database migration or client release.

## Validation

- `npm run typecheck`
- `npm test` — 254 tests passed
- `bash -n scripts/smoke.sh`
- `git diff --check`