### PR TITLE
Measure Symposium publishing without tracking readers

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -13,3 +13,9 @@ LICENSE_API_URL="https://api.brevilabs.com"
 # Publisher keys arrive per request in the Authorization header and are never
 # stored; only their SHA-256 is.
 LICENSE_API_KEY=""
+
+# Existing Brevilabs PostHog project's public ingest key. This authorizes event
+# capture only; do not use a phx_ personal API key here.
+POSTHOG_PROJECT_API_KEY=""
+# Override wrangler.jsonc's production label whenever local capture is enabled.
+ENVIRONMENT="development"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ back.
 | [Identity](docs/identity.md) | Who owns a document, why it is the account and not the license key, and how symposium.md sign-in slots in. |
 | [Private sharing](docs/private-sharing.md) | How reader identity works, and the phases from public links to agents. Designed, not built. |
 | [Deploying](docs/deploying.md) | Provisioning the resources and shipping. |
+| [Product analytics](docs/analytics.md) | Privacy-safe publishing events and aggregate document-view reporting. |
 | [Development](docs/development.md) | Running it locally, including the license-server workaround. |
 | [Comments](docs/comments.md) | Design sketch for the next step of the product. Not planned, not built. |
 | [Positioning](docs/positioning.md) | Why the product exists and what it becomes. |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,108 @@
