### PR TITLE
Rebrand the backend as OpenArtifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
     # environment's branch policy is therefore also the deploy's access control.
     environment:
       name: production
-      url: https://symposium.site
+      url: https://openartifacts.site
 
     # The token is deliberately NOT here. A job-level `env` hands the
     # production credential to every step, including ones that only need to
@@ -175,6 +175,72 @@ jobs:
             echo "no successful production deployment to compare against; skipping the immutability check"
           fi
 
+      # The first four-host cutover needs a safe predecessor. If this workflow
+      # attached the two new domains and flipped their roles in one deploy, a
+      # rollback to the old two-host router would apply path fallback on the new
+      # domains: the document host could expose the API, and the API host could
+      # serve uploaded HTML. Refuse that state instead of trying to repair it
+      # automatically with the production credential.
+      #
+      # A one-time compatibility deploy (documented in docs/deploying.md)
+      # attaches all four routes while keeping the old hosts canonical. After
+      # that, either the compatibility mapping or the final canonical mapping
+      # is a safe predecessor for this deploy.
+      - name: Require a safe four-host predecessor
+        run: |
+          set -euo pipefail
+
+          mapping_is_live() {
+            local mapping="$1"
+            local specs=()
+            if [ "$mapping" = "canonical" ]; then
+              specs=(
+                "api.openartifacts.ai|200|"
+                "openartifacts.site|200|"
+                "api.symposium.md|200|"
+                "symposium.site|307|https://openartifacts.site/health?probe=deploy"
+              )
+            else
+              specs=(
+                "api.symposium.md|200|"
+                "symposium.site|200|"
+                "api.openartifacts.ai|200|"
+                "openartifacts.site|307|https://symposium.site/health?probe=deploy"
+              )
+            fi
+
+            local spec host want expected_location url result code location
+            for spec in "${specs[@]}"; do
+              IFS='|' read -r host want expected_location <<<"$spec"
+              url="https://$host/health"
+              if [ -n "$expected_location" ]; then url="$url?probe=deploy"; fi
+              if ! result="$(curl -sS -o /dev/null -w '%{http_code}|%{redirect_url}' --max-time 20 "$url")"; then
+                return 1
+              fi
+              code="${result%%|*}"
+              location="${result#*|}"
+              if [ "$code" != "$want" ]; then return 1; fi
+              if [ -n "$expected_location" ] && [ "$location" != "$expected_location" ]; then
+                return 1
+              fi
+            done
+          }
+
+          for attempt in 1 2 3 4 5; do
+            if mapping_is_live canonical; then
+              echo "canonical four-host mapping is live"
+              exit 0
+            fi
+            if mapping_is_live compatibility; then
+              echo "compatibility rollback floor is live"
+              exit 0
+            fi
+            if [ "$attempt" -lt 5 ]; then sleep 5; fi
+          done
+
+          echo "::error::No safe four-host predecessor is live. Run and record the one-time compatibility deployment in docs/deploying.md before retrying."
+          exit 1
+
       # `--message` fills the Message column in the dashboard's Deployments
       # tab, which is otherwise a list of uuids and timestamps. It is what makes
       # a rollback decision possible without cross-referencing GitHub.
@@ -192,8 +258,8 @@ jobs:
             --message "$(git log -1 --format='%h %s' | cut -c1-100)"
 
       # A deploy that reports success and serves nothing is the failure this
-      # catches. Both hosts, because they are separate custom domains and one
-      # can be attached while the other is not.
+      # catches. Every canonical and compatibility host is checked because each
+      # is a separate custom domain and one route can fail independently.
       #
       # Retried, because the deploy above is already irreversible: a single
       # transient timeout would fail the job, skip the recording step, and leave
@@ -204,20 +270,43 @@ jobs:
       # and, absent `--fail`, does not treat an HTTP 502 as an error at all.
       # The status code is what this step judges, so the retry belongs around
       # the comparison.
-      - name: Check both hosts answer
+      - name: Check canonical and legacy hosts
         run: |
           set -euo pipefail
-          for host in api.symposium.md symposium.site; do
+          for spec in \
+            "api.openartifacts.ai 200 -" \
+            "openartifacts.site 200 -" \
+            "api.symposium.md 200 -" \
+            "symposium.site 307 https://openartifacts.site/health?probe=deploy"
+          do
+            set -- $spec
+            host="$1"
+            want="$2"
+            expected_location="$3"
+            url="https://$host/health"
+            if [ "$expected_location" != "-" ]; then url="$url?probe=deploy"; fi
+
             code=""
+            location=""
             for attempt in 1 2 3 4 5; do
-              code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://$host/health" || echo 000)"
-              if [ "$code" = "200" ]; then break; fi
-              echo "$host → $code (attempt $attempt of 5)"
+              result="$(curl -sS -o /dev/null -w '%{http_code} %{redirect_url}' --max-time 20 "$url" || echo '000 ')"
+              code="${result%% *}"
+              location="${result#* }"
+              if [ "$code" = "$want" ]; then
+                if [ "$expected_location" = "-" ] || [ "$location" = "$expected_location" ]; then
+                  break
+                fi
+              fi
+              echo "$host → $code $location (attempt $attempt of 5)"
               sleep 5
             done
-            echo "$host → $code"
-            if [ "$code" != "200" ]; then
-              echo "::error::$host answered $code after 5 attempts"
+            echo "$host → $code $location"
+            if [ "$code" != "$want" ]; then
+              echo "::error::$host answered $code; expected $want"
+              exit 1
+            fi
+            if [ "$expected_location" != "-" ] && [ "$location" != "$expected_location" ]; then
+              echo "::error::$host redirected to $location; expected $expected_location"
               exit 1
             fi
           done
@@ -235,7 +324,7 @@ jobs:
             '{ref:$sha,environment:"production-api",description:"Publisher API",auto_merge:false,required_contexts:[]}')"
           id="$(gh api -X POST "repos/$GITHUB_REPOSITORY/deployments" --input - --jq '.id' <<<"$body")"
           status="$(jq -nc --arg sha "$GITHUB_SHA" \
-            '{state:"success",environment:"production-api",environment_url:"https://api.symposium.md",description:("Deployed from "+$sha)}')"
+            '{state:"success",environment:"production-api",environment_url:"https://api.openartifacts.ai",description:("Deployed from "+$sha)}')"
           gh api -X POST "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" --input - --silent <<<"$status"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Symposium
+# OpenArtifacts
 
 Push a local md/html file, get a public HTML page on the internet. v0 scope: HTML
 upload → public page, upload API private and programmatic (Obsidian Copilot only).
@@ -50,9 +50,9 @@ in the positioning doc.
 
 These are day-one decisions, not retrofits:
 
-- User content is served from a **sacrificial domain** (`symposium.site`),
+- User content is served from a **sacrificial domain** (`openartifacts.site`),
   separate from the brand domain. Reputation damage must not land on
-  `symposium.md`. `docs/serving-domain.md` is why, and why a subdomain does not
+  `openartifacts.ai`. `docs/serving-domain.md` is why, and why a subdomain does not
   substitute. There is no migration path once links are in the wild.
 - Shared docs are **`noindex` + `nofollow` by default**.
 - **Publisher-gated, reader-open**: publishing requires a key; reading requires
@@ -67,7 +67,7 @@ These are day-one decisions, not retrofits:
   rows only — never content — and must be rebuildable by scanning R2 manifests.
   **This does not hold yet — see below. Do not rely on it.**
 - Every push mints an **immutable version** served with `cache-control: immutable`.
