### PR TITLE
Show a proper page for deleted documents

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -221,11 +221,14 @@ worth knowing:
   and the same rendering always produce the same tag, and `If-None-Match` with
   it returns `304`.
 
-`404` for an unknown id or version; `410` once the doc is deleted.
+`404` for an unknown id or version. Once the doc is deleted, `GET` returns a
+self-contained reader-facing HTML page with `410 Gone`; `HEAD` returns the same
+status and headers without a body.
 
 ## Errors
 
-Every failure, on both surfaces, is:
+Every publisher-facing failure and every public-serving failure except a
+deleted document is:
 
 ```json
 {"error": {"code": "not_found", "message": "No doc with id ..."}}
@@ -238,7 +241,6 @@ Match on `code`. `message` is human-facing and free to change.
 | `bad_request` | 400 | Malformed JSON, `html` missing, empty or not a string, non-string `title`, junk `limit` or `cursor`. |
 | `unauthorized` | 401 | No `Authorization: Bearer` header, the license server rejected the key, or — on `POST` and `PUT` only — the key's plan is not entitled to publish. Carries `WWW-Authenticate: Bearer`. |
 | `not_found` | 404 | No such doc, not yours, already deleted, or no route. |
-| `gone` | 410 | The doc was deleted by its author. |
 | `too_large` | 413 | `html` over 10MB. |
 | `quota_exceeded` | 429 | Daily push or doc-count ceiling reached. |
 | `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,13 +1,11 @@
 /**
- * The error contract: every failure is `{error: {code, message}}` with the
- * status derived from the code, so the code is the stable thing clients match
- * on and the message stays free to change.
+ * The JSON error contract for publisher APIs and non-page serving failures.
+ * The code is stable for clients to match; the message stays free to change.
  */
 export type ErrorCode =
   | "bad_request"
   | "unauthorized"
   | "not_found"
-  | "gone"
   | "too_large"
   | "quota_exceeded"
   | "internal";
