### PR TITLE
Show proper pages for unavailable documents

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -221,20 +221,31 @@ worth knowing:
   and the same rendering always produce the same tag, and `If-None-Match` with
   it returns `304`.
 
-`404` for an unknown id or version. Once the doc is deleted, `GET` returns a
-self-contained reader-facing HTML page with `410 Gone`; `HEAD` returns the same
-status and headers without a body.
+Every Worker-controlled reader outcome where no document can be displayed is a
+self-contained HTML page:
+
+| Status | Reader sees |
+| --- | --- |
+| `404 Not Found` | A neutral unavailable page for an unknown or malformed link, a missing version, or missing stored bytes. |
+| `410 Gone` | An explicit deleted page when the retained doc row proves the author withdrew it. |
+| `500 Internal Server Error` | A temporary-unavailable page when a serving dependency fails. |
+
+All three are `no-store` and retain the serving header policy above. `HEAD`
+returns the same status and headers as `GET` without a body. Healthy `200` and
+conditional `304` responses are unchanged.
 
 ## Errors
 
-Every publisher-facing failure and every public-serving failure except a
-deleted document is:
+Every publisher-facing API failure is JSON:
 
 ```json
 {"error": {"code": "not_found", "message": "No doc with id ..."}}
 ```
 
 Match on `code`. `message` is human-facing and free to change.
+
+The public serving surface uses the HTML status pages above instead. It never
+exposes this API payload to a reader.
 
 | `code` | HTTP | When |
 | --- | --- | --- |

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,15 +148,15 @@ export default {
       }
     } catch (error) {
       // R2 and D1 can fail mid-request. Left uncaught they become workerd's
-      // plain-text 500 — the one response the frozen contract does not describe,
-      // and Copilot parses `{error:{code}}` on every failure. The cause is
-      // logged rather than returned: it can quote a query or a key.
+      // plain-text 500. The API keeps its JSON contract, while the reader-facing
+      // surface gets a proper status page. The cause is logged rather than
+      // returned because it can quote a query or a key.
       console.error("unhandled error", { path: url.pathname, error });
       const message = "Something went wrong on our end. Please try again.";
       // The surface still decides the headers. A 500 on a doc url is a serving
       // response like any other, and has to carry the robots tag that proves it.
       return surface === "serving"
-        ? servingError("internal", message)
+        ? servingError(request.method, "internal")
         : errorResponse("internal", message);
     }
   },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -19,7 +19,6 @@
  */
 import type { Env } from "./config.js";
 import { findServableVersion } from "./db.js";
-import { errorResponse } from "./errors.js";
 import { isDocId } from "./ids.js";
 import {
   FAVICON_LINK,
@@ -170,28 +169,47 @@ function servingHeaders(cacheControl: string): Headers {
   });
 }
 