-  R2 stores the publisher's own bytes; Symposium's additions (the robots meta,
+  R2 stores the publisher's own bytes; OpenArtifacts' additions (the robots meta,
   the favicon, the social card and the two bylines) are injected on the way out by
   `renderServedHtml`, so a byline change — or a plan that removes one — reaches
   documents already published.
@@ -100,8 +100,11 @@ treat D1 as a system of record, not as a cache.
 
 ## Owed now that the serving domain has landed
 
-The domains are attached: documents on `symposium.site`, the API on
-`api.symposium.md`. `workers_dev` stays `false` — the router would otherwise
+The serving split is attached today on the legacy hosts: documents on
+`symposium.site`, the API on `api.symposium.md`. The cutover makes
+`openartifacts.site` and `api.openartifacts.ai` canonical while retaining the
+old document host as a redirect and the old API host as a native alias.
+`workers_dev` stays `false` — an unconfigured router would otherwise
 serve `/d/*` on a `workers.dev` hostname, and that domain is on the Public
 Suffix List, so a listing against it would take every Worker on the account's
 subdomain. Two things came due the moment user content moved to a real serving
@@ -119,10 +122,15 @@ domain, and both are easy to miss because nothing fails loudly without them:
   without the second is how a withdrawn doc stays readable. The private-cache
   copies readers already hold are unrecallable by any design, and the README says
   so.
-`SERVING_HOST` and `API_HOST` are already set, which is what makes the router
-resolve surface by host instead of falling back to path prefixes. Leave them
-set: unset on a two-domain deployment, `/api/v1` becomes reachable on the
-sacrificial domain, which is the whole point of splitting them.
+All four canonical and legacy host vars are set in `wrangler.jsonc`, which makes
+the router resolve by an explicit host allowlist and fail closed on everything
+else. Leave them set together. Path-prefix fallback exists only for local
+development when every host var is empty.
+
+The first four-domain cutover is two-stage. Deploy the compatibility mapping in
+`docs/deploying.md`, record its Worker version id as the rollback floor, then
+let CI flip the canonical hosts. Never roll back below that floor while either
+new domain remains attached; older versions route unknown hosts by path.
 
 ## Git hygiene
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ catch up without being briefed.
 
 ---
 
-That is what **Symposium** is for, not what it does today. Only the first step
+That is what **OpenArtifacts** is for, not what it does today. Only the first step
 exists: push a local md/html file and get a public HTML page on the internet.
 The upload API is private and programmatic, its only caller is Obsidian
 Copilot's share action, and there are no reader accounts, no permissions, and no
@@ -13,8 +13,9 @@ comments.
 
 ## What works today
 
-Everything here is built, tested, and live. See [Production](#production) for
-where it runs.
+Everything here is built and tested. The new canonical domains become live only
+after their Cloudflare zones and custom domains are attached; see
+[Production](#production).
 
 - **Publish a note.** Send rendered HTML, get back a link. Obsidian Copilot
   renders the note locally, so callouts, wikilinks and dataview output survive —
@@ -55,10 +56,11 @@ Roughly in order. Nothing below is started.
 - **Caching.** Cloudflare does not cache HTML by default, so every read today
   invokes the Worker and touches D1 and R2. It needs a cache rule, and then
   deletes have to purge the cache in the same change or unshared documents keep
-  being served. The domain split it sits on top of is already live: documents on
-  `symposium.site`, the API on `api.symposium.md`, and no `workers.dev` url at
-  all, since the router would serve documents there and a `workers.dev` listing
-  takes every Worker on the account's subdomain with it.
+  being served. Today the split is live on the legacy aliases: documents on
+  `symposium.site` and the API on `api.symposium.md`. The cutover adds
+  `openartifacts.site` and `api.openartifacts.ai` as the canonical hosts, with no
+  `workers.dev` url at all, since a listing there would take every Worker on the
+  account's subdomain with it.
   [`docs/serving-domain.md`](docs/serving-domain.md) explains why that split
   could not have been added later.
 - **Backups that don't depend on the database.** Right now the database is the
@@ -83,7 +85,7 @@ Roughly in order. Nothing below is started.
 
 ## Where this is going
 
-Symposium is the first step of an agent-first docs product: a shared artifact where
+OpenArtifacts is the first step of an agent-first docs product: a shared artifact where
 humans and agents comment and iterate together to converge on consensus. The
 argument for it, and the constraints it has to respect, are in
 [`docs/positioning.md`](docs/positioning.md) and
@@ -95,13 +97,16 @@ lists the ones that bind day to day.
 
 | | |
 | --- | --- |
-| [symposium.site](https://symposium.site) | Serves published documents. User HTML lives here and never on the brand domain. |
-| [api.symposium.md](https://api.symposium.md) | The publisher API. Key-authenticated, no browser surface. |
-| [Cloudflare dashboard](https://dash.cloudflare.com/960579f222ad237394703bd52f28114c/workers/services/view/symposium/production) | The Worker itself: deployments, versions, logs, and the rollback button. |
+| [openartifacts.site](https://openartifacts.site) | Canonical document host after cutover. User HTML lives here and never on the brand domain. |
+| [api.openartifacts.ai](https://api.openartifacts.ai) | Canonical publisher API after cutover. Key-authenticated, no browser surface. |
+| [symposium.site](https://symposium.site) | Legacy document host. Redirects path and query to `openartifacts.site`. |
+| [api.symposium.md](https://api.symposium.md) | Legacy API alias. Serves natively for released clients. |
+| [Cloudflare dashboard](https://dash.cloudflare.com/960579f222ad237394703bd52f28114c/workers/services/view/symposium/production) | The existing Worker: deployments, versions, logs, and the rollback button. |
 
 Deploys run from [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)
 on merge to `main`. [Deploying](docs/deploying.md) covers how, and how to roll
-back.
+back. The first four-domain cutover is deliberately two-stage: a compatibility
+version is recorded as the rollback floor before CI flips the canonical hosts.
 
 ## Docs
 
@@ -109,8 +114,8 @@ back.
 | --- | --- |
 | [HTTP API](docs/http-api.md) | Every endpoint, in full. The frozen contract Obsidian Copilot is built against. |
 | [Hosting](docs/hosting.md) | How this runs on Cloudflare. **Start here if you know Vercel but not Workers.** |
-| [Serving domain](docs/serving-domain.md) | Why user content lives on `symposium.site` and never on the brand domain. |
-| [Identity](docs/identity.md) | Who owns a document, why it is the account and not the license key, and how symposium.md sign-in slots in. |
+| [Serving domain](docs/serving-domain.md) | Why user content lives on `openartifacts.site` and never on the brand domain. |
+| [Identity](docs/identity.md) | Who owns a document, why it is the account and not the license key, and how openartifacts.ai sign-in slots in. |
 | [Private sharing](docs/private-sharing.md) | How reader identity works, and the phases from public links to agents. Designed, not built. |
 | [Deploying](docs/deploying.md) | Provisioning the resources and shipping. |
 | [Development](docs/development.md) | Running it locally, including the license-server workaround. |

--- a/docs/cost-at-scale.md
+++ b/docs/cost-at-scale.md
@@ -1,14 +1,14 @@
 ---
-title: symposium.md - Business Feasibility - Cost at Scale
+title: openartifacts.ai - Business Feasibility - Cost at Scale
 date: 2026-07-21
 tags:
-  - symposium
+  - openartifacts
   - feasibility
   - business
 status: draft
 ---
 
-# symposium.md - Business Feasibility - Cost at Scale
+# openartifacts.ai - Business Feasibility - Cost at Scale
 
 Companion to [[Agent-First Docs - Product Positioning]]. That doc argues *why* the product should exist. This one asks a colder question: **what does it cost to serve, and does the cost curve stay sane from 1k to 100k to 1M users?** (Pricing was revised on 2026-07-25: publishing is paid, reading is free. See §8. Sections written against the earlier free-share plan are flagged where it matters.)
 
@@ -24,7 +24,7 @@ Scope of the launch product being costed: **one-click sharing from Copilot for O
 Three properties of the product shape (from the positioning doc) drive the whole cost story:
 
 1. **The artifact is static.** Every push mints an immutable version. Immutable version URLs are perfectly cacheable, so a doc that goes viral costs approximately nothing extra: the CDN absorbs it, origin serves it once. We are closer to Pastebin than to Google Docs.
-2. **No live editor, no realtime sync.** Google Docs' real infrastructure cost is not storage, it is operational-transform sync fanout, presence, and cursors for concurrent editors. Notion carries a heavy block-database and realtime layer. Symposium's model is push-based: the expensive collaborative-editing problem is deliberately not in the architecture. Even comments (phase 3) can be poll-based for a long time before anyone notices.
+2. **No live editor, no realtime sync.** Google Docs' real infrastructure cost is not storage, it is operational-transform sync fanout, presence, and cursors for concurrent editors. Notion carries a heavy block-database and realtime layer. OpenArtifacts' model is push-based: the expensive collaborative-editing problem is deliberately not in the architecture. Even comments (phase 3) can be poll-based for a long time before anyone notices.
 3. **Zero inference COGS.** The agents are the users' own (Claude Code, Copilot, whatever calls our MCP). Unlike Notion AI or any "AI docs" product, we pay for no tokens, ever. Our marginal cost for agent traffic is a JSON API call. This is the quiet structural advantage of the agent-first posture: the intelligence is BYO.
 
 The sanity checks from the market:
@@ -155,7 +155,7 @@ The paid publishing gate (§8) removes the *free* term from that equation, which
 
 Day-one mitigations, all cheap in dollars:
 
-1. **Serve user content from a separate domain** than the product/brand domain (the `notion.site` / `googleusercontent.com` pattern). Reputation damage lands on the sacrificial domain, not on `symposium.md` itself. This is the single highest-leverage decision and it costs $10/yr.
+1. **Serve user content from a separate domain** than the product/brand domain (the `notion.site` / `googleusercontent.com` pattern). Reputation damage lands on the sacrificial domain, not on `openartifacts.ai` itself. This is the single highest-leverage decision and it costs $10/yr.
 2. **`noindex` + `nofollow` by default.** Shared docs are for invited readers, not search engines. This deletes the SEO-spam incentive entirely, which is most of the spam volume. (Publishers can opt into indexing later, as a feature, maybe a paid one.)
 3. **Publisher-gated, reader-open.** Publishing requires a paid plan — active Copilot Plus and lifetime licenses today, with a standalone subscription planned; reading requires nothing. The abuse funnel is throttled at the account layer: new-account rate limits, velocity checks on pushes.
 4. **Automated scanning on push**: outbound links against Google Safe Browsing (free API); if/when image upload ships, CSAM hash-matching via Cloudflare's free tool (also a legal obligation, not a nice-to-have).
@@ -177,7 +177,7 @@ Decision (2026-07-21): the whole stack runs on the Cloudflare bundle - DNS, CDN,
 
 - `docs/{id}/v{n}.html` - immutable versions, content-addressed, `cache-control: immutable`. Dedupe identical chunks across versions so "every push mints a version" doesn't compound into a storage tax. Immutability means the CDN does the serving business for us; a viral doc costs origin one read.
 - `docs/{id}/threads/{tid}.html` - each comment thread is a self-contained HTML fragment with semantic markup: `<article class="thread" data-anchor-quote="...">` containing nested comments carrying `data-author`, `data-state="pending|posted|resolved"`, `data-resolved-by-version`. Agents parse the exact markup humans render. This settles the open design question in [[Agent-First Docs - Product Positioning]] (structured endpoint vs parsing served HTML): the served HTML *is* the API, because the markup is designed to be machine-legible.
-- `docs/{id}/manifest.json` - one small file per doc: version list, thread list, grant list. Each doc is a fully self-describing R2 prefix: delete the prefix and the doc is gone; export it and the doc is portable. R2 holds the publisher's own bytes; Symposium's additions go in at read time, so a byline change - or a paid plan that removes one - reaches documents already published without rewriting a single stored object. The cost is a streaming pass per uncached read, which the CDN makes rare.
+- `docs/{id}/manifest.json` - one small file per doc: version list, thread list, grant list. Each doc is a fully self-describing R2 prefix: delete the prefix and the doc is gone; export it and the doc is portable. R2 holds the publisher's own bytes; OpenArtifacts' additions go in at read time, so a byline change - or a paid plan that removes one - reaches documents already published without rewriting a single stored object. The cost is a streaming pass per uncached read, which the CDN makes rare.
 
 **Durable Objects - one coordinator per doc.** A DO per doc serializes all writes to that doc: append comment, re-anchor threads on push, update manifest, invalidate cache. DOs carry embedded SQLite, so each doc's working index (anchors, thread states) lives inside the doc's own object - ten million tiny databases, one per doc, instead of one big one. Each is rebuildable from its doc's R2 prefix, and per-doc state dies with the doc.
 
@@ -218,7 +218,7 @@ Phase 1 (public share only) could genuinely ship with zero D1: slug uniqueness v
 
 Outline is the nearest existing product ([[Agent-First Docs - Product Positioning#Why nobody serves this today]]), which makes "just build on it" tempting. Decision (2026-07-23): no. The downsides are structural, not cosmetic:
 
-- **License.** Outline is BUSL-1.1, which prohibits offering it as a commercial hosted service - exactly what symposium.md is. Building on it means a commercial agreement with the named incumbent-to-beat.
+- **License.** Outline is BUSL-1.1, which prohibits offering it as a commercial hosted service - exactly what openartifacts.ai is. Building on it means a commercial agreement with the named incumbent-to-beat.
 - **Wrong data model.** Workspace-wiki (teams, collections, members) vs our per-doc unit with its own audience. Per-doc grantees and "my docs" would be surgery on the spine; single-team instances vs hosting a million individuals likewise.
 - **Editor-centric where we are push-centric.** Its heart is a realtime ProseMirror/Yjs editor; anchors are marks in editor state, which is the exact fragility we differentiate against (whole-doc replace destroys anchors). Our quote-based re-anchoring engine doesn't exist there and would be built against a hostile representation, while we inherit the sync tax section 1 designed out.
 - **Not HTML-native, not our stack.** Sanitized ProseMirror/markdown pipeline vs HTML-as-API (section 6); needs Node + Postgres + Redis + websockets, which forfeits the all-Cloudflare cost structure and makes a big Postgres the system of record.
@@ -252,7 +252,7 @@ forever and gated access control at $5-8/mo. That is no longer the plan — see
 
 **The current launch gate includes every paid Copilot license.** Active Plus
 subscriptions and lifetime Supporter/Believer licenses can publish. The
-standalone Symposium subscription above is still planned; until it exists,
+standalone OpenArtifacts subscription above is still planned; until it exists,
 publishing requires a paid Copilot license. The explicit set in `src/auth.ts`
 keeps unknown or future plans closed until their entitlement is deliberate.
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -6,11 +6,13 @@ commands are creating.
 
 [← README](../README.md) · [Hosting](hosting.md) · [HTTP API](http-api.md)
 
-> **The Worker is deployed.** All eight steps below have run on the Brevilabs
-> account, and `wrangler.jsonc` carries the real `database_id`. They are kept as
-> the record of how production was built and as the procedure for a fresh
-> account — do not re-run them against Brevilabs'. Routine deploys now happen in
-> CI; see [Later deploys happen in CI](#later-deploys-happen-in-ci). One thing to
+> **The Worker and storage are deployed.** The original provisioning steps have
+> run on the Brevilabs account, and `wrangler.jsonc` carries the real
+> `database_id`. The OpenArtifacts domain cutover remains pending until the new
+> Cloudflare zones exist. These steps are also the procedure for a fresh account
+> — do not re-run the storage commands against Brevilabs'. Routine deploys
+> happen in CI; see
+> [Later deploys happen in CI](#later-deploys-happen-in-ci). One thing to
 > know going in: D1 is still the only record of who owns a doc, what it is called,
 > and whether it was deleted, so until per-doc manifests ship, back-ups mean D1's
 > own 30-day Time Travel window rather than "rebuild it from R2". That is fine at
@@ -43,10 +45,12 @@ right one — leave it alone.
 npx wrangler d1 migrations apply symposium --remote
 ```
 
-**Steps 4–8 ship the Worker.** They have all run on the Brevilabs account; what
-follows is the record of how, and the procedure for a fresh account. Step 7 is
-the one that makes the Worker reachable: `workers_dev` is `false`, so a Worker
-with no custom domain attached answers on nothing at all.
+**Steps 4–9 ship the Worker.** Steps 4–5 have run on the Brevilabs account. The
+rebrand cutover in steps 6–9 must wait for the `openartifacts.ai` and
+`openartifacts.site` Cloudflare zones and the landing-page OG image. It uses two
+Worker versions. The first attaches all four domains while the old hosts remain
+canonical; the second flips the canonical names. That first version is the safe
+rollback floor.
 
 ```bash
 # 4. Credentials for the license server. Both prompt for the value, so neither
@@ -60,16 +64,37 @@ npx wrangler secret put LICENSE_API_KEY
 # 5. Ship. The Worker has no hostname yet — see below.
 npx wrangler deploy
 
-# 6. Set SERVING_HOST and API_HOST in wrangler.jsonc, then redeploy. Still
-#    unreachable, which is the point: the hosts go live before any domain does.
-npx wrangler deploy
+# 6. Merge the reviewed rebrand PR. Its first automatic deploy stops at the
+#    safe-predecessor gate without changing production. From that exact main
+#    checkout, deploy the compatibility mapping. The routes come from
+#    wrangler.jsonc; these four overrides keep the old hosts canonical.
+npx wrangler deploy \
+  --var SERVING_HOST:symposium.site \
+  --var API_HOST:api.symposium.md \
+  --var LEGACY_SERVING_HOST:openartifacts.site \
+  --var LEGACY_API_HOST:api.openartifacts.ai \
+  --message "OpenArtifacts cutover floor"
 
-# 7. Attach symposium.site and api.symposium.md as custom domains. This is what
-#    makes it reachable, and by now the running version already knows the hosts.
+# Copy the printed Current Version ID into the rollout record. It is the oldest
+# version that may remain attached to all four domains.
 
-# 8. Check what just shipped, end to end, against the surface that ships.
-SYMPOSIUM_LICENSE_KEY=<a real paid Copilot key> \
-  scripts/smoke.sh https://api.symposium.md
+# 7. Verify the compatibility mapping: the two API hosts answer natively, the
+#    old document host answers natively, and the new document host redirects to
+#    the same path and query on the old host.
+curl -sS -o /dev/null -w '%{http_code}\n' https://api.symposium.md/health
+curl -sS -o /dev/null -w '%{http_code}\n' https://api.openartifacts.ai/health
+curl -sS -o /dev/null -w '%{http_code}\n' https://symposium.site/health
+curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' \
+  'https://openartifacts.site/health?probe=cutover'
+
+# 8. Re-run the main-branch Deploy workflow. Its predecessor gate now passes;
+#    the committed vars flip to the final mapping and CI verifies all four
+#    hosts. Do not edit or remove the legacy routes.
+gh workflow run deploy.yml --repo Brevilabs/OpenArtifacts --ref main
+
+# 9. Check what just shipped, end to end, against the canonical API.
+OPENARTIFACTS_LICENSE_KEY=<a real paid Copilot key> \
+  scripts/smoke.sh https://api.openartifacts.ai
 ```
 
 The smoke script publishes a doc, reads it, lists it, deletes it and confirms the
@@ -83,28 +108,33 @@ license key to spend.
 `workers_dev` is `false`, so step 5 uploads a Worker that answers on nothing at
 all. That is deliberate, not an unfinished state.
 
-The router resolves by host and falls back to path prefixes when the host matches
-neither `SERVING_HOST` nor `API_HOST` — so a `workers.dev` hostname would happily
-serve `/d/*`, putting user HTML on a domain we neither control nor can afford to
-sacrifice. `workers.dev` is on the Public Suffix List, which makes
+The router resolves by an explicit host allowlist and fails closed on unknown
+hosts once any host var is configured. It falls back to path prefixes only when
+all four vars are empty, which is useful locally but would make a `workers.dev`
+hostname serve `/d/*`. That would put user HTML on a domain we neither control
+nor can afford to sacrifice. `workers.dev` is on the Public Suffix List, which makes
 `<subdomain>.workers.dev` the unit a Safe Browsing listing applies to: one bad
 upload would take down every Worker on the account's subdomain. The serving
 domain exists precisely so the blast radius lands somewhere we chose.
 
-So the order is configure, then attach, then test — and the redeploy goes *before*
-the attach, not after. Set `SERVING_HOST` and `API_HOST` in `wrangler.jsonc` and
-redeploy while the Worker is still unreachable, then attach the domains, then
-smoke-test. Attaching first would leave the domains pointing at a version whose
-hosts are empty, and the path-prefix fallback would serve `/d/*` on
-`api.symposium.md` and `/api/v1/*` on `symposium.site` until the redeploy landed
-— the exact split this document argues for, undone for the length of a deploy.
-The `url` the API returns follows the vars automatically.
+So the order is add both new Cloudflare zones, merge the reviewed router, deploy
+the compatibility mapping, record its version id, verify it, then let CI flip
+the canonical mapping. Do not attach the new names by hand to the old router.
+During the compatibility stage, `openartifacts.site` redirects to
+`symposium.site` and both API hosts serve natively. After the flip,
+`symposium.site` redirects to `openartifacts.site`; `api.symposium.md` remains a
+native API alias so authenticated methods keep their body and Authorization
+header. The final `url` returned through either API host names
+`openartifacts.site`.
 
 ## Later deploys happen in CI
 
 Merging to `main` runs `.github/workflows/deploy.yml`, which typechecks, tests,
-refuses to deploy over an unapplied migration, ships, checks both hosts answer,
-and records what shipped on the repo page. Nobody deploys from a laptop.
+refuses to deploy over an unapplied migration, requires a safe four-host
+predecessor, ships, checks all canonical and compatibility hosts, and records
+what shipped on the repo page. The one-time compatibility version in step 6 is
+the only manual Worker deploy in the rebrand. Run it from the reviewed `main`
+SHA; after the canonical flip, nobody deploys from a laptop.
 
 It needs one secret, `CLOUDFLARE_API_TOKEN` — an *environment* secret on
 `production`, never a repository one, for the reasons below. It is configured on
@@ -114,8 +144,9 @@ token holds two account permissions: **Workers Scripts: Edit** to deploy, and
 would also reach DNS and every other zone setting. Create it under My Profile →
 API Tokens → Create Token; the *Edit Cloudflare Workers* template is a fine
 starting point, but it does **not** include D1, so add that row by hand. Scope
-Account Resources to the one account and Zone Resources to `symposium.site` and
-`symposium.md` specifically, which is what authorizes the custom-domain routes.
+Account Resources to the one account and Zone Resources to `openartifacts.site`,
+`openartifacts.ai`, `symposium.site`, and `symposium.md` specifically, which is
+what authorizes the canonical and compatibility custom-domain routes.
 Leave Client IP filtering empty: GitHub's runners have no stable egress IPs.
 
 D1: Edit is broader than the guard needs — it only runs a `SELECT` — but the
@@ -142,7 +173,7 @@ and dispatch from it, which no branch rule matches and no in-file guard survives
 Check with:
 
 ```bash
-gh api repos/Brevilabs/symposium/environments/production/deployment-branch-policies \
+gh api repos/Brevilabs/OpenArtifacts/environments/production/deployment-branch-policies \
   --jq '.branch_policies[] | {name, type}'
 ```
 
@@ -150,9 +181,11 @@ Required reviewers would gate this further, but GitHub rejects that protection
 rule on this billing plan for a private repo, so the branch policy is the whole
 of the platform-level control.
 
-Without the secret the workflow cannot run at all, and deploys fall back to being
-manual: steps 5 and 8 above, plus step 3 whenever a migration is added. That is
-also the recovery path if the token is ever revoked.
+Without the secret the workflow cannot run at all. Deploys then fall back to a
+manual `npx wrangler deploy` from the reviewed `main` SHA, plus step 3 whenever
+a migration is added. For the rebrand, run the compatibility deploy in step 6,
+verify it, then run a plain `npx wrangler deploy` for the final mapping instead
+of dispatching step 8. That is also the recovery path if the token is revoked.
 
 Migrations remain manual in every case. Step 3, then merge — the workflow fails
 rather than applying one.
@@ -186,8 +219,8 @@ Two things the workflow deliberately does not do:
   stop noticing it. Once applied, a migration is append-only: add a new file.
 - **It does not smoke-test.** That needs a real paid license key, spends a push from
   its daily quota, and writes to production R2 and D1 on every merge. `/health`
-  on both hosts is the liveness check instead. Run `scripts/smoke.sh` by hand
-  when the change warrants it.
+  on the canonical and compatibility hosts is the liveness check instead. Run
+  `scripts/smoke.sh` by hand when the change warrants it.
 
 What remains ungated is that a merge to `main` deploys with no pause. That is
 the same exposure as the manual `wrangler deploy` it replaces, minus the laptop,
@@ -195,16 +228,25 @@ and closing it needs a billing plan that allows required reviewers.
 
 ## Rolling back
 
-Every deploy creates an immutable version and Cloudflare keeps them all.
+Every deploy creates an immutable version and Cloudflare keeps them all. The
+OpenArtifacts cutover has a hard floor: never activate a version older than the
+`Current Version ID` recorded in step 6 while either new custom domain is
+attached. Older versions know only two hosts and would route the new domains by
+path, exposing the wrong surface.
 
 ```bash
 npx wrangler versions list          # ids, timestamps, and the commit in Message
-npx wrangler rollback <version-id>
+npx wrangler rollback               # immediate predecessor
+npx wrangler rollback <version-id>  # cutover floor or newer only
 ```
 
 Or the dashboard: **Compute (Workers) → symposium → Deployments**, then
-**⋯ → Rollback** on a version. The workflow passes `--message` so that list
-reads as commits rather than uuids.
+**⋯ → Rollback** on the immediate predecessor or a version at or above the
+recorded cutover floor. The compatibility version's message is
+`OpenArtifacts cutover floor`; the workflow passes commit messages on later
+versions. Do not select a pre-floor dashboard version. If one is ever required,
+first detach both new custom domains and verify they no longer invoke this
+Worker, then roll back.
 
 **Rollback reverts code and nothing else.** D1 rows and R2 objects written by
 the bad version stay written, which is the other half of why migrations are not

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Running Symposium on your machine. No Cloudflare account needed.
+Running OpenArtifacts on your machine. No Cloudflare account needed.
 
 [← README](../README.md) · [HTTP API](http-api.md) · [Deploying](deploying.md)
 
@@ -39,7 +39,7 @@ npx wrangler d1 execute symposium --local --command \
   "INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
    VALUES ('$HASH', 'plus', $(($(date +%s) * 1000)), 'local-account')"
 
-SYMPOSIUM_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
+OPENARTIFACTS_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
 ```
 
 Alternatively, copy `.dev.vars.example` to `.dev.vars` and point

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,6 +1,6 @@
 # Hosting
 
-What Symposium runs on, assuming you know how web apps get deployed but have never
+What OpenArtifacts runs on, assuming you know how web apps get deployed but have never
 used Cloudflare. If your reference point is Vercel and Vercel Postgres, the
 [translation table](#coming-from-vercel) maps most of it in one screen.
 
@@ -26,20 +26,21 @@ why this repo has no Express, no `pg`, and no ORM. See
 where you would expect.
 
 **R2** — object storage. S3's API, with no charge for data leaving it. You `put`
-and `get` blobs by key. Symposium keeps every published version as one immutable
+and `get` blobs by key. OpenArtifacts keeps every published version as one immutable
 object at `docs/{docId}/v{n}.html`; reading a document is one `get`, streamed
 straight back to the reader.
 
 **D1** — a SQL database. It is **SQLite**, not Postgres, and that difference does
-real work — see [D1 in practice](#d1-in-practice). Symposium uses it purely as an
+real work — see [D1 in practice](#d1-in-practice). OpenArtifacts uses it purely as an
 index: who owns a doc, what it is called, which versions exist, whether it was
 deleted. No document content is ever stored in it.
 
 **workers.dev** — a free subdomain Cloudflare gives every account, so a Worker is
 normally reachable the moment you deploy without owning a domain or touching DNS.
-**Symposium does not use it.** `workers_dev` is `false` in `wrangler.jsonc`,
-because the router falls back to path prefixes on any unrecognized host and would
-therefore serve user documents at `/d/*` on a `workers.dev` url. That domain is
+**OpenArtifacts does not use it.** `workers_dev` is `false` in `wrangler.jsonc`.
+The router falls back to path prefixes only when every host var is empty, as it
+is locally; exposing that configuration on `workers.dev` would serve user
+documents at `/d/*` there. That domain is
 on the Public Suffix List, so a Safe Browsing listing would apply to
 `<subdomain>.workers.dev` and take every Worker on the account with it — the
 opposite of what the serving domain is for. It also sits outside Cloudflare's CDN
@@ -62,6 +63,9 @@ credentials in the environment, no pool. `wrangler.jsonc` declares **bindings**:
 "r2_buckets":   [{ "binding": "DOCS", "bucket_name": "symposium-docs" }],
 "d1_databases": [{ "binding": "DB",   "database_name": "symposium", … }]
 ```
+
+Those resource names predate the rebrand and are retained deliberately. Moving
+the data is not part of the domain and product-name cutover.
 
 and Cloudflare hands the code an already-connected client for each, as
 properties of the `env` object every request receives:
@@ -102,9 +106,12 @@ reader → Cloudflare edge → Worker (src/index.ts)
 
 The Worker's first decision is which of two surfaces a request belongs to:
 `/api/v1/*` is the publisher API and needs a key, `/d/*` is public reading. They
-sit on separate domains — user content on `symposium.site`, a domain chosen to be
-disposable, the API on `api.symposium.md` — for reasons in
-[cost-at-scale.md](cost-at-scale.md) §5.
+sit on separate canonical domains — user content on `openartifacts.site`, a
+domain chosen to be disposable, the API on `api.openartifacts.ai` — for reasons
+in [cost-at-scale.md](cost-at-scale.md) §5. The compatibility stage redirects
+`openartifacts.site` to the still-canonical `symposium.site`. The final stage
+reverses that redirect, while `api.symposium.md` remains a native API alias for
+released clients throughout.
 
 **Nothing is cached today**, and attaching the domains did not by itself change
 that: Cloudflare does not cache HTML by default *on any domain*. Eligibility is
@@ -129,7 +136,7 @@ Postgres reflexes to unlearn:
   `wrangler d1 migrations apply`. No Prisma, no Drizzle — queries are written by
   hand in `src/db.ts`.
 - **A database is single-threaded**, processing queries one at a time. Ideal for
-  the small indexed lookups Symposium makes; not where an analytical query goes.
+  the small indexed lookups OpenArtifacts makes; not where an analytical query goes.
 - **Writes go to one region**, reads can be replicated. Barely matters here: a
   read touches D1 once for a pointer, and the document itself comes from R2.
 - **Backups are Time Travel** — restore to any point in the last 30 days by
@@ -137,7 +144,7 @@ Postgres reflexes to unlearn:
 
 Limits and price: 10 GB per database, 50,000 databases per account, 1,000
 queries per Worker invocation. Billing is per row read and written, with 25
-billion reads and 50 million writes included monthly, so at Symposium's shape it is
+billion reads and 50 million writes included monthly, so at OpenArtifacts' shape it is
 effectively free.
 
 ## R2 in practice
@@ -150,7 +157,7 @@ Storage is $0.015/GB-month; writes (Class A) $4.50 per million, reads (Class B)
 $0.36 per million. A push is a couple of writes, a read is one.
 
 Objects are immutable, and serving is a read plus one streaming rewrite: R2
-holds the publisher's document and Symposium's additions go in on the way out.
+holds the publisher's document and OpenArtifacts' additions go in on the way out.
 The pass never buffers, so it costs CPU proportional to bytes already in flight,
 and the CDN keeps repeat readers off the Worker entirely.
 
@@ -162,8 +169,8 @@ edited in Cloudflare's UI are overwritten by the next deploy.
 
 Two kinds of configuration, and the split is enforced:
 
-- **Vars** — plaintext in `wrangler.jsonc`, committed. `SERVING_HOST` and
-  `API_HOST` are vars.
+- **Vars** — plaintext in `wrangler.jsonc`, committed. The canonical and legacy
+  serving/API hosts are vars.
 - **Secrets** — never in any file. `wrangler secret put NAME` prompts and stores
   the value encrypted; code reads it off the same `env` object, indistinguishable
   from a var. `LICENSE_API_KEY` is a secret.
@@ -175,14 +182,18 @@ an identifier, the binding will not resolve without it, and it is committed.
 
 ## Deploys come from CI
 
-Merging to `main` runs `.github/workflows/deploy.yml`, which holds the only
-credential allowed to deploy. `wrangler deploy` still uploads whoever's working
-tree when run by hand, which is how the first deploy happened; it is the
-fallback now, not the practice. Cloudflare's own git integration is a third
-option we have not set up. `docs/deploying.md` has the mechanics.
+Merging to `main` runs `.github/workflows/deploy.yml`, which holds the routine
+deployment credential. The OpenArtifacts cutover has one documented manual
+compatibility deploy from the reviewed `main` SHA so all four domains have a
+safe rollback version before their roles flip. Outside that step,
+`wrangler deploy` uploads whoever's working tree when run by hand and is the
+fallback, not the practice. Cloudflare's own git integration is a third option
+we have not set up. `docs/deploying.md` has the mechanics.
 
 Every deploy is retained as a version, and `wrangler rollback` returns to an
-earlier one. There are no per-PR preview URLs unless we configure them.
+earlier one. While either new domain is attached, never select a version older
+than the recorded OpenArtifacts cutover floor; those versions do not recognize
+all four hosts. There are no per-PR preview URLs unless we configure them.
 
 ## Local development
 
@@ -215,7 +226,7 @@ including the license-server workaround a local push needs.
 
 ## Why this stack, and where it strains
 
-The decisive property is R2's lack of egress fees. Symposium is, at bottom, a service
+The decisive property is R2's lack of egress fees. OpenArtifacts is, at bottom, a service
 that hands the same immutable bytes to many readers, and everywhere else that
 shape is dominated by bandwidth — S3 plus CloudFront is roughly $0.085/GB, which
 at scale *is* the business, and is zero here. The rest follows: immutable version
@@ -225,7 +236,7 @@ priced per user or per seat, which is the other way this category usually gets
 expensive.
 
 The weak link is D1, and it is worth being clear-eyed. One database is capped at
-10 GB, is single-threaded, and takes writes in a single region. Symposium's shape
+10 GB, is single-threaded, and takes writes in a single region. OpenArtifacts' shape
 keeps that comfortable — a push is a handful of small writes, a read is one
 indexed lookup — but a write-heavy future (agents pushing on every edit, then
 comment threads) would eventually reach it. Two escape hatches are already in the
@@ -252,7 +263,7 @@ Two caveats to hold onto:
 
 For a document-sharing service specifically, this is a strong fit, and more so
 the larger it gets. It would be the wrong stack for something transactional,
-relationally complex, or CPU-heavy per request — Symposium is none of those.
+relationally complex, or CPU-heavy per request — OpenArtifacts is none of those.
 
 It also holds for where the product is going. Comments (see
 [comments.md](comments.md)) are the workload Durable Objects exist for: a

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -16,12 +16,19 @@ Two surfaces on two domains:
 | API | `/api/v1/*` | required | Publisher-facing. JSON in, JSON out. |
 | Serving | `/d/*` | none | Reader-facing. Public HTML. Never sets a cookie. |
 
-The API is served from `api.symposium.md` and documents from `symposium.site`.
+The API is served from `api.openartifacts.ai` and documents from `openartifacts.site`.
 The `url` field a push returns therefore points at a different host than the one
 the client called, which is the reason a client must never build a doc url
 itself. **Always use the `url` the API returns.**
 
-`GET /health` → `200 {"ok": true}` is reachable on both, unauthenticated.
+Compatibility is host-level, not a second contract: `api.symposium.md` serves
+the API natively so released clients keep their method, body, and Authorization
+header. `symposium.site` returns `307` to the same path and query on
+`openartifacts.site`. Both API hosts return canonical document urls.
+
+`GET /health` → `200 {"ok": true}` is reachable on both canonical hosts and the
+legacy API host, unauthenticated. The legacy document host redirects it like
+every other path.
 
 ## Authentication
 
@@ -83,7 +90,7 @@ Any other method or path under `/api/v1` is `404 not_found`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3n",
- "url": "https://symposium.site/d/9f2k4mvq7t0xbz3n",
+ "url": "https://openartifacts.site/d/9f2k4mvq7t0xbz3n",
  "version": 1}
 ```
 
@@ -108,7 +115,7 @@ it does on `POST`.
 
 ```json
 {"docId": "9f2k4mvq7t0xbz3n",
- "url": "https://symposium.site/d/9f2k4mvq7t0xbz3n",
+ "url": "https://openartifacts.site/d/9f2k4mvq7t0xbz3n",
  "version": 2}
 ```
 
@@ -153,7 +160,7 @@ whichever of its keys published them.
 {"docs": [
    {"docId": "9f2k4mvq7t0xbz3n",
     "title": "Q3 architecture review",
-    "url": "https://symposium.site/d/9f2k4mvq7t0xbz3n",
+    "url": "https://openartifacts.site/d/9f2k4mvq7t0xbz3n",
     "version": 2,
     "updatedAt": 1785000000000}
  ],
@@ -198,9 +205,9 @@ retargeting. The origin is cookieless and holds nothing but already-public docs.
 
 Four things are injected as the document is served: a
 `<meta name="robots" content="noindex,nofollow">` in the head, a
-`<link rel="icon">` beside it carrying the Symposium mark as a `data:` URI, a
+`<link rel="icon">` beside it carrying the OpenArtifacts mark as a `data:` URI, a
 `Shared from Copilot for Obsidian` byline at the top of the body, and a
-`Powered by symposium.md` byline before `</body>`. A document that ships its own
+`Powered by openartifacts.ai` byline before `</body>`. A document that ships its own
 icon keeps that markup — both links are then in the head, and which one the tab
 shows is the browser's choice. Nothing else is touched — the
 markup is never sanitized, rewritten or reformatted, and what R2 stores is the
@@ -313,19 +320,19 @@ confirmation.
 ## A whole round trip
 
 ```bash
-BASE=https://api.symposium.md
+BASE=https://api.openartifacts.ai
 KEY=<paid Copilot license key>
 
 # publish
 curl -sS -X POST "$BASE/api/v1/docs" \
   -H "authorization: Bearer $KEY" -H 'content-type: application/json' \
   -d '{"title":"Notes","html":"<!doctype html><html><body><p>hello</p></body></html>"}'
-# → {"docId":"9f2k…","url":"https://symposium.site/d/9f2k…","version":1}
+# → {"docId":"9f2k…","url":"https://openartifacts.site/d/9f2k…","version":1}
 
 # The document reads use the `url` that push returned, never "$BASE/d/…": the
 # page lives on the serving domain, and the API host resolves every path to the
 # API surface, which would answer these unauthenticated reads 401.
-DOC=https://symposium.site/d/9f2k…
+DOC=https://openartifacts.site/d/9f2k…
 
 curl -sS "$DOC"                                # the public page, no auth
 curl -sS "$BASE/api/v1/docs?limit=10" -H "authorization: Bearer $KEY"

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -5,14 +5,14 @@ used to publish it.**
 
 A license key is a way of proving who you are. It is not who you are. Keeping
 those two apart is what lets someone replace a key, hold two of them, or sign in
-to symposium.md having never made one — and see the same documents throughout.
+to openartifacts.ai having never made one — and see the same documents throughout.
 
 [← README](../README.md) · [HTTP API](http-api.md) · [Private sharing](private-sharing.md)
 
 ## The owner id
 
 `docs.owner` holds an **app-sites `User.id`** — the uuid in the Brevilabs
-Postgres that identifies a person across every Brevilabs product. Symposium
+Postgres that identifies a person across every Brevilabs product. OpenArtifacts
 stores no email and keeps no account table of its own. The id is opaque here:
 nothing parses it, and every query only ever compares it for equality.
 
@@ -21,7 +21,7 @@ Two facts make that enough:
 - **The license server already resolves a key to it.**
   `license.validateLicenseKey` returns `accountId: LicenseKeyConfig.authUserId`
   on every valid response, alongside the plan.
-- **A symposium.md session already carries it.** NextAuth's session callback
+- **An openartifacts.ai session already carries it.** NextAuth's session callback
   sets `session.user.id` to the same uuid.
 
 So both sides arrive at the identical value without deriving anything. There is
@@ -36,7 +36,7 @@ Today there is one credential, and one day there will be two. They meet at
 ```
 Authorization: Bearer <license key>   →  license server  →  accountId  ┐
                                                                        ├→  Publisher.owner  →  docs.owner
-symposium.md session (JWT)            →  session.user.id              ┘
+openartifacts.ai session (JWT)            →  session.user.id              ┘
 ```
 
 `src/auth.ts` is the only module that sees a license key at all. It hashes the
@@ -62,10 +62,10 @@ A fair question, since ownership no longer is. Three reasons:
 
 The hash never leaves that module. It is an index, not an identity.
 
-## What happens when symposium.md gains sign-in
+## What happens when openartifacts.ai gains sign-in
 
 Almost nothing, which is the point. `User` is one NextAuth table shared by every
-app-sites product, so a symposium.md sign-up resolves through the same
+app-sites product, so an openartifacts.ai sign-up resolves through the same
 `authOptions` Copilot already uses:
 
 | On sign-in | Result |
@@ -82,9 +82,9 @@ than a dead end. **No join, and no branch on "is this person a Copilot user."**
 ### The join is for entitlement, not identity
 
 *Who* needs no lookup. *May they publish* does. That gate is currently the
-license key's plan, and a symposium.md-only user has no `LicenseKeyConfig` row at
+license key's plan, and an openartifacts.ai-only user has no `LicenseKeyConfig` row at
 all — so it needs a per-product table, following the shape already in the schema:
-`Customer` for Copilot, `MiyoCustomer` for miyo, and a Symposium equivalent keyed
+`Customer` for Copilot, `MiyoCustomer` for miyo, and an OpenArtifacts equivalent keyed
 by `authUserId`. Joined on the account, answering *what plan*, never *who*.
 
 Keeping that split is what stops the identity model growing a special case per
@@ -124,7 +124,7 @@ should not be relaxed without knowing that.
 - **It does not give a key its own documents.** Two keys on one account share one
   list, one daily push allowance, and one 500-document ceiling. Isolation is per
   account, and `docs/http-api.md` says so.
-- **It does not survive the account being deleted.** Nothing in Symposium
+- **It does not survive the account being deleted.** Nothing in OpenArtifacts
   currently reacts to a `User` row disappearing upstream; the documents would
   simply stop being reachable by anyone. Worth solving before there are accounts
   worth deleting.

--- a/docs/private-sharing.md
+++ b/docs/private-sharing.md
@@ -21,7 +21,7 @@ That sentence is what buys `'unsafe-inline'`, `'unsafe-eval'` and an open
 and Pyodide. Private sharing falsifies both halves of it at once.
 
 **So the obvious implementation is the one that must not be built.** Put a
-session cookie on `symposium.site` and any uploaded document's JavaScript can
+session cookie on `openartifacts.site` and any uploaded document's JavaScript can
 issue same-origin `fetch()` calls carrying that session. `HttpOnly` does not
 help: it stops a script *reading* the cookie, not *using* it. One hostile
 document would read every private document its reader can reach and post the
@@ -33,14 +33,14 @@ interactive documents. Both are load-bearing.
 
 ## The shape: identity never touches the serving origin
 
-`symposium.site` stays cookieless forever. Identity lives on the brand domain,
+`openartifacts.site` stays cookieless forever. Identity lives on the brand domain,
 and access is granted **per document** rather than ambiently.
 
 ```
-reader → symposium.site/d/{id}      private, no grant → 302
-       → symposium.md  sign in       OAuth, session lives here
+reader → openartifacts.site/d/{id}      private, no grant → 302
+       → openartifacts.ai  sign in       OAuth, session lives here
        → API checks the ACL          mints a short-lived signed grant
-       → symposium.site/d/{id}?…     signature verified, bytes served
+       → openartifacts.site/d/{id}?…     signature verified, bytes served
 ```
 
 Grants remove *ambient* authority: a document's scripts cannot forge a grant for
@@ -51,9 +51,9 @@ a document they were not given. That is necessary and it is not sufficient.
 A hostile public document can steal a grant somebody else legitimately obtained:
 
 1. It calls `window.open('/d/{targetId}')` and keeps the opener reference.
-2. The popup bounces to `symposium.md`, where the reader signs in and comes back
+2. The popup bounces to `openartifacts.ai`, where the reader signs in and comes back
    with a grant.
-3. Back on `symposium.site`, opener and popup are same-origin **again**, because
+3. Back on `openartifacts.site`, opener and popup are same-origin **again**, because
    the same-origin check is evaluated per access rather than pinned at open
    time. The opener reads `popup.location.href`, which contains the signature,
    and `popup.document`, which contains the document.
@@ -72,7 +72,7 @@ crosses an origin boundary and the opener can read nothing.
 
 ### The origin label must not be the capability
 
-The obvious form of that — `{docId}.symposium.site` — trades one leak for
+The obvious form of that — `{docId}.openartifacts.site` — trades one leak for
 another. A hostname is not confidential: it appears in the DNS query, and absent
 Encrypted Client Hello it appears in the TLS SNI, both before any encryption. A
 recursive resolver, a corporate DNS server, or anything on the network path
@@ -89,7 +89,7 @@ So the two jobs need two identifiers:
 | origin label | no | isolates browsing contexts |
 | doc id, and any grant | yes | authorises the read, stays in the encrypted path |
 
-`{originLabel}.symposium.site/d/{docId}` gives isolation without exposure. The
+`{originLabel}.openartifacts.site/d/{docId}` gives isolation without exposure. The
 label being enumerable is harmless: reaching the origin without the path id and
 the grant gets you nothing. ECH would close the SNI half of the leak but not the
 DNS half, so it is not a substitute for separating the two.
@@ -140,7 +140,7 @@ step.
 > **An earlier plan had a phase between 1 and 2**: expiring links and
 > per-document passwords, on the argument that they are days of work and cover
 > most of what people mean by "private". It is dropped. **Private sharing
-> requires an account** with symposium.md or Obsidian Copilot, so there is no
+> requires an account** with openartifacts.ai or Obsidian Copilot, so there is no
 > password path and no unauthenticated grant, and nothing private exists until
 > Phase 2 ships. Recorded here because the case for it was reasonable and will
 > be made again; what defeats it is that it buys weeks of convenience at the
@@ -156,7 +156,7 @@ Publishing is gated to paid Copilot plans.
 The large one, the prerequisite for everything after, and the only route to a
 private document.
 
-- OAuth sign-in on `symposium.md` — Google and GitHub cover nearly everyone
+- OAuth sign-in on `openartifacts.ai` — Google and GitHub cover nearly everyone
   without our storing a password. The session lives on the brand domain only.
 - A `readers` table, and an ACL per document: named readers, or a domain rule
   ("anyone at acme.com"), or public. Public stays the default.

--- a/docs/serving-domain.md
+++ b/docs/serving-domain.md
@@ -1,7 +1,7 @@
 # Why user content gets its own domain
 
-**The rule: `symposium.md` is the brand. `symposium.site` serves the documents.
-Nothing a user uploaded is ever served from `symposium.md`.**
+**The rule: `openartifacts.ai` is the brand. `openartifacts.site` serves the documents.
+Nothing a user uploaded is ever served from `openartifacts.ai`.**
 
 This is listed as a non-negotiable constraint in [`CLAUDE.md`](../CLAUDE.md), and
 it is the kind of decision that looks like premature caution right up until the
@@ -11,7 +11,7 @@ morning it is not. This doc is why it holds.
 
 ## What we are actually protecting against
 
-Symposium serves arbitrary user-uploaded HTML with scripts enabled. That is not
+OpenArtifacts serves arbitrary user-uploaded HTML with scripts enabled. That is not
 a compromise, it is the product — interactive figures and embedded simulations
 are the reason the client uploads HTML instead of markdown
 ([http-api.md](http-api.md)). It also happens to be the exact profile that
@@ -26,12 +26,12 @@ and a domain with a history gets flagged faster and cleared slower the second
 time.
 
 Splitting the domains does not prevent any of that. It decides which domain
-absorbs it. A flagged `symposium.site` is a bad week for document serving. A
-flagged `symposium.md` is a bad week for the company.
+absorbs it. A flagged `openartifacts.site` is a bad week for document serving. A
+flagged `openartifacts.ai` is a bad week for the company.
 
 ## Why a subdomain does not work
 
-`docs.symposium.md` buys nothing. Reputation systems operate on the registrable
+`docs.openartifacts.ai` buys nothing. Reputation systems operate on the registrable
 domain — the eTLD+1 — so a listing against a subdomain lands on the parent.
 Cookies and CSP have the same problem in the other direction: same-site
 protections treat a subdomain as related, which is precisely what you do not want
@@ -48,7 +48,7 @@ The pattern is well settled among everyone who has been burned:
 
 Note what these have in common: the serving domain is still obviously the brand.
 Separation costs nothing in recognition. A reader landing on
-`symposium.site/d/abc` knows exactly whose product they are looking at.
+`openartifacts.site/d/abc` knows exactly whose product they are looking at.
 
 ## Why it cannot be fixed later
 
@@ -79,21 +79,25 @@ insuring against is one occurrence.
 
 ## Status
 
-**The split is live.** `symposium.site` serves documents and `api.symposium.md`
-serves the API, both attached as Worker custom domains, with `SERVING_HOST` and
-`API_HOST` set to match. `workers_dev` is `false` and stays that way: the
-path-prefix fallback would otherwise serve `/d/*` on a `workers.dev` url, which
-is the mistake this whole document argues against. The fallback stays in the
-router for the window where one host var is set and the other is not.
+**The split is live on the legacy hosts today.** `symposium.site` serves
+documents and `api.symposium.md` serves the API. The cutover config makes
+`openartifacts.site` and `api.openartifacts.ai` canonical after their Cloudflare
+zones and custom domains are attached. The legacy document host then redirects
+the exact path and query; the legacy API host keeps serving natively.
 
-Three things had to land together. One has;
-[`CLAUDE.md`](../CLAUDE.md) carries the detail on the rest:
+`workers_dev` is `false` and stays that way. With any host var set, the router
+uses an explicit allowlist and fails closed on unknown hosts. Path-prefix
+fallback exists only for local development, when all four vars are empty.
 
-1. **Set `SERVING_HOST` and `API_HOST`.** Done. The router resolves surface by
-   host first and only falls back to path prefixes while both are empty.
+The remaining serving work is unchanged:
+
+1. **Attach the new canonical domains in two stages.** Pending on both
+   Cloudflare zones. First deploy the four-host router with the old hosts still
+   canonical and record that version as the rollback floor; then let CI flip
+   the canonical mapping. The deployment gate refuses to skip this step.
 2. **Add a Cache Rule.** Outstanding. Cloudflare does not cache HTML by default,
-   and `/d/{docId}` has no file extension, so attaching the domains changed
-   nothing about caching.
+   and `/d/{docId}` has no file extension, so attaching the new domains will not
+   change caching by itself.
 3. **Purge on delete, in the same change.** Outstanding, and coupled to the one
    above. Once there is an edge cache, an unshared doc keeps being served from
    it. Shipping caching without purging is how a withdrawn document stays

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "symposium",
+  "name": "openartifacts",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "symposium",
+      "name": "openartifacts",
       "version": "0.0.0",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.21",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "symposium",
+  "name": "openartifacts",
   "version": "0.0.0",
   "description": "Push a local md/html file, get a public HTML page on the internet",
   "type": "module",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# End-to-end smoke check against a *deployed* Symposium worker.
+# End-to-end smoke check against a *deployed* OpenArtifacts worker.
 #
-#   SYMPOSIUM_LICENSE_KEY=... scripts/smoke.sh https://api.symposium.md
+#   OPENARTIFACTS_LICENSE_KEY=... scripts/smoke.sh https://api.openartifacts.ai
 #
 # It publishes a doc, reads it back from its public url, finds it in the
 # publisher's list, deletes it, and confirms the url has become 410. Every step
@@ -19,24 +19,24 @@
 # machine via `ps`. Nothing here echoes it, and the API never returns it.
 set -euo pipefail
 
-BASE_URL=${1:-${SYMPOSIUM_BASE_URL:-}}
+BASE_URL=${1:-${OPENARTIFACTS_BASE_URL:-}}
 
 usage() {
   cat >&2 <<'EOF'
-usage: SYMPOSIUM_LICENSE_KEY=<paid Copilot license key> scripts/smoke.sh <base url>
+usage: OPENARTIFACTS_LICENSE_KEY=<paid Copilot license key> scripts/smoke.sh <base url>
 
-  <base url>          the API host, e.g. https://api.symposium.md
-                      (or set SYMPOSIUM_BASE_URL instead of passing it)
+  <base url>          the API host, e.g. https://api.openartifacts.ai
+                      (or set OPENARTIFACTS_BASE_URL instead of passing it)
                       Document reads use the url the push returns, so the
                       serving domain is never passed in.
-  SYMPOSIUM_LICENSE_KEY   a paid license key with a push quota to spare.
+  OPENARTIFACTS_LICENSE_KEY   a paid license key with a push quota to spare.
                       Never passed as an argument, never printed.
 EOF
   exit 2
 }
 
 [ -n "$BASE_URL" ] || usage
-[ -n "${SYMPOSIUM_LICENSE_KEY:-}" ] || usage
+[ -n "${OPENARTIFACTS_LICENSE_KEY:-}" ] || usage
 
 # Trailing slashes would double up in every url built below.
 BASE_URL=${BASE_URL%/}
@@ -57,7 +57,7 @@ BODY="$WORK/body"
 # builtin, so escaping the key for that quoting never puts it in a process's
 # arguments either.
 printf 'header = "Authorization: Bearer %s"\n' \
-  "$(printf '%s' "$SYMPOSIUM_LICENSE_KEY" | sed 's/[\\"]/\\&/g')" >"$AUTH"
+  "$(printf '%s' "$OPENARTIFACTS_LICENSE_KEY" | sed 's/[\\"]/\\&/g')" >"$AUTH"
 
 HTTP_STATUS=""
 
@@ -118,10 +118,10 @@ json_string() {
 
 # Marks the doc this run published, so the read-back is checking our own bytes
 # rather than any doc happening to be there.
-MARKER="symposium-smoke-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+MARKER="openartifacts-smoke-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
 cat >"$WORK/push.json" <<EOF
-{"title":"Symposium smoke check $MARKER",
+{"title":"OpenArtifacts smoke check $MARKER",
  "html":"<!doctype html><html lang=en><head><meta charset=utf-8><title>smoke</title></head><body><p>$MARKER</p></body></html>"}
 EOF
 
@@ -145,7 +145,7 @@ public_request "$DOC_URL"
 expect_status 200 "GET $DOC_URL"
 expect_body "$MARKER" "the page serves the bytes that were pushed"
 expect_body "Copilot for Obsidian</span>" "the page carries the header byline"
-expect_body "symposium.md</a>" "the page carries the footer byline, linked"
+expect_body "openartifacts.ai</a>" "the page carries the footer byline, linked"
 expect_body 'rel="icon"' "the page carries a tab icon"
 
 api_request GET "$BASE_URL/api/v1/docs?limit=100"

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -160,7 +160,7 @@ async function storeVersion(
   title: string | null,
   atMs: number,
 ): Promise<boolean> {
-  // The publisher's own bytes, unmodified. Symposium's additions go in when the
+  // The publisher's own bytes, unmodified. OpenArtifacts' additions go in when the
   // document is served, so a byline change — or a plan that removes one —
   // reaches documents already published. `size` is therefore the size of what
   // the publisher sent, not of what a reader receives.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -82,7 +82,7 @@ export interface Publisher {
   /**
    * The app-sites `User.id` whose documents these are. Every doc query keys off
    * it, which is what makes two keys on one account see one shelf and lets a
-   * symposium.md session find the same documents from `session.user.id` alone.
+   * openartifacts.ai session find the same documents from `session.user.id` alone.
    *
    * The license key itself appears nowhere outside this module: it identifies a
    * credential, and nothing downstream has any business knowing which one was

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,9 @@
 /**
  * Worker bindings and the quota ceilings from the plan (D10).
  *
- * `SERVING_HOST` / `API_HOST` are declared in wrangler.jsonc but left empty in
- * v0, where everything runs on one workers.dev subdomain and the router falls
- * back to path prefixes. Setting them later splits the surfaces across the
- * brand and sacrificial domains without a code change (D3).
+ * The canonical and legacy host vars are declared in wrangler.jsonc. Local
+ * development leaves all four empty, where the router falls back to path
+ * prefixes. Production configures them together so unknown hosts fail closed.
  */
 export interface Env {
   /** R2 bucket holding the served bytes. System of record. */
@@ -12,10 +11,14 @@ export interface Env {
   /** D1 pointer index. Rebuildable from R2; never holds content. */
   DB: D1Database;
 
-  /** Host that serves public docs. Empty in v0. */
+  /** Canonical host that serves public docs. Empty in local development. */
   SERVING_HOST?: string;
-  /** Host that exposes /api/v1. Empty in v0. */
+  /** Canonical host that exposes /api/v1. Empty in local development. */
   API_HOST?: string;
+  /** Previous docs host. Redirects every path and query to SERVING_HOST. */
+  LEGACY_SERVING_HOST?: string;
+  /** Previous API host. Serves the API natively for released clients. */
+  LEGACY_API_HOST?: string;
 
   /**
    * Base url of the Brevilabs license server, e.g. `https://api.brevilabs.com`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,28 +8,37 @@ import {
 } from "./auth.js";
 import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
-import { handleServing, servingError, SERVING_PREFIX } from "./serve.js";
+import {
+  handleServing,
+  servingError,
+  servingRedirect,
+  SERVING_PREFIX,
+} from "./serve.js";
 
 /**
  * The two surfaces. They are separate because user HTML has to be served from a
  * sacrificial host that never carries the API — a doc that turns out to be
  * phishing should cost us the serving domain, not the brand domain.
  */
-export type Surface = "api" | "serving" | "unknown";
+export type Surface = "api" | "serving" | "legacy-serving" | "unknown";
 
 export interface SurfaceConfig {
-  /** Host serving public docs. Empty/undefined in v0. */
+  /** Canonical host serving public docs. Empty/undefined locally. */
   servingHost?: string;
-  /** Host exposing /api/v1. Empty/undefined in v0. */
+  /** Canonical host exposing /api/v1. Empty/undefined locally. */
   apiHost?: string;
+  /** Previous docs host. It redirects to servingHost. */
+  legacyServingHost?: string;
+  /** Previous API host. It serves the API natively for released clients. */
+  legacyApiHost?: string;
 }
 
 const API_PREFIX = "/api/v1";
 
 /**
  * Lowercase and drop the trailing root dot, so `A.Com` and `a.com.` both match
- * `a.com`. The root dot matters: `new URL("https://symposium.page./x").hostname` is
- * `"symposium.page."`, so without this a request with a dotted Host header would
+ * `a.com`. The root dot matters: `new URL("https://openartifacts.site./x").hostname` is
+ * `"openartifacts.site."`, so without this a request with a dotted Host header would
  * miss the serving-host match and fall through to the path prefix — which is
  * exactly how `/api/v1` would become reachable on the serving domain.
  */
@@ -46,18 +55,35 @@ function pathIsUnder(pathname: string, prefix: string): boolean {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
 
+function hostsAreConfigured(config: SurfaceConfig): boolean {
+  return [
+    config.servingHost,
+    config.apiHost,
+    config.legacyServingHost,
+    config.legacyApiHost,
+  ].some((host) => host?.trim());
+}
+
 /**
  * Host first, path second.
  *
- * Once the hosts are configured, the host alone decides the surface: a request
+ * Once any host is configured, the host alone decides the surface: a request
  * arriving on SERVING_HOST is the serving surface no matter what path it asks
  * for, which is what makes `/api/v1` unreachable there rather than merely
- * unadvertised. When the host matches nothing configured — the v0 workers.dev
- * case, and the migration window before DNS moves — the path prefix decides.
+ * unadvertised. Unknown production hosts fail closed. Path-prefix fallback is
+ * only for local development, when every host var is empty.
  */
 export function resolveSurface(hostname: string, pathname: string, config: SurfaceConfig): Surface {
   if (hostMatches(hostname, config.servingHost)) return "serving";
-  if (hostMatches(hostname, config.apiHost)) return "api";
+  if (hostMatches(hostname, config.legacyServingHost)) return "legacy-serving";
+  if (
+    hostMatches(hostname, config.apiHost) ||
+    hostMatches(hostname, config.legacyApiHost)
+  ) {
+    return "api";
+  }
+
+  if (hostsAreConfigured(config)) return "unknown";
 
   if (pathIsUnder(pathname, API_PREFIX)) return "api";
   if (pathIsUnder(pathname, SERVING_PREFIX)) return "serving";
@@ -121,16 +147,33 @@ export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
-    // Deliberately outside the surface split: the deploy smoke check has to
-    // reach it on whichever host it lands on, and it discloses nothing.
-    if (url.pathname === "/health") {
-      return Response.json({ ok: true });
-    }
-
-    const surface = resolveSurface(url.hostname, url.pathname, {
+    const surfaceConfig = {
       servingHost: env.SERVING_HOST,
       apiHost: env.API_HOST,
-    });
+      legacyServingHost: env.LEGACY_SERVING_HOST,
+      legacyApiHost: env.LEGACY_API_HOST,
+    };
+    const surface = resolveSurface(url.hostname, url.pathname, surfaceConfig);
+
+    if (surface === "legacy-serving") {
+      const servingHost = env.SERVING_HOST?.trim();
+      if (!servingHost) return servingError(request.method, "internal");
+
+      const target = new URL(url);
+      target.protocol = "https:";
+      target.hostname = normalizeHostname(servingHost);
+      target.port = "";
+      return servingRedirect(target.toString());
+    }
+
+    // Local development has no configured hosts. In production, health answers
+    // only on an explicit serving/API host; an unknown Host still fails closed.
+    if (
+      url.pathname === "/health" &&
+      (surface !== "unknown" || !hostsAreConfigured(surfaceConfig))
+    ) {
+      return Response.json({ ok: true });
+    }
 
     try {
       // `return await`, not `return` — here, and at every dispatch either

--- a/src/render.ts
+++ b/src/render.ts
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 3;
+export const RENDER_REVISION = 4;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
@@ -85,13 +85,13 @@ export const FAVICON_LINK =
 /**
  * The card image every shared doc unfurls with, on the brand domain.
  *
- * It is the one Symposium addition that cannot be inlined. A data URI is not a
+ * It is the one OpenArtifacts addition that cannot be inlined. A data URI is not a
  * valid `og:image` — every unfurler fetches the value over http(s) from its own
  * infrastructure, never from the reader's browser — so this is a hard
  * dependency on a url staying alive, which is exactly the dependency the
  * favicon and the Copilot mark were inlined to avoid.
  *
- * Given that, `symposium.md` rather than the marketing site's Vercel
+ * Given that, `openartifacts.ai` rather than the marketing site's Vercel
  * deployment url: pinned `/v{n}` pages are served `immutable` for a year, so a
  * document published today is still handing this url to crawlers long after
  * this deploy, and a preview deployment's hostname is not a thing to bet that
@@ -100,7 +100,7 @@ export const FAVICON_LINK =
  * It loads on the *unfurler's* side, so nothing about it touches the serving
  * origin's CSP or costs a reader a request.
  */
-export const OG_IMAGE_URL = "https://symposium.md/og-image.png";
+export const OG_IMAGE_URL = "https://openartifacts.ai/og-image.png";
 
 /**
  * The part of the card that is the same for every document: which image, how
@@ -118,11 +118,11 @@ export const OG_IMAGE_URL = "https://symposium.md/og-image.png";
  * nothing that unfurls these links renders anything differently for it.
  *
  * `og:site_name` does earn its place: it is the small label Discord and Slack
- * put above the title, and naming Symposium there is the branding this exists
+ * put above the title, and naming OpenArtifacts there is the branding this exists
  * for.
  */
 export const SOCIAL_CARD_META =
-  '<meta property="og:site_name" content="Symposium">' +
+  '<meta property="og:site_name" content="OpenArtifacts">' +
   `<meta property="og:image" content="${OG_IMAGE_URL}">` +
   '<meta property="og:image:width" content="1200">' +
   '<meta property="og:image:height" content="630">' +
@@ -277,8 +277,8 @@ const BYLINE_LINK_WITH_MARK =
 const SPAN_RESET = "all:initial;font:inherit;color:inherit;";
 
 /** Where the document came from. Injected at the top of the body. */
-export const SYMPOSIUM_HEADER =
-  '<div class="symposium-header" style="' +
+export const OPENARTIFACTS_HEADER =
+  '<div class="openartifacts-header" style="' +
   BYLINE_BASE +
   ";margin:0 0 2rem;padding:0.75rem 0;border-bottom:1px solid rgba(128,128,128,0.25)\">" +
   `<span style="${SPAN_RESET}display:inline-flex;align-items:center;gap:0.4em">Shared from ` +
@@ -288,11 +288,11 @@ export const SYMPOSIUM_HEADER =
   "</a></span></div>";
 
 /** What served it. Injected immediately before `</body>`. */
-export const SYMPOSIUM_FOOTER =
-  '<div class="symposium-footer" style="' +
+export const OPENARTIFACTS_FOOTER =
+  '<div class="openartifacts-footer" style="' +
   BYLINE_BASE +
   ";margin:4rem 0 0;padding:1rem 0;border-top:1px solid rgba(128,128,128,0.25)\">" +
-  `Powered by <a href="https://symposium.md" ${BYLINE_LINK}>symposium.md</a>, ` +
+  `Powered by <a href="https://openartifacts.ai" ${BYLINE_LINK}>openartifacts.ai</a>, ` +
   "where agents and humans get on the same page</div>";
 
 /** HTMLRewriter treats injected content as markup, not text, only when asked. */
@@ -347,8 +347,8 @@ const AS_HTML = { html: true } as const;
  * it did when serving was a passthrough.
  *
  * `branding` will be false for plans that pay to remove the bylines. It takes
- * the favicon and the social card with them — a Symposium mark in the reader's
- * tab is branding too, and a card carrying Symposium's own image is the most
+ * the favicon and the social card with them — an OpenArtifacts mark in the reader's
+ * tab is branding too, and a card carrying OpenArtifacts' own image is the most
  * visible branding of the lot: it is what a paying customer's link shows in
  * somebody else's Discord. `og:title` goes with it rather than being kept on
  * its own, because a card with a title and no image is a worse unfurl than the
@@ -420,10 +420,10 @@ export function renderServedHtml(response: Response, branding = true): Response 
         // before `c`.
         if (headerPlaced) return;
         headerPlaced = true;
-        if (branding) body.prepend(SYMPOSIUM_HEADER, AS_HTML);
+        if (branding) body.prepend(OPENARTIFACTS_HEADER, AS_HTML);
         body.onEndTag((endTag) => {
           footerPlaced = true;
-          if (branding) endTag.before(SYMPOSIUM_FOOTER, AS_HTML);
+          if (branding) endTag.before(OPENARTIFACTS_FOOTER, AS_HTML);
         });
       },
     })
@@ -434,8 +434,8 @@ export function renderServedHtml(response: Response, branding = true): Response 
           const titleMeta = socialTitleMeta(documentTitle);
           if (titleMeta.length > 0) end.append(titleMeta, AS_HTML);
         }
-        if (branding && !headerPlaced) end.append(SYMPOSIUM_HEADER, AS_HTML);
-        if (branding && !footerPlaced) end.append(SYMPOSIUM_FOOTER, AS_HTML);
+        if (branding && !headerPlaced) end.append(OPENARTIFACTS_HEADER, AS_HTML);
+        if (branding && !footerPlaced) end.append(OPENARTIFACTS_FOOTER, AS_HTML);
       },
     })
     .transform(response);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,7 +1,7 @@
 /**
  * The public serving surface: `GET /d/{docId}` and `GET /d/{docId}/v{n}`.
  *
- * R2 holds the publisher's own bytes; Symposium's additions — the robots meta,
+ * R2 holds the publisher's own bytes; OpenArtifacts' additions — the robots meta,
  * the favicon, the social card and the two bylines — are injected here, on the
  * way out, by `renderServedHtml`. That is what lets a byline change, or a plan that removes
  * one, reach documents already published, and it is why the stored object and
@@ -42,7 +42,7 @@ const DOC_PATH_PREFIX = `${SERVING_PREFIX}/`;
 const VERSION_SEGMENT = /^v([1-9][0-9]{0,8})$/;
 
 /**
- * The Content Security Policy. This is the security boundary of Symposium, so every
+ * The Content Security Policy. This is the security boundary of OpenArtifacts, so every
  * directive below is a deliberate choice rather than a copied default.
  *
  * The threat model is unusual and worth stating plainly: the page's own author
@@ -209,7 +209,7 @@ function servingPageHtml(copy: ServingPageCopy): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ${NOINDEX_META}
 ${FAVICON_LINK}
-<title>${copy.title} · Symposium</title>
+<title>${copy.title} · OpenArtifacts</title>
 <style>
   :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
   * { box-sizing: border-box; }
@@ -227,10 +227,10 @@ ${FAVICON_LINK}
 </head>
 <body>
 <main aria-labelledby="page-title">
-  <div class="brand"><span class="mark" aria-hidden="true"><span></span><span></span><span></span></span>Symposium</div>
+  <div class="brand"><span class="mark" aria-hidden="true"><span></span><span></span><span></span></span>OpenArtifacts</div>
   <h1 id="page-title">${copy.heading}</h1>
   <p>${copy.message}</p>
-  <a href="https://symposium.md">About Symposium</a>
+  <a href="https://openartifacts.ai">About OpenArtifacts</a>
 </main>
 </body>
 </html>`;
@@ -255,6 +255,13 @@ function servingPageResponse(method: string, kind: ServingPageKind): Response {
 /** Exported because the router's serving-surface catch-all needs the same page. */
 export function servingError(method: string, code: "not_found" | "internal"): Response {
   return servingPageResponse(method, code);
+}
+
+/** Temporary legacy-host redirect with the serving origin's full safety policy. */
+export function servingRedirect(location: string): Response {
+  const headers = servingHeaders("no-store");
+  headers.set("location", location);
+  return new Response(null, { status: 307, headers });
 }
 
 /** One neutral page for every miss, so it never confirms whether an id existed. */

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -15,6 +15,6 @@ import type { Env } from "./config.js";
  */
 export function publicDocUrl(env: Env, requestUrl: URL, docId: string): string {
   const servingHost = env.SERVING_HOST?.trim();
-  const origin = servingHost ? `${requestUrl.protocol}//${servingHost}` : requestUrl.origin;
+  const origin = servingHost ? `https://${servingHost}` : requestUrl.origin;
   return `${origin}/d/${docId}`;
 }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -481,7 +481,7 @@ describe("the gate is on publishing, not on the publisher", () => {
 
   const call = (method: string, path: string, db: D1Database) =>
     worker.fetch(
-      new Request(`https://symposium.workers.dev/api/v1${path}`, {
+      new Request(`https://openartifacts.workers.dev/api/v1${path}`, {
         method,
         headers: { authorization: `Bearer ${KEY}`, "content-type": "application/json" },
         body: method === "POST" || method === "PUT" ? JSON.stringify({ html: "<p>x</p>" }) : null,
@@ -605,7 +605,7 @@ describe("resolvePublisher — license env not configured", () => {
 
 describe("authenticateRequest", () => {
   const request = (authorization?: string) =>
-    new Request("https://symposium.test/api/v1/docs", {
+    new Request("https://openartifacts.test/api/v1/docs", {
       headers: authorization === undefined ? {} : { authorization },
     });
 
@@ -686,7 +686,7 @@ describe("/api/v1 is gated on a publisher", () => {
   const ctx = {} as ExecutionContext;
   const call = (authorization?: string, db: D1Database = fakeD1()) =>
     worker.fetch(
-      new Request("https://symposium.workers.dev/api/v1/docs", {
+      new Request("https://openartifacts.workers.dev/api/v1/docs", {
         headers: authorization === undefined ? {} : { authorization },
       }),
       env({ DB: db, SERVING_HOST: "", API_HOST: "" }),

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
 import worker from "../src/index.js";
 
-const env = { SERVING_HOST: "", API_HOST: "" } as Env;
+const env = {
+  SERVING_HOST: "",
+  API_HOST: "",
+  LEGACY_SERVING_HOST: "",
+  LEGACY_API_HOST: "",
+} as Env;
 const ctx = {} as ExecutionContext;
 
 const call = (path: string) =>
-  worker.fetch(new Request(`https://symposium.test${path}`), env, ctx);
+  worker.fetch(new Request(`https://openartifacts.test${path}`), env, ctx);
 
 describe("worker", () => {
   it("serves a health check", async () => {

--- a/test/ids.test.ts
+++ b/test/ids.test.ts
@@ -64,7 +64,7 @@ describe("newDocId", () => {
   it("is url-safe as a single path segment", () => {
     for (const id of ids.slice(0, 50)) {
       expect(encodeURIComponent(id)).toBe(id);
-      expect(new URL(`https://symposium.page/d/${id}`).pathname).toBe(`/d/${id}`);
+      expect(new URL(`https://openartifacts.page/d/${id}`).pathname).toBe(`/d/${id}`);
     }
   });
 

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -9,11 +9,11 @@ import { docObjectPrefix, versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
 /**
- * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
- * router fall back to path prefixes. Deliberately not a real deployment host:
- * these tests are about the surfaces, not about which domain carries them.
+ * Local routing has no configured hosts, so it falls back to path prefixes.
+ * Deliberately not a real deployment host: these tests are about the surfaces,
+ * not about which production domain carries them.
  */
-const API_ORIGIN = "https://symposium.workers.dev";
+const API_ORIGIN = "https://openartifacts.workers.dev";
 
 const KEY_A = "cplus_live_a1b2c3d4e5f60718";
 const KEY_B = "cplus_live_9988776655443322";
@@ -85,7 +85,14 @@ async function send(
   const ctx = createExecutionContext();
   const response = await worker.fetch(
     new Request(`${API_ORIGIN}${path}`, init),
-    { ...env, ...overrides },
+    {
+      ...env,
+      SERVING_HOST: "",
+      API_HOST: "",
+      LEGACY_SERVING_HOST: "",
+      LEGACY_API_HOST: "",
+      ...overrides,
+    },
     ctx,
   );
   await waitOnExecutionContext(ctx);
@@ -434,10 +441,13 @@ describe("GET /api/v1/docs", () => {
     const created = await publish(KEY_A, "A note");
 
     const response = await send("GET", "/api/v1/docs", KEY_A, undefined, {
-      SERVING_HOST: "symposium.page",
+      SERVING_HOST: "openartifacts.site",
+      API_HOST: "openartifacts.workers.dev",
     });
 
-    expect((await listed(response)).docs[0]?.url).toBe(`https://symposium.page/d/${created.docId}`);
+    expect((await listed(response)).docs[0]?.url).toBe(
+      `https://openartifacts.site/d/${created.docId}`,
+    );
   });
 
   it("orders newest first", async () => {

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -6,16 +6,16 @@ import { commitVersionMetadata } from "../src/db.js";
 import type { DocRow, PushQuotaRow, VersionRow } from "../src/db.js";
 import { DOC_ID_LENGTH, isDocId } from "../src/ids.js";
 import { MAX_REQUEST_BYTES, utcDay, utf8Length } from "../src/quota.js";
-import { NOINDEX_META, SYMPOSIUM_FOOTER } from "../src/render.js";
+import { NOINDEX_META, OPENARTIFACTS_FOOTER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
 /**
- * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
- * router fall back to path prefixes. Deliberately not a real deployment host:
- * these tests are about the surfaces, not about which domain carries them.
+ * Local routing has no configured hosts, so it falls back to path prefixes.
+ * Deliberately not a real deployment host: these tests are about the surfaces,
+ * not about which production domain carries them.
  */
-const API_ORIGIN = "https://symposium.workers.dev";
+const API_ORIGIN = "https://openartifacts.workers.dev";
 
 /**
  * A well-formed id that is not in the database. Derived from DOC_ID_LENGTH, not
@@ -74,6 +74,7 @@ async function send(
   key: string | null,
   body?: unknown,
   overrides: Partial<Env> = {},
+  origin = API_ORIGIN,
 ): Promise<Response> {
   const headers = new Headers();
   if (key !== null) headers.set("authorization", `Bearer ${key}`);
@@ -86,8 +87,15 @@ async function send(
 
   const ctx = createExecutionContext();
   const response = await worker.fetch(
-    new Request(`${API_ORIGIN}${path}`, init),
-    { ...env, ...overrides },
+    new Request(`${origin}${path}`, init),
+    {
+      ...env,
+      SERVING_HOST: "",
+      API_HOST: "",
+      LEGACY_SERVING_HOST: "",
+      LEGACY_API_HOST: "",
+      ...overrides,
+    },
     ctx,
   );
   await waitOnExecutionContext(ctx);
@@ -158,11 +166,11 @@ describe("POST /api/v1/docs", () => {
     const article = `<p>${"content ".repeat(26_000)}</p>`;
     expect(article.length).toBeGreaterThan(200 * 1024);
 
-    // `SERVING_HOST: ""` pins the request-host fallback instead of inheriting
-    // whatever wrangler.jsonc configures. This test is about the stored bytes;
-    // which host the url names is D3's job, below.
+    // The helper pins local path fallback instead of inheriting the production
+    // hosts from wrangler.jsonc. This test is about the stored bytes; which host
+    // the url names is D3's job, below.
     const body = await pushedOk(
-      await post(KEY_A, { title: "A note", html: page(article) }, { SERVING_HOST: "" }),
+      await post(KEY_A, { title: "A note", html: page(article) }),
       201,
     );
 
@@ -173,7 +181,7 @@ describe("POST /api/v1/docs", () => {
       version: 1,
     });
 
-    // R2 holds the publisher's bytes and nothing else: Symposium's additions go
+    // R2 holds the publisher's bytes and nothing else: OpenArtifacts' additions go
     // in at serve time, so a byline change reaches documents already published.
     const object = await env.DOCS.get(versionObjectKey(body.docId, 1));
     expect(object).not.toBeNull();
@@ -181,7 +189,7 @@ describe("POST /api/v1/docs", () => {
 
     expect(html).toBe(page(article));
     expect(html).not.toContain(NOINDEX_META);
-    expect(html).not.toContain(SYMPOSIUM_FOOTER);
+    expect(html).not.toContain(OPENARTIFACTS_FOOTER);
     expect(object!.httpMetadata?.contentType).toBe("text/html; charset=utf-8");
 
     // D1 is a pointer index: it has to agree with what R2 actually holds.
@@ -195,7 +203,7 @@ describe("POST /api/v1/docs", () => {
   });
 
   it("keeps uploaded scripts intact (D6)", async () => {
-    const interactive = '<script>window.__symposium = "runs";</script><canvas id="figure"></canvas>';
+    const interactive = '<script>window.__openartifacts = "runs";</script><canvas id="figure"></canvas>';
 
     const body = await pushedOk(
       await post(KEY_A, { title: "Figure", html: page(interactive) }),
@@ -229,13 +237,31 @@ describe("POST /api/v1/docs", () => {
     expect((await docRow(body.docId))?.title).toBe("Untitled");
   });
 
-  it("points the url at the serving host once one is configured (D3)", async () => {
-    const body = await pushedOk(
-      await post(KEY_A, { title: "t", html: page("<p>x</p>") }, { SERVING_HOST: "symposium.page" }),
-      201,
-    );
+  it("returns a canonical document url through both API hosts (D3)", async () => {
+    const hosts: Partial<Env> = {
+      SERVING_HOST: "openartifacts.site",
+      API_HOST: "api.openartifacts.ai",
+      LEGACY_SERVING_HOST: "symposium.site",
+      LEGACY_API_HOST: "api.symposium.md",
+    };
 
-    expect(body.url).toBe(`https://symposium.page/d/${body.docId}`);
+    for (const apiHost of ["api.openartifacts.ai", "api.symposium.md"]) {
+      for (const scheme of ["https", "http"]) {
+        const body = await pushedOk(
+          await send(
+            "POST",
+            "/api/v1/docs",
+            KEY_A,
+            { title: "t", html: page("<p>x</p>") },
+            hosts,
+            `${scheme}://${apiHost}`,
+          ),
+          201,
+        );
+
+        expect(body.url).toBe(`https://openartifacts.site/d/${body.docId}`);
+      }
+    }
   });
 });
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -6,8 +6,8 @@ import {
   renderServedHtml,
   SOCIAL_CARD_META,
   socialTitleMeta,
-  SYMPOSIUM_FOOTER,
-  SYMPOSIUM_HEADER,
+  OPENARTIFACTS_FOOTER,
+  OPENARTIFACTS_HEADER,
 } from "../src/render.js";
 
 const bake = async (html: string, branding = true): Promise<string> =>
@@ -52,7 +52,7 @@ describe("renderServedHtml — what gets injected", () => {
   // them accept. Pinned on the brand domain rather than a deployment url,
   // because `/v{n}` pages hand this string to crawlers for a year.
   it("points the card image at a stable brand-domain url", () => {
-    expect(OG_IMAGE_URL).toBe("https://symposium.md/og-image.png");
+    expect(OG_IMAGE_URL).toBe("https://openartifacts.ai/og-image.png");
     expect(SOCIAL_CARD_META).toContain(`<meta property="og:image" content="${OG_IMAGE_URL}">`);
   });
 
@@ -61,6 +61,9 @@ describe("renderServedHtml — what gets injected", () => {
   // render a thumbnail — or nothing — on the first paste. They are the actual
   // size of the file at the url above.
   it("states the image size and asks for a full-bleed card", () => {
+    expect(SOCIAL_CARD_META).toContain(
+      '<meta property="og:site_name" content="OpenArtifacts">',
+    );
     expect(SOCIAL_CARD_META).toContain('<meta property="og:image:width" content="1200">');
     expect(SOCIAL_CARD_META).toContain('<meta property="og:image:height" content="630">');
     expect(SOCIAL_CARD_META).toContain('<meta name="twitter:card" content="summary_large_image">');
@@ -148,12 +151,12 @@ describe("renderServedHtml — what gets injected", () => {
   it("carries the Copilot mark inline, in the byline's own grey", () => {
     // Inline, so the mark does not depend on another host being up, and no
     // request leaves the page to fetch it.
-    expect(SYMPOSIUM_HEADER).toContain("background:url(data:image/svg+xml,");
-    expect(SYMPOSIUM_HEADER).toContain(encodeURIComponent('fill="#888"'));
+    expect(OPENARTIFACTS_HEADER).toContain("background:url(data:image/svg+xml,");
+    expect(OPENARTIFACTS_HEADER).toContain(encodeURIComponent('fill="#888"'));
     // Decorative: the link text already names the product.
-    expect(SYMPOSIUM_HEADER).toContain('aria-hidden="true"');
-    expect(SYMPOSIUM_HEADER).toContain("width:17px");
-    expect(SYMPOSIUM_HEADER).toContain("height:14px");
+    expect(OPENARTIFACTS_HEADER).toContain('aria-hidden="true"');
+    expect(OPENARTIFACTS_HEADER).toContain("width:17px");
+    expect(OPENARTIFACTS_HEADER).toContain("height:14px");
   });
 
   // The header is prepended, so anything it adds is the *first* of its kind in
@@ -162,31 +165,31 @@ describe("renderServedHtml — what gets injected", () => {
   // interactive figures are an explicitly supported input (D6). A background
   // image on an empty span answers to neither selector.
   it("adds no element a document's own figure selectors could find", () => {
-    for (const byline of [SYMPOSIUM_HEADER, SYMPOSIUM_FOOTER]) {
+    for (const byline of [OPENARTIFACTS_HEADER, OPENARTIFACTS_FOOTER]) {
       expect(byline).not.toContain("<svg");
       expect(byline).not.toContain("<img");
       expect(byline).not.toContain("<canvas");
     }
   });
 
-  it("names Symposium and what it is for, in text a reader can see", async () => {
+  it("names OpenArtifacts and what it is for, in text a reader can see", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
     expect(baked).toContain(">Powered by <");
-    expect(baked).toContain(">symposium.md</a>");
+    expect(baked).toContain(">openartifacts.ai</a>");
     expect(baked).toContain("where agents and humans get on the same page");
   });
 
   it("links both bylines out, which is the whole point of carrying them", async () => {
-    expect(SYMPOSIUM_HEADER).toContain('href="https://obsidiancopilot.com"');
-    expect(SYMPOSIUM_FOOTER).toContain('href="https://symposium.md"');
+    expect(OPENARTIFACTS_HEADER).toContain('href="https://obsidiancopilot.com"');
+    expect(OPENARTIFACTS_FOOTER).toContain('href="https://openartifacts.ai"');
   });
 
   // A container reset does not reach descendants, so a document's
   // `a { display: none }` would delete the branding. The anchors carry their
   // own reset, then put back what they need.
   it("resets its own anchors rather than inheriting the document's link styles", () => {
-    for (const byline of [SYMPOSIUM_HEADER, SYMPOSIUM_FOOTER]) {
+    for (const byline of [OPENARTIFACTS_HEADER, OPENARTIFACTS_FOOTER]) {
       expect(byline).toContain('<a href="https://');
       for (const restored of ["font:inherit", "cursor:pointer", "color:#888"]) {
         expect(byline).toContain(restored);
@@ -198,13 +201,13 @@ describe("renderServedHtml — what gets injected", () => {
 
     // Asserted apart, because a shared `display:inline` check would pass for the
     // header only by being a prefix of `inline-flex`.
-    expect(SYMPOSIUM_FOOTER).toContain("display:inline;");
-    expect(SYMPOSIUM_HEADER).toContain("display:inline-flex");
+    expect(OPENARTIFACTS_FOOTER).toContain("display:inline;");
+    expect(OPENARTIFACTS_HEADER).toContain("display:inline-flex");
 
     // One reset per element the byline adds — no exceptions, since a bare span
     // is one a document's `span { font-size: 0 }` reaches. Counted against the
     // tags rather than hard-coded, so an element added later cannot skip one.
-    for (const byline of [SYMPOSIUM_HEADER, SYMPOSIUM_FOOTER]) {
+    for (const byline of [OPENARTIFACTS_HEADER, OPENARTIFACTS_FOOTER]) {
       const elements =
         occurrences(byline, "<div") + occurrences(byline, "<a ") + occurrences(byline, "<span");
       expect(occurrences(byline, "all:initial")).toBe(elements);
@@ -214,7 +217,7 @@ describe("renderServedHtml — what gets injected", () => {
   // The reader is mid-document; a byline that navigates the page away costs
   // them their place. `noopener` is what makes `_blank` safe to hand out.
   it("opens both links in a new tab, without handing over a window handle", () => {
-    for (const byline of [SYMPOSIUM_HEADER, SYMPOSIUM_FOOTER]) {
+    for (const byline of [OPENARTIFACTS_HEADER, OPENARTIFACTS_FOOTER]) {
       expect(byline).toContain('target="_blank"');
       expect(byline).toContain('rel="noopener noreferrer"');
     }
@@ -226,8 +229,8 @@ describe("renderServedHtml — where the injections land", () => {
     const baked = await bake(page("<p>hello</p>"));
 
     expect(baked).toContain(`<head>${NOINDEX_META}${FAVICON_LINK}${SOCIAL_CARD_META}`);
-    expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
-    expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
+    expect(baked).toContain(`<body>${OPENARTIFACTS_HEADER}`);
+    expect(baked).toContain(`${OPENARTIFACTS_FOOTER}</body>`);
   });
 
   // `og:title` is read out of the document's own `<title>`, which has not been
@@ -243,8 +246,8 @@ describe("renderServedHtml — where the injections land", () => {
   it("puts the header above the document's own content, not below it", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
-    expect(baked.indexOf(SYMPOSIUM_HEADER)).toBeLessThan(baked.indexOf("<p>hello</p>"));
-    expect(baked.indexOf(SYMPOSIUM_FOOTER)).toBeGreaterThan(baked.indexOf("<p>hello</p>"));
+    expect(baked.indexOf(OPENARTIFACTS_HEADER)).toBeLessThan(baked.indexOf("<p>hello</p>"));
+    expect(baked.indexOf(OPENARTIFACTS_FOOTER)).toBeGreaterThan(baked.indexOf("<p>hello</p>"));
   });
 
   it("injects each exactly once, however many candidate tags the page has", async () => {
@@ -254,8 +257,8 @@ describe("renderServedHtml — where the injections land", () => {
     expect(occurrences(baked, FAVICON_LINK)).toBe(1);
     expect(occurrences(baked, SOCIAL_CARD_META)).toBe(1);
     expect(occurrences(baked, "og:title")).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_HEADER)).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_HEADER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_FOOTER)).toBe(1);
   });
 
   // A repeated head is the shape that catches a card title accumulated across
@@ -282,8 +285,8 @@ describe("renderServedHtml — where the injections land", () => {
     );
 
     expect(occurrences(baked, NOINDEX_META)).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_HEADER)).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_HEADER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_FOOTER)).toBe(1);
     expect(baked).toContain("<p>one</p>");
     expect(baked).toContain("<p>two</p>");
   });
@@ -298,9 +301,9 @@ describe("renderServedHtml — where the injections land", () => {
         "<body><p>inner</p></body><p>after</p></body></html>",
     );
 
-    expect(occurrences(baked, SYMPOSIUM_HEADER)).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
-    expect(baked.indexOf(SYMPOSIUM_FOOTER)).toBeGreaterThan(baked.indexOf("<p>after</p>"));
+    expect(occurrences(baked, OPENARTIFACTS_HEADER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_FOOTER)).toBe(1);
+    expect(baked.indexOf(OPENARTIFACTS_FOOTER)).toBeGreaterThan(baked.indexOf("<p>after</p>"));
   });
 
   // A `<template>` holding ordinary content is a shape real documents have, and
@@ -310,10 +313,10 @@ describe("renderServedHtml — where the injections land", () => {
   it("leaves template content alone", async () => {
     const baked = await bake(page("<template><p>inert</p></template><p>real</p>"));
 
-    expect(occurrences(baked, SYMPOSIUM_HEADER)).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_HEADER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_FOOTER)).toBe(1);
     expect(baked).toContain("<template><p>inert</p></template>");
-    expect(baked.indexOf(SYMPOSIUM_HEADER)).toBeLessThan(baked.indexOf("<template>"));
+    expect(baked.indexOf(OPENARTIFACTS_HEADER)).toBeLessThan(baked.indexOf("<template>"));
   });
 
   it("keeps the document's own head content, including its own meta tags", async () => {
@@ -333,8 +336,8 @@ describe("renderServedHtml — documents missing the tags to hang them on", () =
     );
 
     expect(headOf(baked)).toContain(NOINDEX_META);
-    expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
-    expect(baked).toContain(SYMPOSIUM_FOOTER);
+    expect(baked).toContain(`<body>${OPENARTIFACTS_HEADER}`);
+    expect(baked).toContain(OPENARTIFACTS_FOOTER);
     expect(baked).toContain("<p>hi</p>");
   });
 
@@ -355,8 +358,8 @@ describe("renderServedHtml — documents missing the tags to hang them on", () =
 
     expect(baked).toContain(NOINDEX_META);
     expect(baked).toContain(FAVICON_LINK);
-    expect(baked).toContain(`<body>${SYMPOSIUM_HEADER}`);
-    expect(baked).toContain(`${SYMPOSIUM_FOOTER}</body>`);
+    expect(baked).toContain(`<body>${OPENARTIFACTS_HEADER}`);
+    expect(baked).toContain(`${OPENARTIFACTS_FOOTER}</body>`);
     // The doctype has to stay first: a meta ahead of it would put the page into
     // quirks mode, which is a real change to how the document renders.
     expect(baked.startsWith("<!doctype html>")).toBe(true);
@@ -367,8 +370,8 @@ describe("renderServedHtml — documents missing the tags to hang them on", () =
 
     expect(baked).toContain("<p>just a fragment</p>");
     expect(baked).toContain(NOINDEX_META);
-    expect(baked).toContain(SYMPOSIUM_HEADER);
-    expect(baked).toContain(SYMPOSIUM_FOOTER);
+    expect(baked).toContain(OPENARTIFACTS_HEADER);
+    expect(baked).toContain(OPENARTIFACTS_FOOTER);
   });
 
   // The documented cost of hanging the header on `<body>`: with no start tag to
@@ -378,7 +381,7 @@ describe("renderServedHtml — documents missing the tags to hang them on", () =
   it("puts the header below the content when there is no body start tag", async () => {
     const baked = await bake("<p>just a fragment</p>");
 
-    expect(baked.indexOf(SYMPOSIUM_HEADER)).toBeGreaterThan(
+    expect(baked.indexOf(OPENARTIFACTS_HEADER)).toBeGreaterThan(
       baked.indexOf("<p>just a fragment</p>"),
     );
   });
@@ -409,7 +412,7 @@ describe("renderServedHtml — the document's own content", () => {
 
     expect(baked).toContain(decoys);
     expect(occurrences(baked, NOINDEX_META)).toBe(1);
-    expect(occurrences(baked, SYMPOSIUM_FOOTER)).toBe(1);
+    expect(occurrences(baked, OPENARTIFACTS_FOOTER)).toBe(1);
   });
 
   it("preserves non-ASCII content byte for byte", async () => {
@@ -432,15 +435,15 @@ describe("renderServedHtml — the document's own content", () => {
 describe("renderServedHtml — branding off", () => {
   // The separation the tier work depends on: a plan that pays to lose the
   // bylines must not also lose `noindex`, which is policy rather than branding.
-  // The tab icon goes with them: a Symposium mark in the reader's tab is
+  // The tab icon goes with them: an OpenArtifacts mark in the reader's tab is
   // branding too. The robots meta is policy and stays.
   it("drops both bylines, the icon and the card but keeps the robots meta", async () => {
     const bare = await bake(page("<p>hello</p>"), false);
 
-    expect(bare).not.toContain(SYMPOSIUM_HEADER);
-    expect(bare).not.toContain(SYMPOSIUM_FOOTER);
+    expect(bare).not.toContain(OPENARTIFACTS_HEADER);
+    expect(bare).not.toContain(OPENARTIFACTS_FOOTER);
     expect(bare).not.toContain(FAVICON_LINK);
-    // The card carries Symposium's own image into somebody else's Discord,
+    // The card carries OpenArtifacts' own image into somebody else's Discord,
     // which is the most visible branding of the lot. `og:title` goes with it:
     // a title with no image unfurls worse than the fallback would.
     expect(bare).not.toContain(SOCIAL_CARD_META);
@@ -453,6 +456,6 @@ describe("renderServedHtml — branding off", () => {
     const bare = await bake("<!doctype html><html><body><p>hi</p></body></html>", false);
 
     expect(bare).toContain(NOINDEX_META);
-    expect(bare).not.toContain(SYMPOSIUM_HEADER);
+    expect(bare).not.toContain(OPENARTIFACTS_HEADER);
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -2,19 +2,36 @@ import { describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
 import worker, { resolveSurface } from "../src/index.js";
 
-/** Phase 1 routing never touches a binding, so the storage bindings stay unset. */
+/** Routing tests never touch storage, so those bindings stay unset. */
 const env = (vars: Partial<Env> = {}): Env =>
-  ({ SERVING_HOST: "", API_HOST: "", ...vars }) as Env;
+  ({
+    SERVING_HOST: "",
+    API_HOST: "",
+    LEGACY_SERVING_HOST: "",
+    LEGACY_API_HOST: "",
+    ...vars,
+  }) as Env;
 
 const ctx = {} as ExecutionContext;
 
 const get = (url: string, vars: Partial<Env> = {}) =>
   worker.fetch(new Request(url), env(vars), ctx);
 
-const WORKERS_DEV = "symposium.workers.dev";
-const TWO_DOMAIN = { servingHost: "symposium.page", apiHost: "api.symposium.md" };
+const WORKERS_DEV = "openartifacts.workers.dev";
+const HOSTS = {
+  servingHost: "openartifacts.site",
+  apiHost: "api.openartifacts.ai",
+  legacyServingHost: "symposium.site",
+  legacyApiHost: "api.symposium.md",
+};
+const PRODUCTION_ENV: Partial<Env> = {
+  SERVING_HOST: HOSTS.servingHost,
+  API_HOST: HOSTS.apiHost,
+  LEGACY_SERVING_HOST: HOSTS.legacyServingHost,
+  LEGACY_API_HOST: HOSTS.legacyApiHost,
+};
 
-describe("resolveSurface — workers.dev, no hosts configured", () => {
+describe("resolveSurface — local development, no hosts configured", () => {
   const unset = {};
 
   it("routes /api/v1 paths to the API surface", () => {
@@ -35,117 +52,137 @@ describe("resolveSurface — workers.dev, no hosts configured", () => {
   });
 
   it("ignores empty host vars the same as absent ones", () => {
-    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs", { servingHost: "", apiHost: "" })).toBe(
-      "api",
-    );
+    expect(
+      resolveSurface(WORKERS_DEV, "/api/v1/docs", {
+        servingHost: "",
+        apiHost: "",
+        legacyServingHost: "",
+        legacyApiHost: "",
+      }),
+    ).toBe("api");
   });
 });
 
-describe("resolveSurface — two configured domains", () => {
-  it("routes by host, not path", () => {
-    expect(resolveSurface("symposium.page", "/d/abc", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("api.symposium.md", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+describe("resolveSurface — canonical and legacy domains", () => {
+  it("routes the canonical hosts by surface", () => {
+    expect(resolveSurface("openartifacts.site", "/d/abc", HOSTS)).toBe("serving");
+    expect(resolveSurface("api.openartifacts.ai", "/api/v1/docs", HOSTS)).toBe("api");
   });
 
-  it("keeps /api/v1 off the serving host", () => {
-    expect(resolveSurface("symposium.page", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("symposium.page", "/api/v1/docs/abc", TWO_DOMAIN)).toBe("serving");
+  it("redirects the legacy document host and serves the legacy API natively", () => {
+    expect(resolveSurface("symposium.site", "/d/abc", HOSTS)).toBe("legacy-serving");
+    expect(resolveSurface("api.symposium.md", "/api/v1/docs", HOSTS)).toBe("api");
   });
 
-  it("keeps doc serving off the API host", () => {
-    expect(resolveSurface("api.symposium.md", "/d/abc", TWO_DOMAIN)).toBe("api");
+  it("keeps /api/v1 off both document hosts", () => {
+    expect(resolveSurface("openartifacts.site", "/api/v1/docs", HOSTS)).toBe("serving");
+    expect(resolveSurface("symposium.site", "/api/v1/docs", HOSTS)).toBe("legacy-serving");
   });
 
-  it("matches the host case-insensitively and ignores the root dot", () => {
-    // Both forms reach `/api/v1` if the match fails, so each asserts the
-    // security property rather than just a normalisation detail.
-    expect(resolveSurface("SYMPOSIUM.PAGE", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("symposium.page.", "/api/v1/docs", TWO_DOMAIN)).toBe("serving");
-    expect(resolveSurface("symposium.page", "/api/v1/docs", { servingHost: "SYMPOSIUM.Page." })).toBe(
-      "serving",
-    );
+  it("keeps document serving off both API hosts", () => {
+    expect(resolveSurface("api.openartifacts.ai", "/d/abc", HOSTS)).toBe("api");
+    expect(resolveSurface("api.symposium.md", "/d/abc", HOSTS)).toBe("api");
   });
 
-  it("does not match a subdomain or suffix of a configured host", () => {
-    // A path with no prefix to fall back on, so "unknown" can only mean the
-    // host itself did not match.
-    expect(resolveSurface("evil.symposium.page", "/nope", TWO_DOMAIN)).toBe("unknown");
-    expect(resolveSurface("symposium.page.evil.com", "/nope", TWO_DOMAIN)).toBe("unknown");
-    expect(resolveSurface("notsymposium.page", "/nope", TWO_DOMAIN)).toBe("unknown");
-    // And a lookalike host still gets no serving treatment for an API path.
-    expect(resolveSurface("evil.symposium.page", "/api/v1/docs", TWO_DOMAIN)).toBe("api");
+  it("matches every configured host case-insensitively and ignores the root dot", () => {
+    expect(resolveSurface("OPENARTIFACTS.SITE.", "/api/v1/docs", HOSTS)).toBe("serving");
+    expect(resolveSurface("SYMPOSIUM.SITE.", "/d/abc", HOSTS)).toBe("legacy-serving");
+    expect(resolveSurface("API.OPENARTIFACTS.AI.", "/d/abc", HOSTS)).toBe("api");
+    expect(resolveSurface("API.SYMPOSIUM.MD.", "/d/abc", HOSTS)).toBe("api");
   });
 
-  it("falls back to path prefixes on an unrecognised host", () => {
-    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs", TWO_DOMAIN)).toBe("api");
-    expect(resolveSurface(WORKERS_DEV, "/d/abc", TWO_DOMAIN)).toBe("serving");
+  it("fails closed on unknown hosts even when the path names a surface", () => {
+    expect(resolveSurface(WORKERS_DEV, "/api/v1/docs", HOSTS)).toBe("unknown");
+    expect(resolveSurface(WORKERS_DEV, "/d/abc", HOSTS)).toBe("unknown");
+    expect(resolveSurface("evil.openartifacts.site", "/api/v1/docs", HOSTS)).toBe("unknown");
+    expect(resolveSurface("openartifacts.site.evil.com", "/d/abc", HOSTS)).toBe("unknown");
   });
 
-  it("routes by host when only the serving host is configured", () => {
-    expect(resolveSurface("symposium.page", "/api/v1/docs", { servingHost: "symposium.page" })).toBe(
-      "serving",
-    );
+  it("fails closed when only part of the production host config is present", () => {
+    expect(
+      resolveSurface(WORKERS_DEV, "/api/v1/docs", { servingHost: "openartifacts.site" }),
+    ).toBe("unknown");
   });
 });
 
 describe("worker dispatch", () => {
-  it("serves the health check on any host", async () => {
-    for (const host of [WORKERS_DEV, "symposium.page", "api.symposium.md"]) {
-      const res = await get(`https://${host}/health`, {
-        SERVING_HOST: "symposium.page",
-        API_HOST: "api.symposium.md",
-      });
+  it("serves health on canonical hosts and the native legacy API host", async () => {
+    for (const host of ["openartifacts.site", "api.openartifacts.ai", "api.symposium.md"]) {
+      const res = await get(`https://${host}/health`, PRODUCTION_ENV);
       expect(res.status).toBe(200);
       await expect(res.json()).resolves.toEqual({ ok: true });
     }
   });
 
-  it("answers unknown paths with the error contract", async () => {
-    const res = await get(`https://${WORKERS_DEV}/nope`);
-    expect(res.status).toBe(404);
-    expect(res.headers.get("content-type")).toContain("application/json");
-    await expect(res.json()).resolves.toEqual({
-      error: { code: "not_found", message: expect.stringContaining("/nope") },
-    });
+  it("redirects legacy document health and fails closed on an unknown host", async () => {
+    const legacy = await get("https://symposium.site/health?probe=deploy", PRODUCTION_ENV);
+    expect(legacy.status).toBe(307);
+    expect(legacy.headers.get("location")).toBe(
+      "https://openartifacts.site/health?probe=deploy",
+    );
+
+    const unknown = await get(`https://${WORKERS_DEV}/health`, PRODUCTION_ENV);
+    expect(unknown.status).toBe(404);
   });
 
-  it("hands /api/v1 to the API surface on workers.dev", async () => {
-    // The API surface authenticates before it routes (phase 2), so an
-    // unauthenticated request stops at 401 rather than reaching a handler.
-    const res = await get(`https://${WORKERS_DEV}/api/v1/docs`);
+  it("preserves the exact path and query when redirecting an old document URL", async () => {
+    const res = await get(
+      "https://symposium.site/d/9f2k4mvq7t0xbz3n/v2?source=old%20note&view=full",
+      PRODUCTION_ENV,
+    );
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "https://openartifacts.site/d/9f2k4mvq7t0xbz3n/v2?source=old%20note&view=full",
+    );
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("serves the old API host natively without an auth redirect", async () => {
+    const res = await get("https://api.symposium.md/api/v1/docs", PRODUCTION_ENV);
     expect(res.status).toBe(401);
-    // The serving surface stamps every response it produces; the API does not.
+    expect(res.headers.get("location")).toBeNull();
     expect(res.headers.get("x-robots-tag")).toBeNull();
   });
 
-  it("hands /d to the serving surface on workers.dev", async () => {
-    const res = await get(`https://${WORKERS_DEV}/d/abc`);
+  it("answers unknown configured hosts without falling through by path", async () => {
+    const res = await get(`https://${WORKERS_DEV}/api/v1/docs`, PRODUCTION_ENV);
     expect(res.status).toBe(404);
-    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(await res.text()).toContain("This document isn’t available.");
-    expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("x-robots-tag")).toBeNull();
   });
 
-  it("never reaches the API surface on the serving host", async () => {
-    // Including the trailing-root-dot form, which `new URL()` preserves in
-    // `hostname` and which would otherwise miss the host match and fall
-    // through to the /api/v1 path prefix.
-    for (const host of ["symposium.page", "symposium.page.", "SYMPOSIUM.PAGE"]) {
-      const res = await get(`https://${host}/api/v1/docs`, {
-        SERVING_HOST: "symposium.page",
-        API_HOST: "api.symposium.md",
-      });
-      expect(res.status).toBe(404);
-      // Two independent signals that the serving surface answered: only it
-      // stamps the robots header, and only it renders an HTML status page.
-      expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
-      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
-      expect(await res.text()).toContain("This document isn’t available.");
+  it("keeps the API off the canonical document host", async () => {
+    const res = await get("https://openartifacts.site/api/v1/docs", PRODUCTION_ENV);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(await res.text()).toContain("This document isn’t available.");
+  });
+
+  it("keeps documents off both API hosts", async () => {
+    for (const host of ["api.openartifacts.ai", "api.symposium.md"]) {
+      const res = await get(`https://${host}/d/9f2k4mvq7t0xbz3n`, PRODUCTION_ENV);
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-robots-tag")).toBeNull();
     }
   });
 
-  it("never sets a cookie on the serving surface", async () => {
-    const res = await get("https://symposium.page/d/abc", { SERVING_HOST: "symposium.page" });
+  it("keeps local path fallback for wrangler dev", async () => {
+    const api = await get(`https://${WORKERS_DEV}/api/v1/docs`);
+    expect(api.status).toBe(401);
+
+    const serving = await get(`https://${WORKERS_DEV}/d/abc`);
+    expect(serving.status).toBe(404);
+    expect(serving.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+  });
+
+  it("never sets a cookie on the canonical document surface", async () => {
+    const res = await get("https://openartifacts.site/d/abc", PRODUCTION_ENV);
     expect(res.headers.get("set-cookie")).toBeNull();
   });
 });

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -2,7 +2,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
 import { DOC_ID_LENGTH } from "../src/ids.js";
-import { NOINDEX_META, SYMPOSIUM_FOOTER, SYMPOSIUM_HEADER } from "../src/render.js";
+import { NOINDEX_META, OPENARTIFACTS_FOOTER, OPENARTIFACTS_HEADER } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
@@ -17,7 +17,7 @@ async function expectServes(response: Response, docId: string, version: number) 
   const document = await stored(docId, version);
   expect(document).not.toContain(NOINDEX_META);
   expect(html).toContain(NOINDEX_META);
-  expect(html).toContain(SYMPOSIUM_FOOTER);
+  expect(html).toContain(OPENARTIFACTS_FOOTER);
   // Everything inside the body the owner sent, in order, still there.
   const inner = document.slice(document.indexOf("<body>") + 6, document.indexOf("</body>"));
   expect(html).toContain(inner.trim());
@@ -36,18 +36,20 @@ async function expectStatusPage(
   expect(response.headers.get("cache-control")).toBe("no-store");
 
   const html = await response.text();
-  expect(html).toContain(`<title>${title} · Symposium</title>`);
+  expect(html).toContain(`<title>${title} · OpenArtifacts</title>`);
+  expect(html).toContain(">OpenArtifacts</div>");
+  expect(html).toContain('<a href="https://openartifacts.ai">About OpenArtifacts</a>');
   expect(html).toContain(`<h1 id="page-title">${heading}</h1>`);
   expect(html).toContain(message);
   expect(html).toContain(NOINDEX_META);
 }
 
 /**
- * A host matching neither SERVING_HOST nor API_HOST, which is what makes the
- * router fall back to path prefixes. Deliberately not a real deployment host:
- * these tests are about the surfaces, not about which domain carries them.
+ * Local routing has no configured hosts, so it falls back to path prefixes.
+ * Deliberately not a real deployment host: these tests are about the surfaces,
+ * not about which production domain carries them.
  */
-const ORIGIN = "https://symposium.workers.dev";
+const ORIGIN = "https://openartifacts.workers.dev";
 
 const KEY = "cplus_live_a1b2c3d4e5f60718";
 
@@ -94,7 +96,14 @@ async function send(
   const ctx = createExecutionContext();
   const response = await worker.fetch(
     new Request(`${ORIGIN}${path}`, { method, ...init }),
-    { ...env, ...overrides },
+    {
+      ...env,
+      SERVING_HOST: "",
+      API_HOST: "",
+      LEGACY_SERVING_HOST: "",
+      LEGACY_API_HOST: "",
+      ...overrides,
+    },
     ctx,
   );
   await waitOnExecutionContext(ctx);
@@ -171,9 +180,9 @@ describe("GET /d/{docId}", () => {
     expect(html).toContain("<p>second draft</p>");
     expect(html).not.toContain("<p>first draft</p>");
     expect(html).toContain(NOINDEX_META);
-    expect(html).toContain(SYMPOSIUM_FOOTER);
+    expect(html).toContain(OPENARTIFACTS_FOOTER);
     expect(object).not.toContain(NOINDEX_META);
-    expect(object).not.toContain(SYMPOSIUM_FOOTER);
+    expect(object).not.toContain(OPENARTIFACTS_FOOTER);
   });
 
   // End to end, because "injected once" is asserted against the renderer in
@@ -186,13 +195,13 @@ describe("GET /d/{docId}", () => {
 
     const html = await (await get(`/d/${docId}`)).text();
 
-    for (const addition of [NOINDEX_META, SYMPOSIUM_HEADER, SYMPOSIUM_FOOTER]) {
+    for (const addition of [NOINDEX_META, OPENARTIFACTS_HEADER, OPENARTIFACTS_FOOTER]) {
       expect(html.split(addition).length - 1).toBe(1);
     }
     // The bylines' own markers, so a future restyle that changes the constants
     // cannot make the count above pass by matching nothing.
-    expect(html.split("symposium-header").length - 1).toBe(1);
-    expect(html.split("symposium-footer").length - 1).toBe(1);
+    expect(html.split("openartifacts-header").length - 1).toBe(1);
+    expect(html.split("openartifacts-footer").length - 1).toBe(1);
   });
 
   it("serves version 1 at the same url before there is a version 2", async () => {
@@ -498,7 +507,7 @@ describe("a doc that is not there", () => {
     // arrangement in which the prefix lookalikes below reach this handler at
     // all — on workers.dev the router answers them as unknown paths — and it is
     // the arrangement where mistaking `/dx{docId}` for a doc url would matter.
-    const servingHost = { SERVING_HOST: "symposium.workers.dev", DB: noDb };
+    const servingHost = { SERVING_HOST: "openartifacts.workers.dev", DB: noDb };
 
     for (const path of impossible) {
       const response = await get(path, undefined, servingHost);
@@ -700,7 +709,7 @@ describe("HEAD and conditional requests", () => {
     const response = await get(`/d/${docId}`, { headers: { "if-none-match": older } });
 
     expect(response.status).toBe(200);
-    expect(await response.text()).toContain(SYMPOSIUM_FOOTER);
+    expect(await response.text()).toContain(OPENARTIFACTS_FOOTER);
     expect(response.headers.get("etag")).toBe(current);
   });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,18 +7,19 @@
     "enabled": true
   },
 
-  // The two hostnames the Worker answers on, and the only ones — `workers_dev`
-  // is false. Declared here rather than clicked in the dashboard so the repo
-  // describes production: a custom domain created by hand is state nothing in
-  // this file knows about.
+  // The canonical and legacy hostnames the Worker answers on, and the only
+  // ones — `workers_dev` is false. Declared here rather than clicked in the
+  // dashboard so the repo describes the post-cutover target: the new domains
+  // must exist in Cloudflare before this config can deploy.
   //
   // `custom_domain` makes Cloudflare create and own the DNS record, which is
-  // why neither zone should carry a hand-made record for these names. They must
-  // match `vars` below exactly; the router compares the request host against
-  // those strings, so a name attached here but missing there would fall through
-  // to path prefixes and serve both surfaces on one domain.
+  // why none of the zones should carry a hand-made record for these names. They
+  // must match `vars` below exactly; the router fails closed on every other
+  // host once any configured hostname is present.
   "routes": [
+    { "pattern": "openartifacts.site", "custom_domain": true },
     { "pattern": "symposium.site", "custom_domain": true },
+    { "pattern": "api.openartifacts.ai", "custom_domain": true },
     { "pattern": "api.symposium.md", "custom_domain": true }
   ],
 
@@ -38,9 +39,9 @@
     }
   ],
 
-  // No workers.dev route, ever. `resolveSurface` falls back to path prefixes on
-  // any host matching neither var below, so a workers.dev hostname would serve
-  // /d/* — user HTML on a domain we cannot sacrifice, and one whose Public
+  // No workers.dev route, ever. `resolveSurface` falls back to path prefixes
+  // only when every host var is empty, so an unconfigured workers.dev hostname
+  // would serve /d/* — user HTML on a domain we cannot sacrifice, and one whose Public
   // Suffix List entry makes a listing hit every Worker on the account.
   // docs/serving-domain.md is the argument; docs/deploying.md covers the cost,
   // which is that the Worker has no hostname until a custom domain is attached.
@@ -48,21 +49,24 @@
 
   // The surface split. Documents serve from the sacrificial domain, the API
   // from the brand one, and `resolveSurface` decides by host — so /api/v1 is
-  // unreachable on symposium.site rather than merely unadvertised (see
+  // unreachable on openartifacts.site rather than merely unadvertised (see
   // docs/serving-domain.md, docs/cost-at-scale.md §6).
   //
-  // Both together or neither. The router falls back to path prefixes while
-  // *either* is empty, which would leave /api/v1 answering on the sacrificial
-  // domain and defeat the split.
+  // Configure all four together. The old document host redirects path and
+  // query to the canonical host. The old API host serves natively so released
+  // clients keep their method and Authorization header on every request.
   //
-  // These must be deployed BEFORE the custom domains are attached. Attaching
-  // first binds the real domains to a version that still has them empty, and
-  // for the length of that deploy the fallback serves /d/* on the API host and
-  // /api/v1/* on the serving host — the split inverted, on the first requests
-  // those domains ever take. With workers_dev false this deploy is reachable on
-  // nothing, so going first costs nothing.
+  // Both new Cloudflare zones must exist before this config can ship. The first
+  // four-route deploy must use the compatibility overrides in
+  // docs/deploying.md, keeping the old hosts canonical while this router is
+  // attached everywhere. Record that version as the rollback floor, then let
+  // CI deploy the final mapping below. CI refuses the one-step cutover. Do not
+  // attach the new names by hand to an old Worker version whose router does not
+  // recognize them.
   "vars": {
-    "SERVING_HOST": "symposium.site",
-    "API_HOST": "api.symposium.md"
+    "SERVING_HOST": "openartifacts.site",
+    "API_HOST": "api.openartifacts.ai",
+    "LEGACY_SERVING_HOST": "symposium.site",
+    "LEGACY_API_HOST": "api.symposium.md"
   }
 }


### PR DESCRIPTION
Fixes #47

## Why

The backend repository is now named OpenArtifacts, but the runtime contract, deployment configuration, documentation, and public output still used the Symposium brand and domains. The cutover needs one canonical identity without breaking released clients or existing document links.

## What

- Renames backend-facing product and package references to `OpenArtifacts`.
- Makes `openartifacts.site` the canonical document host and `api.openartifacts.ai` the canonical API host.
- Redirects `symposium.site` to the same path and query on `openartifacts.site` with a temporary, non-cacheable `307` response.
- Keeps `api.symposium.md` as a native API alias so existing authenticated clients preserve their method, body, and authorization header.
- Fails closed for unknown hosts when production host configuration is present.
- Generates canonical HTTPS document URLs through both API hosts.
- Updates deployment checks, operational documentation, rendering copy, and regression coverage.
- Refuses the first canonical flip until a verified four-host compatibility version exists as the rollback floor.
- Preserves the existing Worker, D1 database, R2 bucket, applied migrations, and released `symposium` frontmatter key.

## Non goal

- Rename the Copilot plugin skill. That is a separate follow-up.
- Rename deployed Cloudflare resources or rewrite applied migration history.
- Provision the new Cloudflare zones or publish the landing-page OG asset in this PR.

## Screenshot

Not applicable. This is a backend and rendered-document branding change with no interactive application UI. Deterministic HTML assertions cover the visible copy; the new public origins are not live yet, so a production capture would be misleading.

## Risk

Risk: **High** because hostname routing and the public API/domain contract are security and compatibility boundaries.

| Gate | Result | Reason |
| --- | --- | --- |
| Behavior is deterministic and testable | ✅ | Host classification, redirects, health checks, rendered output, and canonical URLs have regression coverage. |
| A defect surfaces in CI or first use | ✅ | CI exercises the routing matrix and deployment checks probe all four hosts. |
| Revert fully restores prior state | ✅ | There is no data migration; the staged cutover establishes a safe rollback floor before the hostname flip. |
| No authentication, security, or input-boundary change | ❌ | Host routing is a security boundary; configured unknown hosts now fail closed and legacy API authentication remains native. |
| No public, plugin, message, or on-disk contract change | ❌ | Canonical document and API domains change, while both legacy host contracts remain compatible. |
| No core concurrency or state-machine change | ✅ | Request routing and output branding change without new mutable state or concurrency. |
| No hot path lacks regression coverage | ✅ | Canonical, legacy, cross-surface, mixed-case, trailing-dot, and unknown-host paths are covered. |
| No dependency change | ✅ | Package metadata changes only; the dependency graph is unchanged. |
| Human-only verification stays in one area and fails visibly | ✅ | Cloudflare domain attachment is the only manual surface and failures appear immediately in health and redirect probes. |

Reviewer focus: inspect `resolveSurface` and legacy routing in `src/index.ts`, `publicDocUrl` in `src/urls.ts`, `servingRedirect` in `src/serve.ts`, and the four custom-domain routes in `wrangler.jsonc`. Pay particular attention to unknown hosts, cross-surface paths, and legacy compatibility.

## Verification

Automated:

- `npm run typecheck`
- `npm test`
- `npx wrangler deploy --dry-run`

Human:

1. Provision both new Cloudflare zones and confirm `https://openartifacts.ai/og-image.png` is a direct `200` image before merging.
2. Follow the two-stage cutover in `docs/deploying.md`: deploy the four-host compatibility mapping from reviewed `main`, record its Worker version ID, and verify the new document host redirects to the old host.
3. Re-run the main-branch deployment, then verify `/health` on both canonical hosts and the legacy API host plus the exact `307` destination from the legacy document host.
4. Publish through both API hosts and confirm each response returns an `https://openartifacts.site/...` document URL.
5. Confirm an unknown configured host returns `404` and never serves document HTML or API responses.

## Note

Keep this PR in draft until the new Cloudflare zones and landing-page OG asset are ready. The first post-merge deployment intentionally stops before production changes; the compatibility rollout and recorded rollback floor in `docs/deploying.md` must precede the canonical flip.