@@ -16,7 +14,6 @@ const ERROR_STATUS: Record<ErrorCode, number> = {
   bad_request: 400,
   unauthorized: 401,
   not_found: 404,
-  gone: 410,
   too_large: 413,
   quota_exceeded: 429,
   internal: 500,

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,12 @@ import type { Env } from "./config.js";
 import { findServableVersion } from "./db.js";
 import { errorResponse } from "./errors.js";
 import { isDocId } from "./ids.js";
-import { RENDER_REVISION, renderServedHtml } from "./render.js";
+import {
+  FAVICON_LINK,
+  NOINDEX_META,
+  RENDER_REVISION,
+  renderServedHtml,
+} from "./render.js";
 import { STORED_CONTENT_TYPE, versionObjectKey } from "./storage.js";
 
 /** Path prefix of the serving surface, used by the router's path fallback. */
@@ -166,19 +171,61 @@ function servingHeaders(cacheControl: string): Headers {
 }
 
 /**
- * Every failure this surface answers with, exported because the router's
+ * Every JSON failure this surface answers with, exported because the router's
  * catch-all needs one too: a binding that throws mid-read must still produce a
  * *serving* response, or an outage becomes the one doc url that invites a
  * crawler in. Routing a thrown error back through here is what makes the header
  * policy a property of the surface rather than of remembering to add it.
  *
- * All of them are `no-store` rather than cacheable. 410 in particular is
- * heuristically cacheable by default, and a delete is the one answer a publisher
- * may need to be able to correct. Uncached costs us nothing: none of these ever
- * reached R2.
+ * All of them are `no-store` rather than cacheable. Uncached costs us nothing:
+ * none of these ever reached R2.
  */
-export function servingError(code: "not_found" | "gone" | "internal", message: string): Response {
+export function servingError(code: "not_found" | "internal", message: string): Response {
   return errorResponse(code, message, servingHeaders("no-store"));
+}
+
+const DELETED_DOCUMENT_PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+${NOINDEX_META}
+${FAVICON_LINK}
+<title>Document deleted · Symposium</title>
+<style>
+  :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  * { box-sizing: border-box; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 2rem; color: #edf3ee; background: #0d100e; }
+  main { width: min(100%, 34rem); padding: clamp(2rem, 6vw, 4rem); border: 1px solid #2b332e; border-radius: 1.5rem; background: #121613; box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.35); }
+  .brand { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 3.5rem; color: #a7b0aa; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; }
+  .mark { display: grid; gap: 0.25rem; width: 2rem; padding: 0.5rem 0.4rem; border-radius: 0.5rem; background: #46d17f; }
+  .mark span { display: block; height: 2px; border-radius: 999px; background: #0d100e; }
+  .mark span:last-child { width: 65%; }
+  h1 { max-width: 12ch; margin: 0; color: #f7faf7; font-size: clamp(2.25rem, 7vw, 4.25rem); line-height: 0.98; letter-spacing: -0.055em; }
+  p { max-width: 30rem; margin: 1.5rem 0 0; color: #a7b0aa; font-size: 1.05rem; line-height: 1.7; }
+  a { display: inline-flex; margin-top: 2rem; color: #72e29d; font-weight: 650; text-underline-offset: 0.25em; }
+  a:hover { color: #a0efbd; }
+</style>
+</head>
+<body>
+<main>
+  <div class="brand"><span class="mark" aria-hidden="true"><span></span><span></span><span></span></span>Symposium</div>
+  <h1>This document is gone.</h1>
+  <p>The author deleted this document. If you still need it, ask them to share a new copy.</p>
+  <a href="https://symposium.md">About Symposium</a>
+</main>
+</body>
+</html>`;
+
+function deletedDocumentResponse(method: string): Response {
+  // 410 is heuristically cacheable by default. A publisher may need to correct
+  // a mistaken deletion, so this response must never be stored by a cache.
+  const headers = servingHeaders("no-store");
+  headers.set("content-type", STORED_CONTENT_TYPE);
+  return new Response(method === "HEAD" ? null : DELETED_DOCUMENT_PAGE, {
+    status: 410,
+    headers,
+  });
 }
 
 /**
@@ -428,7 +475,7 @@ export async function handleServing(request: Request, url: URL, env: Env): Promi
   const found = await findServableVersion(env.DB, route.docId, route.pinned);
   if (found === null) return noDocAt(url.pathname);
   if (found.deleted_at !== null) {
-    return servingError("gone", "This doc was deleted by its author.");
+    return deletedDocumentResponse(request.method);
   }
   if (found.version === null) return noDocAt(url.pathname);
 

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -235,9 +235,8 @@ describe("DELETE /api/v1/docs/{docId}", () => {
     // than concluding they mistyped it. That is what the kept row buys.
     const gone = await read(`/d/${created.docId}`);
     expect(gone.status).toBe(410);
-    await expect(gone.json()).resolves.toEqual({
-      error: { code: "gone", message: expect.any(String) },
-    });
+    expect(gone.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(await gone.text()).toContain("The author deleted this document.");
   });
 
   it("410s the doc's pinned versions too", async () => {

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -378,9 +378,12 @@ describe("a deleted doc", () => {
     const response = await get(`/d/${docId}`);
 
     expect(response.status).toBe(410);
-    await expect(response.json()).resolves.toEqual({
-      error: { code: "gone", message: expect.any(String) },
-    });
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    const html = await response.text();
+    expect(html).toContain("<title>Document deleted · Symposium</title>");
+    expect(html).toContain("This document is gone.");
+    expect(html).toContain("The author deleted this document.");
+    expect(html).toContain(NOINDEX_META);
     // A reader who bookmarked the link deserves to know it was withdrawn, not
     // to wonder whether they mistyped it.
     expect(response.headers.get("cache-control")).toBe("no-store");
@@ -393,6 +396,8 @@ describe("a deleted doc", () => {
     for (const path of [`/d/${docId}/v1`, `/d/${docId}/v2`, `/d/${docId}/v99`]) {
       const response = await get(path);
       expect({ path, status: response.status }).toEqual({ path, status: 410 });
+      expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await response.text()).toContain("The author deleted this document.");
     }
   });
 
@@ -526,7 +531,12 @@ describe("HEAD and conditional requests", () => {
     const docId = await twoVersionDoc();
     await softDelete(docId);
 
-    expect((await send("HEAD", `/d/${docId}`)).status).toBe(410);
+    const response = await send("HEAD", `/d/${docId}`);
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).toBe("");
   });
 
   it("answers a matching If-None-Match with 304 and no body", async () => {


### PR DESCRIPTION
Fixes #41

## Why

A reader who follows a shared Symposium link after its author deletes the document currently sees raw JSON instead of a clear, intentional page.

## What

> **Before:** A deleted latest or pinned document link returns a raw JSON error.
>
> **After:** The same link renders a self-contained Symposium page explaining that the author deleted the document, while retaining `410 Gone`, no-store caching, and crawler-blocking headers.

`HEAD` remains bodyless with the same status and headers.

## Non goal

- Changing unknown-document or internal-error pages.
- Restoring deleted content or changing deletion, retention, or cache purging.
- Changing publisher API JSON responses.

## Screenshot

Screenshot unavailable — the rendered after state was captured and checked locally, but the authenticated Chrome extension does not have file-upload access enabled. The base branch's raw `application/json` response was verified from current `main` and its deterministic deletion tests.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deleted latest, pinned, and HEAD responses have deterministic tests |
| A defect would fail CI or be obvious on first use | ✅ | Contract tests run in CI and the rendered page is immediately visible |
| A revert fully restores prior state, including persisted data | ✅ | No migration, stored data, or irreversible write changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The existing deleted-document serving branch is the only changed request path |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The public deleted-document response body changes from JSON to HTML |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Deletion state and serving order are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Latest, pinned, HEAD, and unchanged error behavior are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A regression appears immediately when a deleted link is opened |

Review: inspect `src/serve.ts` — `DELETED_DOCUMENT_PAGE`, `deletedDocumentResponse`, and the deleted branch in `handleServing` — line by line, then run Verification steps 2–4, including pinned, HEAD, and unknown-document variants.

## Verification

1. Publish a document in the local development environment, record its latest and pinned URLs, then delete it.
2. Open the latest and pinned URLs; each should show the Symposium deletion page with status `410`.
3. Send `HEAD` to the deleted URL; it should return `410` with an empty body.
4. Open an unknown document URL; it should remain a JSON `404`.