+# Product analytics
+
+Symposium deliberately splits product analytics by surface:
+
+- Successful authenticated publishing operations go to the existing Brevilabs
+  PostHog project.
+- Public document requests remain in Cloudflare's aggregate HTTP analytics.
+
+Published pages do not load a PostHog SDK, set analytics cookies, or identify a
+reader. No document id, url, title, content, license key, storage key, exact
+size, raw error, referrer, IP address, or reader identifier is sent to PostHog.
+
+## PostHog publishing events
+
+The Worker emits these events only after a successful API response:
+
+| API operation | Event | Properties |
+| --- | --- | --- |
+| `POST /api/v1/docs` (`201`) | `symposium_publish` | `distinct_id`, `operation=create`, `service=symposium`, `environment`, `$process_person_profile=false` |
+| `PUT /api/v1/docs/{id}` (`200`) | `symposium_publish` | `distinct_id`, `operation=update`, `service=symposium`, `environment`, `$process_person_profile=false` |
+| `DELETE /api/v1/docs/{id}` (`204`) | `symposium_unshare` | `distinct_id`, `service=symposium`, `environment`, `$process_person_profile=false` |
+
+`distinct_id` is the Brevilabs account id authentication already resolves as
+the document owner. Capture runs through `ExecutionContext.waitUntil()`, so an
+analytics outage never delays or changes the publishing response.
+
+`POSTHOG_HOST` and `ENVIRONMENT` are non-secret bindings in `wrangler.jsonc`.
+Configure the project ingest key once on the deployed Worker:
+
+```bash
+npx wrangler secret put POSTHOG_PROJECT_API_KEY
+```
+
+Use the project's `phc_...` ingest key, not a `phx_...` personal API key. For
+local development, copy `.dev.vars.example` to the ignored `.dev.vars` file.
+When the secret is absent, capture is disabled.
+
+PostHog trends can report:
+
+- documents created: count `symposium_publish` where `operation=create`;
+- unique creators: unique users for that same series;
+- repeat publishing: count `symposium_publish` where `operation=update`;
+- documents withdrawn: count `symposium_unshare`.
+
+## Recent public document views in Cloudflare
+
+Cloudflare already receives every request to `symposium.site`. Use its GraphQL
+Analytics API to count successful end-user document `GET`s without exporting a
+document path or reader identifier to another system.
+
+Create a Cloudflare API token with read access to the `symposium.site` zone's
+analytics and set these shell variables locally; neither belongs in this repo:
+
+```bash
+export CLOUDFLARE_ANALYTICS_TOKEN="..."
+export CLOUDFLARE_ZONE_TAG="..."
+```
+
+This query counts successful `GET /d/*` requests on only the serving hostname.
+It excludes `HEAD`, API traffic, health checks, cache-purge traffic, errors, and
+redirects. `200` and `304` are included because both mean a reader successfully
+used a document representation.
+
+```bash
+curl --silent https://api.cloudflare.com/client/v4/graphql \
+  --header "Authorization: Bearer $CLOUDFLARE_ANALYTICS_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data @- <<JSON | jq .
+{
+  "query": "query DocumentViews($zoneTag: string, $start: Time, $end: Time) { viewer { zones(filter: { zoneTag: $zoneTag }) { views: httpRequestsAdaptiveGroups(limit: 1, filter: { datetime_geq: $start, datetime_lt: $end, clientRequestHTTPHost: \"symposium.site\", clientRequestHTTPMethod: \"GET\", clientRequestPath_like: \"/d/%\", requestSource: \"eyeball\", OR: [{ edgeResponseStatus: 200 }, { edgeResponseStatus: 304 }] }) { count avg { sampleInterval } confidence(level: 0.95) { count { estimate lower upper sampleSize } } } } } }",
+  "variables": {
+    "zoneTag": "$CLOUDFLARE_ZONE_TAG",
+    "start": "2026-08-01T00:00:00Z",
+    "end": "2026-09-01T00:00:00Z"
+  }
+}
+JSON
+```
+
+`count` is the estimated request total. The confidence fields and
+`sampleInterval` make adaptive sampling visible. It is a view/request metric,
+not a count of people: reloads and unidentified bots can contribute.
+
+### Discover the account-specific retention window
+
+Cloudflare retention and maximum query duration depend on the zone's plan and
+the token's access. Query the settings node instead of assuming a plan window:
+
+```bash
+curl --silent https://api.cloudflare.com/client/v4/graphql \
+  --header "Authorization: Bearer $CLOUDFLARE_ANALYTICS_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data @- <<JSON | jq '.data.viewer.zones[0].settings.httpRequestsAdaptiveGroups'
+{
+  "query": "query AnalyticsLimits($zoneTag: string) { viewer { zones(filter: { zoneTag: $zoneTag }) { settings { httpRequestsAdaptiveGroups { enabled maxDuration notOlderThan maxPageSize } } } } }",
+  "variables": { "zoneTag": "$CLOUDFLARE_ZONE_TAG" }
+}
+JSON
+```
+
+`notOlderThan` is retention in seconds; `maxDuration` is the widest time range
+one query may cover. Record the observed production values when access to the
+owning Cloudflare account is available.
+
+Cloudflare recent analytics is the current view destination. If the team later
+needs a permanent all-time history beyond `notOlderThan`, add a separate design
+that persists only daily aggregate totals. Do not add per-view PostHog events or
+reader identifiers.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,7 +14,7 @@ size, raw error, referrer, IP address, or reader identifier is sent to PostHog.
 
 The Worker emits these events only after a successful API response:
 