-/**
- * Every JSON failure this surface answers with, exported because the router's
- * catch-all needs one too: a binding that throws mid-read must still produce a
- * *serving* response, or an outage becomes the one doc url that invites a
- * crawler in. Routing a thrown error back through here is what makes the header
- * policy a property of the surface rather than of remembering to add it.
- *
- * All of them are `no-store` rather than cacheable. Uncached costs us nothing:
- * none of these ever reached R2.
- */
-export function servingError(code: "not_found" | "internal", message: string): Response {
-  return errorResponse(code, message, servingHeaders("no-store"));
+type ServingPageKind = "not_found" | "deleted" | "internal";
+
+interface ServingPageCopy {
+  status: 404 | 410 | 500;
+  title: string;
+  heading: string;
+  message: string;
 }
 
-const DELETED_DOCUMENT_PAGE = `<!doctype html>
+const SERVING_PAGES: Record<ServingPageKind, ServingPageCopy> = {
+  not_found: {
+    status: 404,
+    title: "Document unavailable",
+    heading: "This document isn’t available.",
+    message:
+      "The link may be incorrect, or the author may have deleted the document. Check the address or ask the author to share a new copy.",
+  },
+  deleted: {
+    status: 410,
+    title: "Document deleted",
+    heading: "This document is gone.",
+    message:
+      "The author deleted this document. If you still need it, ask them to share a new copy.",
+  },
+  internal: {
+    status: 500,
+    title: "Document temporarily unavailable",
+    heading: "We can’t open this document right now.",
+    message: "Something went wrong on our end. Please try again in a moment.",
+  },
+};
+
+function servingPageHtml(copy: ServingPageCopy): string {
+  return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ${NOINDEX_META}
 ${FAVICON_LINK}
-<title>Document deleted · Symposium</title>
+<title>${copy.title} · Symposium</title>
 <style>
   :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
   * { box-sizing: border-box; }
@@ -208,35 +226,40 @@ ${FAVICON_LINK}
 </style>
 </head>
 <body>
-<main>
+<main aria-labelledby="page-title">
   <div class="brand"><span class="mark" aria-hidden="true"><span></span><span></span><span></span></span>Symposium</div>
-  <h1>This document is gone.</h1>
-  <p>The author deleted this document. If you still need it, ask them to share a new copy.</p>
+  <h1 id="page-title">${copy.heading}</h1>
+  <p>${copy.message}</p>
   <a href="https://symposium.md">About Symposium</a>
 </main>
 </body>
 </html>`;
+}
 
