### PR TITLE
Brand the document status pages with the OpenArtifacts mark

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -72,18 +72,20 @@ export const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
  * and neither outcome is wrong: the page is the publisher's, and it is served
  * by us.
  */
+/** The cube mark `openartifacts.ai` uses as its own favicon, as raw SVG sized by its container. */
+export const OPENARTIFACTS_MARK_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200" rx="44" fill="#15161a"/>' +
+  '<g transform="translate(0 8)"><path d="M100 16 L100 60 M27.3 142 L65.4 120 M172.7 142 L134.6 120" stroke="#ffffff" stroke-opacity="0.3" stroke-width="2.6" fill="none"/>' +
+  '<path d="M100 16 L27.3 58 L27.3 142 L100 184 L172.7 142 L172.7 58 Z" stroke="#ffffff" stroke-opacity="0.8" stroke-width="2.6" fill="none" stroke-linejoin="miter"/>' +
+  '<path d="M100 60 L65.4 80 L100 100 L134.6 80 Z" fill="#f2f2f0"/>' +
+  '<path d="M65.4 80 L65.4 120 L100 140 L100 100 Z" fill="#6f7175"/>' +
+  '<path d="M100 140 L134.6 120 L134.6 80 L100 100 Z" fill="#3b3d40"/>' +
+  '<path d="M27.3 58 L100 100 M100 184 L100 100 M172.7 58 L100 100" stroke="#ffffff" stroke-opacity="0.72" stroke-width="2.6" fill="none"/>' +
+  '</g></svg>';
+
 export const FAVICON_LINK =
   '<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,' +