-| API operation | Event | Properties |
+| API operation | Event | PostHog fields |
 | --- | --- | --- |
 | `POST /api/v1/docs` (`201`) | `symposium_publish` | `distinct_id`, `operation=create`, `service=symposium`, `environment`, `$process_person_profile=false` |
 | `PUT /api/v1/docs/{id}` (`200`) | `symposium_publish` | `distinct_id`, `operation=update`, `service=symposium`, `environment`, `$process_person_profile=false` |

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -49,13 +49,14 @@ the one that makes the Worker reachable: `workers_dev` is `false`, so a Worker
 with no custom domain attached answers on nothing at all.
 
 ```bash
-# 4. Credentials for the license server. Both prompt for the value, so neither
-#    ends up in your shell history. LICENSE_API_KEY is *ours*, never a
+# 4. Runtime secrets. Each command prompts for the value, so none ends up in
+#    shell history. LICENSE_API_KEY is *ours*, never a
 #    publisher's key. On a first deploy the Worker does not exist yet, so the
 #    first of these also asks whether to create it — answer yes; step 5
 #    overwrites the placeholder and the secrets survive it.
 npx wrangler secret put LICENSE_API_URL     # e.g. https://api.brevilabs.com
 npx wrangler secret put LICENSE_API_KEY
+npx wrangler secret put POSTHOG_PROJECT_API_KEY # phc_ project ingest key
 
 # 5. Ship. The Worker has no hostname yet — see below.
 npx wrangler deploy

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": ">=20"
   },
   "scripts": {
+    "build": "wrangler deploy --dry-run --outdir dist",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -20,7 +20,6 @@ async function capture(env: Env, owner: string, event: SymposiumEvent): Promise<
   if (!env.POSTHOG_PROJECT_API_KEY || !env.POSTHOG_HOST || !env.ENVIRONMENT) return;
 
   const properties: Record<string, string | boolean> = {
-    distinct_id: owner,
     service: "symposium",
     environment: env.ENVIRONMENT,
     // Keep the shared account id available for event analysis without creating
@@ -35,6 +34,7 @@ async function capture(env: Env, owner: string, event: SymposiumEvent): Promise<
     body: JSON.stringify({
       api_key: env.POSTHOG_PROJECT_API_KEY,
       event: event.event,
+      distinct_id: owner,
       properties,
     }),
   });

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,73 @@
+import type { Env } from "./config.js";
+
+const POSTHOG_CAPTURE_PATH = "/i/v0/e/";
+
+export type PublishOperation = "create" | "update";
+
+type SymposiumEvent =
+  | { event: "symposium_publish"; operation: PublishOperation }
+  | { event: "symposium_unshare" };
+
+/**
+ * Send one deliberately small event to PostHog.
+ *
+ * The publisher id is the account id authentication already resolved for
+ * ownership. Document ids and request data are not accepted by this interface,
+ * which keeps accidental content, urls, license keys, and reader data out of
+ * the payload by construction.
+ */
+async function capture(env: Env, owner: string, event: SymposiumEvent): Promise<void> {
+  if (!env.POSTHOG_PROJECT_API_KEY || !env.POSTHOG_HOST || !env.ENVIRONMENT) return;
+
+  const properties: Record<string, string | boolean> = {
+    distinct_id: owner,
+    service: "symposium",
+    environment: env.ENVIRONMENT,
+    // Keep the shared account id available for event analysis without creating
+    // or updating a PostHog person profile.
+    $process_person_profile: false,
+  };
+  if (event.event === "symposium_publish") properties.operation = event.operation;
+
+  const response = await fetch(new URL(POSTHOG_CAPTURE_PATH, env.POSTHOG_HOST), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      api_key: env.POSTHOG_PROJECT_API_KEY,
+      event: event.event,
+      properties,
+    }),
+  });
+
+  if (!response.ok) {
+    // Deliberately omit owner and response body: neither helps operate the
+    // publisher API, and the body is controlled by a third party.
+    throw new Error(`PostHog capture returned HTTP ${response.status}`);
+  }
+}
+
+export function capturePublish(
+  env: Env,
+  owner: string,
+  operation: PublishOperation,
+): Promise<void> {
+  return capture(env, owner, { event: "symposium_publish", operation });
+}
+
+export function captureUnshare(env: Env, owner: string): Promise<void> {
+  return capture(env, owner, { event: "symposium_unshare" });
+}
+
+/**
+ * Analytics is a side effect of a completed operation, never part of it.
+ * `waitUntil` gives the request time to deliver the event after its response is
+ * ready; this catch guarantees a network or PostHog failure cannot reject the
+ * Worker request.
+ */
+export function scheduleCapture(ctx: ExecutionContext, delivery: Promise<void>): void {
+  ctx.waitUntil(
+    delivery.catch((error: unknown) => {
+      console.warn("PostHog capture failed", error);
+    }),
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,13 @@ export interface Env {
    * publisher's license key, and the two must never be confused.
    */
   LICENSE_API_KEY?: string;
+
+  /** PostHog project ingest key. A deployed Worker secret; never committed. */
+  POSTHOG_PROJECT_API_KEY?: string;
+  /** PostHog ingestion origin, configured as a non-secret Worker variable. */
+  POSTHOG_HOST?: string;
+  /** Deployment name attached to analytics events, e.g. `production`. */
+  ENVIRONMENT?: string;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { deleteDoc, listDocs } from "./api/manage.js";
 import { createDoc, updateDoc } from "./api/push.js";
+import { capturePublish, captureUnshare, scheduleCapture } from "./analytics.js";
 import {
   authenticateRequest,
   INELIGIBLE_PLAN,
@@ -68,7 +69,12 @@ export function resolveSurface(hostname: string, pathname: string, config: Surfa
  * Every API request authenticates before any handler sees it, so a handler can
  * assume a publisher and never has to reason about the license key.
  */
-async function handleApi(request: Request, url: URL, env: Env): Promise<Response> {
+async function handleApi(
+  request: Request,
+  url: URL,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   const auth = await authenticateRequest(request, env);
   if (!auth.ok) return publisherErrorResponse(auth);
 
@@ -101,16 +107,28 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
   // promise, for the reason spelled out on the catch below.
   if (collection === "docs" && extra.length === 0) {
     if (docId === undefined && request.method === "POST") {
-      return await createDoc(request, url, env, auth.publisher);
+      const response = await createDoc(request, url, env, auth.publisher);
+      if (response.status === 201) {
+        scheduleCapture(ctx, capturePublish(env, auth.publisher.owner, "create"));
+      }
+      return response;
     }
     if (docId === undefined && request.method === "GET") {
       return await listDocs(url, env, auth.publisher);
     }
     if (docId !== undefined && request.method === "PUT") {
-      return await updateDoc(request, url, env, auth.publisher, docId);
+      const response = await updateDoc(request, url, env, auth.publisher, docId);
+      if (response.status === 200) {
+        scheduleCapture(ctx, capturePublish(env, auth.publisher.owner, "update"));
+      }
+      return response;
     }
     if (docId !== undefined && request.method === "DELETE") {
-      return await deleteDoc(env, auth.publisher, docId);
+      const response = await deleteDoc(env, auth.publisher, docId);
+      if (response.status === 204) {
+        scheduleCapture(ctx, captureUnshare(env, auth.publisher.owner));
+      }
+      return response;
     }
   }
 
@@ -118,7 +136,7 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
 }
 
 export default {
-  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
     // Deliberately outside the surface split: the deploy smoke check has to
@@ -140,7 +158,7 @@ export default {
       // handle it, which fails the whole test run.
       switch (surface) {
         case "api":
-          return await handleApi(request, url, env);
+          return await handleApi(request, url, env, ctx);
         case "serving":
           return await handleServing(request, url, env);
         default:

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,0 +1,170 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/config.js";
+import { DOC_ID_LENGTH } from "../src/ids.js";
+import worker from "../src/index.js";
+
+const API_ORIGIN = "https://symposium.workers.dev";
+const KEY = "cplus_live_analytics1234";
+const ANALYTICS_ENV: Partial<Env> = {
+  POSTHOG_PROJECT_API_KEY: "phc_test",
+  POSTHOG_HOST: "https://us.i.posthog.com",
+  ENVIRONMENT: "test",
+};
+const UNKNOWN_DOC_ID = "0123456789abcdefghjkmnpqrstvwxyz".repeat(2).slice(0, DOC_ID_LENGTH);
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function send(method: string, path: string, body?: unknown): Promise<Response> {
+  const headers = new Headers({ authorization: `Bearer ${KEY}` });
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    headers.set("content-type", "application/json");
+    init.body = JSON.stringify(body);
+  }
+
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(
+    new Request(`${API_ORIGIN}${path}`, init),
+    { ...env, ...ANALYTICS_ENV },
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+const page = (text: string) =>
+  `<!doctype html><html><head><title>Analytics test</title></head><body>${text}</body></html>`;
+
+interface CapturePayload {
+  api_key: string;
+  event: string;
+  properties: Record<string, unknown>;
+}
+
+describe("PostHog publishing analytics", () => {
+  let owner = "";
+
+  beforeEach(async () => {
+    owner = `account-${(await sha256Hex(KEY)).slice(0, 8)}`;
+    await env.DB.prepare(
+      `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
+       VALUES (?, 'plus', ?, ?)`,
+    )
+      .bind(await sha256Hex(KEY), Date.now(), owner)
+      .run();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("captures one allowlisted event after each successful create, update, and unshare", async () => {
+    const captures: Array<{ url: string; payload: CapturePayload }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      captures.push({
+        url: String(input),
+        payload: JSON.parse(String(init?.body)) as CapturePayload,
+      });
+      return new Response(null, { status: 200 });
+    });
+
+    const createdResponse = await send("POST", "/api/v1/docs", {
+      title: "Private title",
+      html: page("private contents"),
+    });
+    expect(createdResponse.status).toBe(201);
+    const created = (await createdResponse.json()) as { docId: string };
+
+    expect(
+      (
+        await send("PUT", `/api/v1/docs/${created.docId}`, {
+          title: "Changed private title",
+          html: page("changed private contents"),
+        })
+      ).status,
+    ).toBe(200);
+    expect((await send("DELETE", `/api/v1/docs/${created.docId}`)).status).toBe(204);
+
+    expect(captures).toEqual([
+      {
+        url: "https://us.i.posthog.com/i/v0/e/",
+        payload: {
+          api_key: "phc_test",
+          event: "symposium_publish",
+          properties: {
+            distinct_id: owner,
+            service: "symposium",
+            environment: "test",
+            $process_person_profile: false,
+            operation: "create",
+          },
+        },
+      },
+      {
+        url: "https://us.i.posthog.com/i/v0/e/",
+        payload: {
+          api_key: "phc_test",
+          event: "symposium_publish",
+          properties: {
+            distinct_id: owner,
+            service: "symposium",
+            environment: "test",
+            $process_person_profile: false,
+            operation: "update",
+          },
+        },
+      },
+      {
+        url: "https://us.i.posthog.com/i/v0/e/",
+        payload: {
+          api_key: "phc_test",
+          event: "symposium_unshare",
+          properties: {
+            distinct_id: owner,
+            service: "symposium",
+            environment: "test",
+            $process_person_profile: false,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("does not capture failed create, update, or unshare operations", async () => {
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    expect((await send("POST", "/api/v1/docs", { title: "missing html" })).status).toBe(400);
+    expect(
+      (
+        await send("PUT", `/api/v1/docs/${UNKNOWN_DOC_ID}`, {
+          html: page("not published"),
+        })
+      ).status,
+    ).toBe(404);
+    expect((await send("DELETE", `/api/v1/docs/${UNKNOWN_DOC_ID}`)).status).toBe(404);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful API response when PostHog delivery fails", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("analytics offline");
+    });
+
+    const response = await send("POST", "/api/v1/docs", {
+      title: "Still published",
+      html: page("still stored"),
+    });
+
+    expect(response.status).toBe(201);
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith("PostHog capture failed", expect.any(Error));
+  });
+});

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -42,6 +42,7 @@ const page = (text: string) =>
 interface CapturePayload {
   api_key: string;
   event: string;
+  distinct_id: string;
   properties: Record<string, unknown>;
 }
 
@@ -96,8 +97,8 @@ describe("PostHog publishing analytics", () => {
         payload: {
           api_key: "phc_test",
           event: "symposium_publish",
+          distinct_id: owner,
           properties: {
-            distinct_id: owner,
             service: "symposium",
             environment: "test",
             $process_person_profile: false,
@@ -110,8 +111,8 @@ describe("PostHog publishing analytics", () => {
         payload: {
           api_key: "phc_test",
           event: "symposium_publish",
+          distinct_id: owner,
           properties: {
-            distinct_id: owner,
             service: "symposium",
             environment: "test",
             $process_person_profile: false,
@@ -124,8 +125,8 @@ describe("PostHog publishing analytics", () => {
         payload: {
           api_key: "phc_test",
           event: "symposium_unshare",
+          distinct_id: owner,
           properties: {
-            distinct_id: owner,
             service: "symposium",
             environment: "test",
             $process_person_profile: false,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -63,6 +63,8 @@
   // nothing, so going first costs nothing.
   "vars": {
     "SERVING_HOST": "symposium.site",
-    "API_HOST": "api.symposium.md"
+    "API_HOST": "api.symposium.md",
+    "POSTHOG_HOST": "https://us.i.posthog.com",
+    "ENVIRONMENT": "production"
   }
 }


### PR DESCRIPTION
Relates to #39

## Why

Symposium can publish and withdraw documents, but the team cannot currently measure whether authors use those actions. Public readers are a different privacy surface: counting their requests is valuable, but loading PostHog in a published document would create a new cross-document reader graph.

## What

Successful authenticated create, update, and unshare operations now send a small allowlisted event to the existing Brevilabs PostHog project. Capture is best-effort and runs after the API result, so analytics cannot delay or fail the author action.

| Action | Destination | Recorded context |
| --- | --- | --- |
| Create or update a document | PostHog | Trusted publisher ID, operation, service, environment |
| Unshare a document | PostHog | Trusted publisher ID, service, environment |
| View a public document | Cloudflare analytics | Aggregate successful `GET /d/*` requests only |

The operator guide includes reproducible Cloudflare queries for recent view totals, sampling confidence, and the account-specific retention limit.

## Non goal

- Do not send document IDs, URLs, titles, content, license keys, storage keys, sizes, raw errors, referrers, IP addresses, or reader identifiers to PostHog.
- Do not send per-view, first-view, or daily summary events to PostHog.
- Do not treat request totals as unique people or count list/manage-page activity as product value.
- Do not add analytics JavaScript, cookies, or session replay to published documents.
- Do not add permanent D1 view aggregation until the team decides all-time history is required.

## Screenshot

Not applicable — this PR changes Worker-side analytics and operator documentation without changing rendered pages.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic Worker tests cover every emitted payload, failed operation, and delivery failure |
| A defect would fail CI or be obvious on first use | ❌ | A live Cloudflare analytics schema or account mismatch is visible only when an owner runs the documented query |
| A revert fully restores prior state, including persisted data | ❌ | A revert stops future capture, but already-ingested PostHog events remain |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The authenticated publisher ID becomes an analytics field and deployment gains a PostHog ingest secret |
| No public API, plugin API, message, or on-disk contract changes | ❌ | This introduces a PostHog event schema consumed by analytics reports |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Successful API handlers schedule best-effort delivery with `waitUntil()` |
| No hot-path behavior lacks deterministic coverage | ✅ | Create, update, unshare, failure, and analytics-outage branches have deterministic coverage |
| No new dependency | ✅ | Dependency manifests add no runtime package |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The only human-only check is the documented Cloudflare analytics query, which returns its schema or access error immediately |

Review: inspect `src/analytics.ts` — `capture` and `scheduleCapture` — and `src/index.ts` — `handleApi` — line by line, then run Verification steps 1–3 including failed operations, an unreachable PostHog host, and both Cloudflare queries.

## Verification

1. Run `npm test -- test/analytics.test.ts`; confirm create, update, and unshare each produce one allowlisted event while failed operations produce none.
2. In that test, force PostHog delivery to reject; confirm the publishing response remains successful and the failure is contained by the execution context.
3. With read access to the production `symposium.site` zone, run the two queries in `docs/analytics.md`; confirm the first reports only successful end-user `GET /d/*` requests and the second reports `notOlderThan` and `maxDuration` for that account.

## Note

The current Wrangler credentials point to a different Cloudflare account than the production zone, so this PR does not claim a production retention value or configure the production secret. A production account maintainer must record that value and set `POSTHOG_PROJECT_API_KEY` before #39 can close.
