### PR TITLE
Serve pages with the OpenArtifacts icon and tagline

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 4;
+export const RENDER_REVISION = 5;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
@@ -75,10 +75,14 @@ export const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
 export const FAVICON_LINK =
   '<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,' +
   encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
-      '<rect width="32" height="32" rx="7" fill="#121413"/>' +
-      '<path d="M9 11.5h14M9 16h14M9 20.5h9" stroke="#46d17f" stroke-width="2.4" ' +
-      'stroke-linecap="round"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200" rx="44" fill="#15161a"/>' +
+      '<g transform="translate(0 8)"><path d="M100 16 L100 60 M27.3 142 L65.4 120 M172.7 142 L134.6 120" stroke="#ffffff" stroke-opacity="0.3" stroke-width="2.6" fill="none"/>' +
+      '<path d="M100 16 L27.3 58 L27.3 142 L100 184 L172.7 142 L172.7 58 Z" stroke="#ffffff" stroke-opacity="0.8" stroke-width="2.6" fill="none" stroke-linejoin="miter"/>' +
+      '<path d="M100 60 L65.4 80 L100 100 L134.6 80 Z" fill="#f2f2f0"/>' +
+      '<path d="M65.4 80 L65.4 120 L100 140 L100 100 Z" fill="#6f7175"/>' +
+      '<path d="M100 140 L134.6 120 L134.6 80 L100 100 Z" fill="#3b3d40"/>' +
+      '<path d="M27.3 58 L100 100 M100 184 L100 100 M172.7 58 L100 100" stroke="#ffffff" stroke-opacity="0.72" stroke-width="2.6" fill="none"/>' +
+      '</g></svg>',
   ) +
   '">';
 
@@ -126,7 +130,7 @@ export const SOCIAL_CARD_META =
   `<meta property="og:image" content="${OG_IMAGE_URL}">` +
   '<meta property="og:image:width" content="1200">' +
   '<meta property="og:image:height" content="630">' +
-  '<meta property="og:image:alt" content="Where people and agents get on the same page">' +
+  '<meta property="og:image:alt" content="OpenArtifacts: A new mode of communication between agents and humans.">' +
   '<meta name="twitter:card" content="summary_large_image">';
 
 /** How much of a document's title the card carries. Every unfurler truncates
@@ -185,7 +189,7 @@ export function socialTitleMeta(rawTitle: string): string {
  */
 const BYLINE_BASE =
   "all:initial;display:block;box-sizing:border-box;width:100%;clear:both;" +
-  "font:400 13px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;" +
+  "font:400 13px/1.6 Archivo,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;" +
   "color:#888;text-align:center";
 
 /**
@@ -293,7 +297,7 @@ export const OPENARTIFACTS_FOOTER =
   BYLINE_BASE +
   ";margin:4rem 0 0;padding:1rem 0;border-top:1px solid rgba(128,128,128,0.25)\">" +
   `Powered by <a href="https://openartifacts.ai" ${BYLINE_LINK}>openartifacts.ai</a>, ` +
-  "where agents and humans get on the same page</div>";
+  "a new mode of communication between agents and humans</div>";
 
 /** HTMLRewriter treats injected content as markup, not text, only when asked. */
 const AS_HTML = { html: true } as const;

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -37,7 +37,7 @@ describe("renderServedHtml — what gets injected", () => {
   it("carries the tab icon inline, in the brand's own colours", () => {
     expect(FAVICON_LINK).toContain('rel="icon"');
     expect(FAVICON_LINK).toContain('href="data:image/svg+xml,');
-    for (const colour of ["#121413", "#46d17f"]) {
+    for (const colour of ["#15161a", "#f2f2f0"]) {
       expect(FAVICON_LINK).toContain(encodeURIComponent(colour));
     }
     // Escaped, so the `"` on every attribute inside the SVG cannot close the
@@ -177,7 +177,7 @@ describe("renderServedHtml — what gets injected", () => {
 
     expect(baked).toContain(">Powered by <");
     expect(baked).toContain(">openartifacts.ai</a>");
-    expect(baked).toContain("where agents and humans get on the same page");
+    expect(baked).toContain("a new mode of communication between agents and humans");
   });
 
   it("links both bylines out, which is the whole point of carrying them", async () => {


### PR DESCRIPTION
Fixes #51

## Why

A document published after the cutover, for example `openartifacts.site/d/m0s0fepgq96b1ny5`, opens in a tab that still shows the retired Symposium mark: a dark square with three green lines. The Worker inlines that SVG into every page it serves. The social card's alt text and the footer byline also still say "get on the same page", while `openartifacts.ai` now uses the cube mark as its favicon and "A new mode of communication between agents and humans" as its tagline.

## What

| Surface | Before | After |
| --- | --- | --- |
| Tab icon on every served document | Symposium mark, inlined | The same cube mark `openartifacts.ai/favicon.svg` uses, inlined |
| `og:image:alt` on the social card | `Where people and agents get on the same page` | `OpenArtifacts: A new mode of communication between agents and humans.`, the same alt `openartifacts.ai` uses |
| Footer byline | `Powered by openartifacts.ai, where agents and humans get on the same page` | `Powered by openartifacts.ai, a new mode of communication between agents and humans` |
| Byline font | System sans stack | Archivo first, the site's face, falling back to the same system stack; no webfont is loaded |

## Non goal

- Changing the card image, the Copilot byline, or any serving header.
- Letting a document override the injected icon differently than today.

## Screenshot

The inlined icon rendered at 128 px, before and after. Both are the exact SVG bytes the Worker injects.

The social card is not a file in this repo: every served document points `og:image` at `https://openartifacts.ai/og-image.png`, so the card is whatever the site serves there. Brevilabs/app-sites#440 replaces that file with the render below; this PR only corrects the card's alt text.

![The card every served document unfurls with, after app-sites#440](https://github.com/user-attachments/assets/ed18eb36-68f6-4e41-8b5c-ca1cb9766479)

| Before | After |
| --- | --- |
| ![Symposium mark: dark square with three green lines](https://github.com/user-attachments/assets/3e953d6a-9b0f-4bdb-b5bc-e7deeb057ceb) | ![OpenArtifacts cube mark on a dark rounded square](https://github.com/user-attachments/assets/f7cb6fdd-df65-4428-b7c5-637c624b6456) |

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Icon and copy only; `test/render.test.ts` asserts the icon colours, the escaped `href`, and the footer copy |
| A defect would fail CI or be obvious on first use | ✅ | The render tests run in CI and a wrong icon is visible on the first served page |
| A revert fully restores prior state, including persisted data | ✅ | Injected at serve time; nothing is stored |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The injected markup is a constant |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Response bodies change only in the injected head and footer |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Constants only |
| No hot-path behavior lacks deterministic coverage | ✅ | Covered by the render tests |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Visible in the tab of any served document |

Review: skim `FAVICON_LINK`, `SOCIAL_CARD_META`, and `BYLINE_BASE` in `src/render.ts`, then run Verification step 1 after the deploy.

## Verification

1. After the deploy, open any published document on `openartifacts.site` and confirm the tab shows the OpenArtifacts cube. Paste the link into Slack or Discord and confirm the card's alt text and the page footer carry the new tagline.