-  encodeURIComponent(
-      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200" rx="44" fill="#15161a"/>' +
-      '<g transform="translate(0 8)"><path d="M100 16 L100 60 M27.3 142 L65.4 120 M172.7 142 L134.6 120" stroke="#ffffff" stroke-opacity="0.3" stroke-width="2.6" fill="none"/>' +
-      '<path d="M100 16 L27.3 58 L27.3 142 L100 184 L172.7 142 L172.7 58 Z" stroke="#ffffff" stroke-opacity="0.8" stroke-width="2.6" fill="none" stroke-linejoin="miter"/>' +
-      '<path d="M100 60 L65.4 80 L100 100 L134.6 80 Z" fill="#f2f2f0"/>' +
-      '<path d="M65.4 80 L65.4 120 L100 140 L100 100 Z" fill="#6f7175"/>' +
-      '<path d="M100 140 L134.6 120 L134.6 80 L100 100 Z" fill="#3b3d40"/>' +
-      '<path d="M27.3 58 L100 100 M100 184 L100 100 M172.7 58 L100 100" stroke="#ffffff" stroke-opacity="0.72" stroke-width="2.6" fill="none"/>' +
-      '</g></svg>',
-  ) +
+  encodeURIComponent(OPENARTIFACTS_MARK_SVG) +
   '">';
 
 /**

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -22,6 +22,7 @@ import { findServableVersion } from "./db.js";
 import { isDocId } from "./ids.js";
 import {
   FAVICON_LINK,
+  OPENARTIFACTS_MARK_SVG,
   NOINDEX_META,
   RENDER_REVISION,
   renderServedHtml,
@@ -211,23 +212,22 @@ ${NOINDEX_META}
 ${FAVICON_LINK}
 <title>${copy.title} · OpenArtifacts</title>
 <style>
-  :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  :root { color-scheme: dark; font-family: Archivo, "Helvetica Neue", Helvetica, Arial, ui-sans-serif, system-ui, sans-serif; }
   * { box-sizing: border-box; }
-  body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 2rem; color: #edf3ee; background: #0d100e; }
-  main { width: min(100%, 34rem); padding: clamp(2rem, 6vw, 4rem); border: 1px solid #2b332e; border-radius: 1.5rem; background: #121613; box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.35); }
-  .brand { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 3.5rem; color: #a7b0aa; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; }
-  .mark { display: grid; gap: 0.25rem; width: 2rem; padding: 0.5rem 0.4rem; border-radius: 0.5rem; background: #46d17f; }
-  .mark span { display: block; height: 2px; border-radius: 999px; background: #0d100e; }
-  .mark span:last-child { width: 65%; }
-  h1 { max-width: 12ch; margin: 0; color: #f7faf7; font-size: clamp(2.25rem, 7vw, 4.25rem); line-height: 0.98; letter-spacing: -0.055em; }
-  p { max-width: 30rem; margin: 1.5rem 0 0; color: #a7b0aa; font-size: 1.05rem; line-height: 1.7; }
-  a { display: inline-flex; margin-top: 2rem; color: #72e29d; font-weight: 650; text-underline-offset: 0.25em; }
-  a:hover { color: #a0efbd; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 2rem; color: #e9ebee; background: #07080b; }
+  main { width: min(100%, 34rem); padding: clamp(2rem, 6vw, 4rem); border: 1px solid #20242c; border-radius: 1.5rem; background: #0d0f14; box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.45); }
+  .brand { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 3.5rem; color: #8d94a0; font-family: "IBM Plex Mono", ui-monospace, Menlo, Consolas, monospace; font-size: 0.7rem; font-weight: 500; letter-spacing: 0.16em; text-transform: uppercase; }
+  .mark { display: block; width: 2rem; height: 2rem; }
+  .mark svg { display: block; width: 100%; height: 100%; }
+  h1 { max-width: 12ch; margin: 0; color: #f4f5f7; font-size: clamp(2.25rem, 7vw, 4.25rem); font-weight: 700; line-height: 0.98; letter-spacing: -0.035em; }
+  p { max-width: 30rem; margin: 1.5rem 0 0; color: #8d94a0; font-size: 1.05rem; line-height: 1.7; }
+  a { display: inline-flex; margin-top: 2rem; color: #f6ae52; font-weight: 600; text-underline-offset: 0.25em; }
+  a:hover { color: #f9c47f; }
 </style>
 </head>
 <body>
 <main aria-labelledby="page-title">
-  <div class="brand"><span class="mark" aria-hidden="true"><span></span><span></span><span></span></span>OpenArtifacts</div>
+  <div class="brand"><span class="mark" aria-hidden="true">${OPENARTIFACTS_MARK_SVG}</span>OpenArtifacts</div>
   <h1 id="page-title">${copy.heading}</h1>
   <p>${copy.message}</p>
   <a href="https://openartifacts.ai">About OpenArtifacts</a>

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -2,7 +2,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
 import { DOC_ID_LENGTH } from "../src/ids.js";
-import { NOINDEX_META, OPENARTIFACTS_FOOTER, OPENARTIFACTS_HEADER } from "../src/render.js";
+import { FAVICON_LINK, NOINDEX_META, OPENARTIFACTS_FOOTER, OPENARTIFACTS_HEADER, OPENARTIFACTS_MARK_SVG } from "../src/render.js";
 import { versionObjectKey } from "../src/storage.js";
 import worker from "../src/index.js";
 
@@ -42,6 +42,11 @@ async function expectStatusPage(
   expect(html).toContain(`<h1 id="page-title">${heading}</h1>`);
   expect(html).toContain(message);
   expect(html).toContain(NOINDEX_META);
+  // The page carries the same cube mark as the tab icon; the retired Symposium
+  // mark must not come back through this template.
+  expect(html).toContain(FAVICON_LINK);
+  expect(html).toContain(`<span class="mark" aria-hidden="true">${OPENARTIFACTS_MARK_SVG}</span>`);
+  expect(html).not.toContain("#46d17f");
 }
 
 /**


### PR DESCRIPTION
Fixes #53

## Why

Open a deleted document, for example `openartifacts.site/d/hcdw8de0tpkzxa90`, and the "This document is gone." page still shows a green rounded square with three lines as its mark, green links, and a green-tinted dark ground. That is the retired Symposium identity, drawn in CSS inside the status-page template. The same template serves the 404 page for an unknown id and the 500 page for a failing read, so every reader who hits a dead link meets the old brand while the tab icon beside it already shows the cube.

## What

| Surface | Before | After |
| --- | --- | --- |
| Mark on the 404, 410 and 500 pages | Three green lines drawn in CSS | The cube mark, the same SVG the tab icon and `openartifacts.ai` use |
| Palette | Green-tinted greys and green links | The site's near-black ground, grey text, and amber links |
| Type | Inter, falling back to the system stack | Archivo, falling back to the same system stack, with a mono brand label; no webfont is loaded |
| Copy, status codes, headers | Unchanged | Unchanged |

## Non goal

- Changing the page copy, structure, status codes, or headers.
- Loading a webfont on the status pages.
- Restyling served documents; only the Worker's own pages change.

## Screenshot

The 410 page rendered at 1100 px, before from production and after from this branch's template with the same system font fallback a reader gets.

| Before | After |
| --- | --- |
| ![Deleted-document page with the green Symposium mark](https://github.com/user-attachments/assets/5083153d-b81e-4af4-b06a-145393684cf2) | ![Deleted-document page with the OpenArtifacts cube mark and amber link](https://github.com/user-attachments/assets/98e22e1e-7131-4934-a271-6d06eed0797a) |

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Markup and CSS in one template; `test/serve.test.ts` asserts every status page carries the favicon's mark and never the old colour |
| A defect would fail CI or be obvious on first use | ✅ | The serve tests run in CI and the page is visible on any dead link |
| A revert fully restores prior state, including persisted data | ✅ | Status pages are `no-store` and nothing is persisted |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The template has no inputs |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Status codes and headers are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Constants and a template only |
| No hot-path behavior lacks deterministic coverage | ✅ | Covered by the serve tests |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Visible on the first dead link |

Review: skim `servingPageHtml` in `src/serve.ts` and `OPENARTIFACTS_MARK_SVG` in `src/render.ts`, then run Verification step 1 after the deploy.

## Verification

1. After the deploy, open `https://openartifacts.site/d/hcdw8de0tpkzxa90` and a made-up id such as `/d/0000000000000000`. Both pages should show the cube mark, grey text on a near-black card, and an amber "About OpenArtifacts" link, with the cube in the tab.