-function deletedDocumentResponse(method: string): Response {
-  // 410 is heuristically cacheable by default. A publisher may need to correct
-  // a mistaken deletion, so this response must never be stored by a cache.
+/**
+ * Every failure page is `no-store`. A 410 is heuristically cacheable by
+ * default, a 404 may later become a document, and a 500 is explicitly
+ * temporary. Keeping one response path makes the serving security policy and
+ * HEAD behavior properties of the surface rather than per-error conventions.
+ */
+function servingPageResponse(method: string, kind: ServingPageKind): Response {
+  const copy = SERVING_PAGES[kind];
   const headers = servingHeaders("no-store");
   headers.set("content-type", STORED_CONTENT_TYPE);
-  return new Response(method === "HEAD" ? null : DELETED_DOCUMENT_PAGE, {
-    status: 410,
+  return new Response(method === "HEAD" ? null : servingPageHtml(copy), {
+    status: copy.status,
     headers,
   });
 }
 
-/**
- * One message for "no such id", "malformed id" and "no such version" alike. The
- * id space is not worth probing at 80 bits, but a reply that distinguished the
- * cases would still be telling a stranger which ids are real — and that matters
- * more now the space is smaller, since an oracle is worth more to an enumerator
- * than the raw arithmetic suggests.
- */
-function noDocAt(pathname: string): Response {
-  return servingError("not_found", `No doc at ${pathname}`);
+/** Exported because the router's serving-surface catch-all needs the same page. */
+export function servingError(method: string, code: "not_found" | "internal"): Response {
+  return servingPageResponse(method, code);
+}
+
+/** One neutral page for every miss, so it never confirms whether an id existed. */
+function noDocAt(method: string): Response {
+  return servingError(method, "not_found");
 }
 
 interface DocRoute {
@@ -398,7 +421,6 @@ async function serveObject(
   env: Env,
   route: DocRoute,
   version: number,
-  pathname: string,
 ): Promise<Response> {
   const key = versionObjectKey(route.docId, version);
   const headers = servingHeaders(
@@ -412,7 +434,7 @@ async function serveObject(
   // wins over D1's rather than becoming a 500.
   if (request.method === "HEAD") {
     const object = await env.DOCS.head(key);
-    if (object === null) return noDocAt(pathname);
+    if (object === null) return noDocAt(request.method);
 
     headers.set("etag", servedEtag(object.httpEtag));
     // A validator has to mean the same thing whichever method asks. HEAD is
@@ -432,7 +454,7 @@ async function serveObject(
   }
 
   const object = await env.DOCS.get(key, { onlyIf: conditions });
-  if (object === null) return noDocAt(pathname);
+  if (object === null) return noDocAt(request.method);
 
   // The response is the object *and* the rendering applied to it, so the
   // validator names both. What it does not fix is a copy that never revalidates:
@@ -466,22 +488,22 @@ export async function handleServing(request: Request, url: URL, env: Env): Promi
   // does not have, and nothing that legitimately reads a doc sends anything
   // else — a POST to a doc url is a probe, and it gets what a probe gets.
   if (request.method !== "GET" && request.method !== "HEAD") {
-    return noDocAt(url.pathname);
+    return noDocAt(request.method);
   }
 
   const route = parseDocPath(url.pathname);
-  if (route === null) return noDocAt(url.pathname);
+  if (route === null) return noDocAt(request.method);
 
   const found = await findServableVersion(env.DB, route.docId, route.pinned);
-  if (found === null) return noDocAt(url.pathname);
+  if (found === null) return noDocAt(request.method);
   if (found.deleted_at !== null) {
-    return deletedDocumentResponse(request.method);
+    return servingPageResponse(request.method, "deleted");
   }
-  if (found.version === null) return noDocAt(url.pathname);
+  if (found.version === null) return noDocAt(request.method);
 
   // `return await`, not `return`, for the reason spelled out in index.ts: an
   // async function that hands back somebody else's promise unawaited drops
   // itself out of the rejection's stack and, in workerd, gets the rejection
   // reported as unhandled even though the router catches it.
-  return await serveObject(request, env, route, found.version, url.pathname);
+  return await serveObject(request, env, route, found.version);
 }

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -121,6 +121,8 @@ describe("worker dispatch", () => {
   it("hands /d to the serving surface on workers.dev", async () => {
     const res = await get(`https://${WORKERS_DEV}/d/abc`);
     expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(await res.text()).toContain("This document isn’t available.");
     expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
   });
 
@@ -135,11 +137,10 @@ describe("worker dispatch", () => {
       });
       expect(res.status).toBe(404);
       // Two independent signals that the serving surface answered: only it
-      // stamps the robots header, and only it phrases the miss as a doc.
+      // stamps the robots header, and only it renders an HTML status page.
       expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
-      await expect(res.json()).resolves.toEqual({
-        error: { code: "not_found", message: expect.stringContaining("No doc at") },
-      });
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("This document isn’t available.");
     }
   });
 

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -24,6 +24,23 @@ async function expectServes(response: Response, docId: string, version: number) 
   return html;
 }
 
+async function expectStatusPage(
+  response: Response,
+  status: number,
+  title: string,
+  heading: string,
+  message: string,
+) {
+  expect(response.status).toBe(status);
+  expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+  expect(response.headers.get("cache-control")).toBe("no-store");
+
+  const html = await response.text();
+  expect(html).toContain(`<title>${title} · Symposium</title>`);
+  expect(html).toContain(`<h1 id="page-title">${heading}</h1>`);
+  expect(html).toContain(message);
+  expect(html).toContain(NOINDEX_META);
+}
 
 /**
  * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
@@ -34,7 +51,6 @@ const ORIGIN = "https://symposium.workers.dev";
 
 const KEY = "cplus_live_a1b2c3d4e5f60718";
 
-/** A doc id of the right shape that no push ever minted. */
 /**
  * A well-formed id that is not in the database. Derived from DOC_ID_LENGTH, not
  * written out: a literal of the wrong length is rejected by `isDocId` on shape
@@ -248,6 +264,7 @@ describe("GET /d/{docId}/v{n}", () => {
     for (const n of [3, 4, 99]) {
       const response = await get(`/d/${docId}/v${n}`);
       expect({ n, status: response.status }).toEqual({ n, status: 404 });
+      expect(await response.text()).toContain("This document isn’t available.");
     }
   });
 
@@ -350,10 +367,13 @@ describe("the headers on every served page", () => {
     const docId = await twoVersionDoc();
     const response = await get(`/d/${docId}`, undefined, { DOCS: brokenDocs });
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({
-      error: { code: "internal", message: expect.any(String) },
-    });
+    await expectStatusPage(
+      response,
+      500,
+      "Document temporarily unavailable",
+      "We can’t open this document right now.",
+      "Something went wrong on our end. Please try again in a moment.",
+    );
     expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
@@ -377,13 +397,13 @@ describe("a deleted doc", () => {
 
     const response = await get(`/d/${docId}`);
 
-    expect(response.status).toBe(410);
-    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    const html = await response.text();
-    expect(html).toContain("<title>Document deleted · Symposium</title>");
-    expect(html).toContain("This document is gone.");
-    expect(html).toContain("The author deleted this document.");
-    expect(html).toContain(NOINDEX_META);
+    await expectStatusPage(
+      response,
+      410,
+      "Document deleted",
+      "This document is gone.",
+      "The author deleted this document.",
+    );
     // A reader who bookmarked the link deserves to know it was withdrawn, not
     // to wonder whether they mistyped it.
     expect(response.headers.get("cache-control")).toBe("no-store");
@@ -416,11 +436,13 @@ describe("a doc that is not there", () => {
   it("404s an id no push ever minted", async () => {
     const response = await get(`/d/${UNKNOWN_DOC_ID}`);
 
-    expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toEqual({
-      error: { code: "not_found", message: expect.stringContaining("No doc at") },
-    });
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expectStatusPage(
+      response,
+      404,
+      "Document unavailable",
+      "This document isn’t available.",
+      "The link may be incorrect, or the author may have deleted the document.",
+    );
   });
 
   it("404s a doc row with no version yet", async () => {
@@ -433,7 +455,9 @@ describe("a doc that is not there", () => {
       .bind(UNKNOWN_DOC_ID, owner, Date.now(), Date.now())
       .run();
 
-    expect((await get(`/d/${UNKNOWN_DOC_ID}`)).status).toBe(404);
+    const response = await get(`/d/${UNKNOWN_DOC_ID}`);
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain("This document isn’t available.");
   });
 
   it("404s an object D1 promises but R2 does not have", async () => {
@@ -442,7 +466,9 @@ describe("a doc that is not there", () => {
 
     // R2 is the system of record, so its answer wins over the pointer index's
     // — a missing object is a miss, not a 500.
-    expect((await get(`/d/${docId}`)).status).toBe(404);
+    const missing = await get(`/d/${docId}`);
+    expect(missing.status).toBe(404);
+    expect(await missing.text()).toContain("This document isn’t available.");
     expect((await get(`/d/${docId}/v1`)).status).toBe(200);
   });
 
@@ -477,6 +503,8 @@ describe("a doc that is not there", () => {
     for (const path of impossible) {
       const response = await get(path, undefined, servingHost);
       expect({ path, status: response.status }).toEqual({ path, status: 404 });
+      expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await response.text()).toContain("This document isn’t available.");
       expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
     }
   });
@@ -487,6 +515,7 @@ describe("a doc that is not there", () => {
     for (const method of ["POST", "PUT", "DELETE", "PATCH"]) {
       const response = await send(method, `/d/${docId}`);
       expect({ method, status: response.status }).toEqual({ method, status: 404 });
+      expect(await response.text()).toContain("This document isn’t available.");
     }
     // And the doc is untouched by the attempt.
     expect((await get(`/d/${docId}`)).status).toBe(200);
@@ -524,7 +553,12 @@ describe("HEAD and conditional requests", () => {
   });
 
   it("404s HEAD for a doc that is not there", async () => {
-    expect((await send("HEAD", `/d/${UNKNOWN_DOC_ID}`)).status).toBe(404);
+    const response = await send("HEAD", `/d/${UNKNOWN_DOC_ID}`);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).toBe("");
   });
 
   it("410s HEAD for a deleted doc", async () => {
@@ -534,6 +568,22 @@ describe("HEAD and conditional requests", () => {
     const response = await send("HEAD", `/d/${docId}`);
 
     expect(response.status).toBe(410);
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).toBe("");
+  });
+
+  it("500s HEAD with the temporary page headers and no body", async () => {
+    const docId = await twoVersionDoc();
+    const brokenDocs = {
+      head: () => {
+        throw new Error("R2 unavailable");
+      },
+    } as unknown as R2Bucket;
+
+    const response = await send("HEAD", `/d/${docId}`, {}, { DOCS: brokenDocs });
+
+    expect(response.status).toBe(500);
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(await response.text()).toBe("");


### PR DESCRIPTION
Fixes #41

## Why

The earlier deleted-document page covered only retained `410 Gone` tombstones. Readers can still see raw JSON for ordinary `404 Not Found` misses and temporary `500 Internal Server Error` failures, including real links whose deletion tombstone is no longer available.

## What

The public document surface now renders one shared Symposium page shell with status-specific copy:

| Outcome | Reader page |
| --- | --- |
| `404 Not Found` | Neutral document-unavailable copy for unknown or malformed links, missing versions, documents without a servable version, and missing stored objects |
| `410 Gone` | Explicit author-deleted copy when a retained tombstone proves deletion |
| `500 Internal Server Error` | Temporary-unavailable copy when a serving dependency fails |

All three remain `no-store`, `noindex`, and protected by the existing serving security headers. `HEAD` keeps the same status and headers without a body; healthy `200` and conditional `304` responses are unchanged.

## Non goal

This does not change the publisher API's JSON contract, claim that every unknown link was deleted, alter deletion retention or storage repair, replace JSON outside the public serving surface, or customize Cloudflare errors produced before the Worker can respond.

## Screenshot

Before — an unknown document link exposed the API-shaped JSON response:

Base branch response (verified from the exact current `main` commit): `{"error":{"code":"not_found","message":"No doc at /d/6m2k4nvq7t0xbz3n"}}`. The browser automation refuses to render raw JSON responses, so a truthful before screenshot could not be captured.

After — the same `404` outcome renders the neutral reader page:

<img width="1280" height="720" alt="After: neutral document-unavailable page" src="https://github.com/user-attachments/assets/9c90f974-170c-4807-8680-37b17a6b75a7" />

The retained `410` state uses the same page shell with explicit author-deleted copy.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Reader-surface tests cover the 404, 410, and forced 500 page contracts |
| A defect would fail CI or be obvious on first use | ✅ | Status, content type, copy, caching, crawler policy, and bodyless HEAD behavior are asserted |
| A revert fully restores prior state, including persisted data | ✅ | The change writes no data and adds no migration |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Authentication and publisher input handling are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Public reader 404 and 500 bodies change from JSON to HTML |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing routing and storage lookup order are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Every changed serving branch, including missing data and thrown storage, has deterministic coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The rendered result is immediately visible on the public document page |

Review: inspect `src/serve.ts` — `SERVING_PAGES`, `servingPageHtml`, `servingPageResponse`, and `handleServing` — plus the serving-surface catch in `src/index.ts` line by line, then run Verification steps 2–5, including malformed links and the forced dependency failure.

## Verification

1. Start the Worker locally with its normal local D1 and R2 bindings.
2. Open an unknown document URL and malformed `/d/*` paths; each should show the neutral page with status `404`.
3. Publish and delete a document, then open its shared and pinned URLs; each should show the explicit deleted page with status `410`.
4. Run `npx vitest run test/serve.test.ts -t "failure|500s HEAD"`; the forced serving dependency failures should return the temporary page for GET and a bodyless HTML response for HEAD, both with status `500`.
5. Send HEAD for the 404 and 410 states; it should match GET's status and headers with an empty body. Confirm an API 404 is still JSON and a healthy document still returns HTML with status `200`.
