### PR TITLE
Let terminal clients obtain and manage OpenArtifacts tokens

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -75,14 +75,16 @@ existing license-outage fallback.
 
 Four request shapes answer without a credential, because the caller has none
 yet: the device-code mint and poll, the approval page's code lookup, and the
-button that starts a handshake. Three Workers rate limiter bindings cover them,
-declared in `wrangler.jsonc`:
+button that starts a handshake. Four Workers rate limiter bindings cover them,
+declared in `wrangler.jsonc`; polling needs both its per-code interval and an
+aggregate ceiling on random misses:
 
 ```jsonc
 "ratelimits": [
   { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },
   { "name": "APPROVAL_LOOKUP_LIMITER", "namespace_id": "1002", "simple": { "limit": 20, "period": 60 } },
-  { "name": "DEVICE_POLL_LIMITER", "namespace_id": "1003", "simple": { "limit": 1, "period": 10 } }
+  { "name": "DEVICE_POLL_LIMITER", "namespace_id": "1003", "simple": { "limit": 1, "period": 10 } },
+  { "name": "DEVICE_POLL_CLIENT_LIMITER", "namespace_id": "1004", "simple": { "limit": 20, "period": 10 } }
 ]
 ```
 
@@ -112,19 +114,27 @@ the interval in the binding makes a pending poll a D1 read rather than a write.
 `DEVICE_POLL_INTERVAL_SECONDS` is advertised to clients and has to match this
 binding's `period`.
 
+`DEVICE_POLL_CLIENT_LIMITER` runs first and allows twenty total polls per client
+address every ten seconds. The per-code limiter cannot bound an attacker who
+invents a fresh random code for every request; this aggregate bucket keeps those
+D1 misses finite while remaining generous to devices behind a shared address.
+
 **Deleting any block is supported.** A deployment that declares no limiter puts
-no limit on that endpoint, which is the right answer for a private deployment
-nobody else can reach. Without `DEVICE_POLL_LIMITER`, the returned polling
-interval is advisory. Everything else works the same either way.
+no corresponding limit on that endpoint, which is the right answer for a
+private deployment nobody else can reach. Without `DEVICE_POLL_LIMITER`, the
+returned polling interval is advisory; without `DEVICE_POLL_CLIENT_LIMITER`,
+random misses have no aggregate ceiling. Everything else works the same either
+way.
 
 The limiter is not a D1 counter on purpose. A counter in a row costs a write for
 every attempt including every refused one, so under sustained abuse the limiter
 itself would exhaust the account's daily write budget — see
 [cost at scale](cost-at-scale.md).
 
-For a public deployment, add a WAF rate limiting rule on `POST /device/code` and
-`/approve` as a second layer. The binding runs inside the Worker, so a request it refuses has
-still been billed as a request; a WAF rule refuses at the edge before that.
+For a public deployment, add WAF rate limiting rules on `POST /device/code`,
+`POST /device/token`, and `/approve` as a second layer. The binding runs inside
+the Worker, so a request it refuses has still been billed as a request; a WAF
+rule refuses at the edge before that.
 
 The checked-in GitHub Actions workflow is Brevilabs-specific. It names the
 production database, domains, repository environment, and deployment records.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -73,15 +73,16 @@ existing license-outage fallback.
 
 ### The sign-in limiters
 
-Three routes answer without a credential, because the caller has none yet: the
-device-code mint, the approval page's code lookup, and the button that starts a
-handshake. Two Workers rate limiter bindings cover them, declared in
-`wrangler.jsonc`:
+Four request shapes answer without a credential, because the caller has none
+yet: the device-code mint and poll, the approval page's code lookup, and the
+button that starts a handshake. Three Workers rate limiter bindings cover them,
+declared in `wrangler.jsonc`:
 
 ```jsonc
 "ratelimits": [
   { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },
-  { "name": "APPROVAL_LOOKUP_LIMITER", "namespace_id": "1002", "simple": { "limit": 20, "period": 60 } }
+  { "name": "APPROVAL_LOOKUP_LIMITER", "namespace_id": "1002", "simple": { "limit": 20, "period": 60 } },
+  { "name": "DEVICE_POLL_LIMITER", "namespace_id": "1003", "simple": { "limit": 1, "period": 10 } }
 ]
 ```
 
@@ -104,11 +105,17 @@ Sharing one bucket would also mean an ordinary sign-in spent three of it, and a
 person who reloaded the approval page twice would be told their code had
 expired.
 
-**Deleting either block is supported.** A deployment that declares no limiter
-puts no limit on those endpoints, which is the right answer for a private
-deployment nobody else can reach. Failing closed instead would mean a Worker
-that signs nobody in until its operator had read this page. Everything else
-works the same either way.
+`DEVICE_POLL_LIMITER` allows one poll per device code every ten seconds. It is
+keyed by the hash of the secret code, so two machines behind one address do not
+share a bucket and the raw credential never becomes limiter metadata. Keeping
+the interval in the binding makes a pending poll a D1 read rather than a write.
+`DEVICE_POLL_INTERVAL_SECONDS` is advertised to clients and has to match this
+binding's `period`.
+
+**Deleting any block is supported.** A deployment that declares no limiter puts
+no limit on that endpoint, which is the right answer for a private deployment
+nobody else can reach. Without `DEVICE_POLL_LIMITER`, the returned polling
+interval is advisory. Everything else works the same either way.
 
 The limiter is not a D1 counter on purpose. A counter in a row costs a write for
 every attempt including every refused one, so under sustained abuse the limiter

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -71,39 +71,52 @@ two plan values currently allowed to publish. With the Brevilabs license
 variables absent, unknown keys fail closed and seeded keys continue through the
 existing license-outage fallback.
 
-### The device-code limiter
+### The sign-in limiters
 
-`POST /device/code` is unauthenticated, because a terminal asking for a sign-in
-code has no credential yet. It is limited by a Workers rate limiter binding,
-declared in `wrangler.jsonc`:
+Three routes answer without a credential, because the caller has none yet: the
+device-code mint, the approval page's code lookup, and the button that starts a
+handshake. Two Workers rate limiter bindings cover them, declared in
+`wrangler.jsonc`:
 
 ```jsonc
 "ratelimits": [
-  { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } }
+  { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },
+  { "name": "APPROVAL_LOOKUP_LIMITER", "namespace_id": "1002", "simple": { "limit": 20, "period": 60 } }
 ]
 ```
 
-Five codes a minute per client address, which is far above one person signing in
-a machine or two. `period` accepts only `10` or `60`. **`namespace_id` is unique
-across your whole account, not per Worker**, so if you run another Worker with a
-limiter, give this one a number that Worker does not use. `DEVICE_MINT_PERIOD_SECONDS`
+`DEVICE_CODE_LIMITER` gives five codes a minute per client address, far above
+one person signing in a machine or two. `period` accepts only `10` or `60`.
+**`namespace_id` is unique across your whole account, not per Worker**, so if
+you run another Worker with a limiter, give these numbers that Worker does not
+use. `DEVICE_MINT_PERIOD_SECONDS`
 in `src/config.ts` is the `Retry-After` a refusal carries and has to match
 `period`; nothing else in the code reads these numbers, because the binding
 reports a verdict and no counts.
 
-**Deleting the block is supported.** A deployment that declares no limiter puts
-no limit on that endpoint, which is the right answer for a private deployment
-nobody else can reach. Failing closed instead would mean a Worker that signs
-nobody in until its operator had read this page. Everything else works the same
-either way.
+The second limiter, `APPROVAL_LOOKUP_LIMITER`, covers the two approval routes
+that take a user code: the page that looks one up and the button that starts a
+handshake against it. Twenty a minute per address, and a separate
+`namespace_id`, because the two limits protect different things. A mint writes a
+row, so its limit is about the write budget; these read a row and conditionally
+update one, and their limit is defence in depth behind the code's own 43 bits.
+Sharing one bucket would also mean an ordinary sign-in spent three of it, and a
+person who reloaded the approval page twice would be told their code had
+expired.
+
+**Deleting either block is supported.** A deployment that declares no limiter
+puts no limit on those endpoints, which is the right answer for a private
+deployment nobody else can reach. Failing closed instead would mean a Worker
+that signs nobody in until its operator had read this page. Everything else
+works the same either way.
 
 The limiter is not a D1 counter on purpose. A counter in a row costs a write for
 every attempt including every refused one, so under sustained abuse the limiter
 itself would exhaust the account's daily write budget — see
 [cost at scale](cost-at-scale.md).
 
-For a public deployment, add a WAF rate limiting rule on `POST /device/code` as
-a second layer. The binding runs inside the Worker, so a request it refuses has
+For a public deployment, add a WAF rate limiting rule on `POST /device/code` and
+`/approve` as a second layer. The binding runs inside the Worker, so a request it refuses has
 still been billed as a request; a WAF rule refuses at the edge before that.
 
 The checked-in GitHub Actions workflow is Brevilabs-specific. It names the

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -71,6 +71,41 @@ two plan values currently allowed to publish. With the Brevilabs license
 variables absent, unknown keys fail closed and seeded keys continue through the
 existing license-outage fallback.
 
+### The device-code limiter
+
+`POST /device/code` is unauthenticated, because a terminal asking for a sign-in
+code has no credential yet. It is limited by a Workers rate limiter binding,
+declared in `wrangler.jsonc`:
+
+```jsonc
+"ratelimits": [
+  { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } }
+]
+```
+
+Five codes a minute per client address, which is far above one person signing in
+a machine or two. `period` accepts only `10` or `60`. **`namespace_id` is unique
+across your whole account, not per Worker**, so if you run another Worker with a
+limiter, give this one a number that Worker does not use. `DEVICE_MINT_PERIOD_SECONDS`
+in `src/config.ts` is the `Retry-After` a refusal carries and has to match
+`period`; nothing else in the code reads these numbers, because the binding
+reports a verdict and no counts.
+
+**Deleting the block is supported.** A deployment that declares no limiter puts
+no limit on that endpoint, which is the right answer for a private deployment
+nobody else can reach. Failing closed instead would mean a Worker that signs
+nobody in until its operator had read this page. Everything else works the same
+either way.
+
+The limiter is not a D1 counter on purpose. A counter in a row costs a write for
+every attempt including every refused one, so under sustained abuse the limiter
+itself would exhaust the account's daily write budget — see
+[cost at scale](cost-at-scale.md).
+
+For a public deployment, add a WAF rate limiting rule on `POST /device/code` as
+a second layer. The binding runs inside the Worker, so a request it refuses has
+still been billed as a request; a WAF rule refuses at the edge before that.
+
 The checked-in GitHub Actions workflow is Brevilabs-specific. It names the
 production database, domains, repository environment, and deployment records.
 Deploy manually until you have adapted all of those values for your account.

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,28 +45,42 @@ OPENARTIFACTS_LICENSE_KEY=$KEY scripts/smoke.sh http://127.0.0.1:8787
 Alternatively, copy `.dev.vars.example` to `.dev.vars` and point
 `LICENSE_API_URL` / `LICENSE_API_KEY` at the real license server.
 
-## Exercising the approval page
+## Signing in from a terminal
 
-The approval page needs a pending device code to bind, and minting one belongs to
-the device flow in
-[#57](https://github.com/Brevilabs/OpenArtifacts/issues/57), so insert the row by
-hand until that lands. It also needs an OAuth client;
-register a Google or GitHub app whose callback is
+The device flow needs no license server and no seeding: `POST /device/code`
+mints the code, and the url it returns is the whole of the browser half. It does
+need an OAuth client, so register a Google or GitHub app whose callback is
 `http://127.0.0.1:8787/approve/callback/{provider}` and put its pair in
 `.dev.vars`.
 
 ```bash
-CODE=WDJB-MJHT
+BASE=http://127.0.0.1:8787
 
-npx wrangler d1 execute symposium --local --command \
-  "INSERT OR REPLACE INTO device_codes (user_code, expires_at, created_at)
-   VALUES ('$CODE', $((($(date +%s) + 900) * 1000)), $(($(date +%s) * 1000)))"
+MINT=$(curl -sS -X POST "$BASE/device/code" \
+  -H 'content-type: application/json' -d '{"label":"dev laptop"}')
 
-open "http://127.0.0.1:8787/approve?user_code=$CODE"
+DEVICE_CODE=$(printf '%s' "$MINT" | jq -r .device_code)
+open "$(printf '%s' "$MINT" | jq -r .verification_uri_complete)"
+
+# before approving, and again after
+curl -sS -X POST "$BASE/device/token" -H 'content-type: application/json' \
+  -d "{\"device_code\":\"$DEVICE_CODE\"}"
 ```
 
-Signing in leaves the account proven and the code unapproved; pressing the button
-on the page that follows is what approves it. The row shows both steps:
+The token that poll returns publishes like a license key, and it is the only
+time the value exists outside your terminal:
+
+```bash
+TOKEN=oat_…
+curl -sS -X POST "$BASE/api/v1/docs" -H "authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"title":"Local","html":"<!doctype html><html><body><p>hi</p></body></html>"}'
+curl -sS "$BASE/api/v1/tokens" -H "authorization: Bearer $TOKEN"
+```
+
+Signing in leaves the account proven and the code unapproved; pressing the
+button on the page that follows is what approves it, and Deny on the same page
+kills the code instead. The row shows both steps:
 
 ```bash
 npx wrangler d1 execute symposium --local --command \

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -293,10 +293,17 @@ returned and cannot be: only hashes are stored.
   refreshing it exactly would put a database write behind every read, and the
   question it answers is which machine is still using this.
 - Revoked tokens are not listed. **There is no paging and none is needed**: an
-  account may hold at most 100 live tokens, which is also everything this
-  returns, so the list is always complete. Nothing an account holds can be
-  hidden behind a limit, which matters because revoking is the only way to
-  manage a token and a token nobody can see is a token nobody can withdraw.
+  account holds at most 100 live tokens, which is also everything this returns,
+  so the list is always complete. Nothing an account holds can hide behind a
+  limit, which matters because revoking is the only way to manage a token and a
+  token nobody can see is a token nobody can withdraw.
+- **The hundred and first token replaces the least recently used one**, which is
+  revoked as the new one is issued. Never-used goes first, then oldest use. This
+  is a rolling window rather than a wall, so signing in a new machine always
+  works — an account that filled up over years of replaced laptops is never
+  locked out by tokens nobody holds any more. Approving a device proves the
+  account's identity, which is a stronger claim than any token, so it is safe
+  for that approval to displace one.
 
 A license key's account holds no tokens, so it gets an empty list rather than a
 refusal.
@@ -322,10 +329,10 @@ authenticated, and the next one will not.
 already revoked, exactly as for a document. A retry after a timeout therefore
 sees `404`, not `200`; treat it as success.
 
-An account is capped at 100 live tokens. Past that, collecting a new one is
-refused with `429 quota_exceeded` and the sign-in waits until something here is
-revoked. Nobody reaches this by signing in machines; it is the bound that lets
-the list above have no cursor.
+An account holds at most 100 live tokens. Signing in a new machine past that
+revokes the least recently used one rather than failing, so revoking is never
+the only way back in. Nobody reaches this by signing in machines; it is the
+bound that lets the list above have no cursor.
 
 ### `GET /d/{docId}` and `GET /d/{docId}/v{n}` — read
 
@@ -494,11 +501,6 @@ Until then, every answer is a `400` carrying one of four codes:
 Exactly one poll per interval is served, so concurrent polls for one device
 code get `slow_down` too however they are spaced. Poll from one place, on the
 `interval` the mint returned.
-
-One further refusal is not a poll condition and carries `429` rather than `400`:
-`quota_exceeded`, when the account already holds the 100 live tokens it is
-allowed. The device code stays collectable, so revoking a token with another
-one and polling again finishes the sign-in already in flight.
 
 A device code is spent by the poll that collects it, so a replayed one is
 `expired_token` — the same answer an unknown code gets, deliberately, because a

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -438,10 +438,12 @@ Neither endpoint authenticates, which is why neither is under `/api/v1`.
 - `expires_in` and `interval` are seconds. Use the `interval` the response gives
   rather than a number of your own.
 
-`429 quota_exceeded`, with `Retry-After`, when one address asks for too many
-codes. The limit exists because an endpoint that mints approval urls is an
-endpoint somebody would otherwise use to send strangers approval urls. One
-person signing in a machine or two never reaches it.
+`429 quota_exceeded`, with `Retry-After: 60`, when one address asks for more
+than five codes in a minute. The limit exists because an endpoint that mints
+approval urls is an endpoint somebody would otherwise use to send strangers
+approval urls. One person signing in a machine or two never reaches it, and a
+self-hosted deployment may switch it off entirely — see
+[Deploying](deploying.md).
 
 ### `POST /device/token` — collect the token
 
@@ -566,9 +568,9 @@ document ceiling, because the ceiling follows the account and not the
 credential.
 
 One further limit sits outside all of this, on `POST /device/code`: a single
-client address may only ask for so many sign-in codes in a ten-minute window,
-and past that the mint answers `429 quota_exceeded` with `Retry-After`. It is
-not a publishing quota and no authenticated call can reach it.
+client address may ask for five sign-in codes a minute, and past that the mint
+answers `429 quota_exceeded` with `Retry-After`. It is not a publishing quota,
+no authenticated call can reach it, and a self-hosted deployment can remove it.
 
 ## The docId round trip
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -16,6 +16,7 @@ Two surfaces on two domains:
 | API | `/api/v1/*` | required | Publisher-facing. JSON in, JSON out. |
 | Serving | `/d/*` | none | Reader-facing. Public HTML. Never sets a cookie. |
 | Approval | `/approve/*` | none | Human-facing. HTML pages on the API host. Not a client surface. |
+| Device | `/device/*` | none | How a client with no credential gets one. JSON, on the API host. |
 
 The API is served from `api.openartifacts.ai` and documents from `openartifacts.site`.
 The `url` field a push returns therefore points at a different host than the one
@@ -33,7 +34,10 @@ legacy document host redirects it, and the retired API host returns `410`.
 
 ## Authentication
 
-Every `/api/v1/*` request carries a Brevilabs license key:
+Every `/api/v1/*` request carries a credential in one header. There are two
+kinds and the header is the same for both.
+
+### A Brevilabs license key
 
 ```http
 Authorization: Bearer <license key>
@@ -61,6 +65,53 @@ qualifies keeps `GET /api/v1/docs` and `DELETE /api/v1/docs/{docId}`, so they ca
 always see what they have published and take it down. Losing the ability to
 publish must never mean losing the ability to unshare.
 
+### An OpenArtifacts token
+
+```http
+Authorization: Bearer oat_hy3m…
+```
+
+A token is issued to one machine by [the device flow](#signing-in-from-a-terminal),
+and it is the only credential an agent ever holds. It is an opaque string
+beginning `oat_`, and that prefix is the whole of its format: do not parse the
+rest, and do not put it in a url or a log.
+
+Only the token's SHA-256 is stored, and the raw value is returned exactly once —
+in the response to the poll that collected it. There is no endpoint that shows a
+token again. A lost token is replaced by approving a new one, never recovered.
+
+**Documents belong to the account, exactly as they do for a key.** Every token
+on one account sees one list, shares one daily push allowance and one document
+ceiling, and any of them can push a new version of, or unshare, a document
+another one created. Revoking a token changes nothing about which documents the
+account holds.
+
+**The two credentials never mix.** A key resolves to the Brevilabs account that
+holds it and a token to the OpenArtifacts account it was issued to; the two id
+spaces cannot collide, so neither can ever see the other's documents. A Copilot
+subscriber who wants the documents their plugin published presents the same
+license key the plugin does — this API accepts it from a terminal like any other
+caller.
+
+**Publishing works on a new account.** A token's account is entitled to publish
+under the quotas below from its first approval, so nobody has to buy anything
+before the first document lands. Per-plan limits and a `402` refusal are
+[#60](https://github.com/Brevilabs/OpenArtifacts/issues/60) and are not here yet.
+
+**Revocation is immediate.** A revoked token fails on its very next request,
+where a revoked license key keeps working until its cached validation ages out.
+Nothing about a token is cached, because its owner is a row in this deployment's
+own database rather than an answer from another service.
+
+### `OPENARTIFACTS_TOKEN`
+
+A client reads the credential from `OPENARTIFACTS_TOKEN` when that variable is
+set, and from its own configuration otherwise. It exists so a script or a CI job
+can publish where no browser can be opened. The variable is a client convention
+rather than a server behaviour, and it carries whatever goes in the header — a
+token or a license key alike, since nothing downstream of the header cares which
+it was.
+
 Reading a doc requires nothing. Serving responses never set a cookie.
 
 ## The approval page
@@ -77,6 +128,7 @@ GET  /approve?user_code=…          the page that offers the providers
 POST /approve/start/{provider}     redirects to the provider
 GET  /approve/callback/{provider}  where the provider redirects back
 POST /approve/confirm              the press that approves the code
+POST /approve/deny                 the press that refuses it
 ```
 
 Three consequences worth stating, because all three are promises made elsewhere:
@@ -104,11 +156,17 @@ POST   /api/v1/docs           {title?, html}  → 201 {docId, url, version}
 PUT    /api/v1/docs/{docId}   {title?, html}  → 200 {docId, url, version}
 DELETE /api/v1/docs/{docId}                   → 204
 GET    /api/v1/docs?limit&cursor              → 200 {docs[], cursor?}
+GET    /api/v1/tokens                         → 200 {tokens[]}
+DELETE /api/v1/tokens/{tokenId}               → 200 {tokenId, remaining}
+POST   /device/code           {label?}        → 200 {device_code, user_code, …}
+POST   /device/token          {device_code}   → 200 {access_token, …}
 GET    /d/{docId}                             → 200 latest HTML
 GET    /d/{docId}/v{n}                        → 200 immutable HTML
 ```
 
-Any other method or path under `/api/v1` is `404 not_found`.
+Any other method or path under `/api/v1` is `404 not_found`. The two `/device`
+paths are the only ones outside it that answer a client, and they carry no
+credential — see [Signing in from a terminal](#signing-in-from-a-terminal).
 
 ### `POST /api/v1/docs` — publish a new doc
 
@@ -212,6 +270,55 @@ whichever of its keys published them.
 Paging is keyset, not offset: a doc published while you are walking pages appears
 on no page you have already read, and no doc is ever served twice or skipped.
 
+### `GET /api/v1/tokens` — list my tokens
+
+Every live token the calling account holds, newest first. Values are not
+returned and cannot be: only hashes are stored.
+
+```json
+{"tokens": [
+   {"tokenId": "tok_9f2k4mvq7t0xbz3n",
+    "label": "Claude Code on loganmac",
+    "createdAt": 1785000000000,
+    "lastUsedAt": 1785003600000}
+ ]}
+```
+
+- `label` is what the machine called itself when it asked for its device code,
+  and it is `null` when it named nothing. It is text a client supplied: escape
+  it before displaying it.
+- `lastUsedAt` is the last request this token authenticated, to the nearest
+  hour, and `null` for a token that has never been used. Coarse on purpose —
+  refreshing it exactly would put a database write behind every read, and the
+  question it answers is which machine is still using this.
+- Revoked tokens are not listed. There is no paging: a token exists because a
+  person approved a machine, so an account holds a handful, and at most 100 are
+  returned.
+
+A license key's account holds no tokens, so it gets an empty list rather than a
+refusal.
+
+### `DELETE /api/v1/tokens/{tokenId}` — revoke a token
+
+`200`, with a body — unlike a document delete, because what the caller needs to
+know is what it has left.
+
+```json
+{"tokenId": "tok_9f2k4mvq7t0xbz3n", "remaining": 0}
+```
+
+`remaining` is how many live tokens the account still holds. **Revoking the last
+one is allowed**, and `remaining: 0` is how a client knows to say so: nothing on
+that account can publish until somebody approves a new device. The documents are
+untouched and stay exactly where they are.
+
+Revoking the token making the request succeeds — this request has already
+authenticated, and the next one will not.
+
+`404 not_found` if the token does not exist, belongs to another account, or was
+already revoked, exactly as for a document. A retry after a timeout therefore
+sees `404`, not `200`; treat it as success.
+
 ### `GET /d/{docId}` and `GET /d/{docId}/v{n}` — read
 
 Unauthenticated. `GET` and `HEAD` only; anything else is `404`.
@@ -276,6 +383,118 @@ All three are `no-store` and retain the serving header policy above. `HEAD`
 returns the same status and headers as `GET` without a body. Healthy `200` and
 conditional `304` responses are unchanged.
 
+## Signing in from a terminal
+
+<a id="signing-in-from-a-terminal"></a>
+
+A client with no credential gets one here. It asks for a code, prints a url,
+and polls; a person opens that url on any device, signs in, and approves. The
+client's next poll returns a token it stores and uses from then on. Nobody
+reads a secret aloud and nothing is pasted, which is the point: a token pasted
+into an agent's conversation is a token in a transcript.
+
+**RFC 8628 shaped, not RFC 8628 wire compatible.** The two endpoints, the two
+codes, the polling interval and the four poll conditions are the standard's, so
+a client written against it will recognise them. The differences are that
+requests are JSON like the rest of this API rather than form encoded, and that a
+failure carries this API's own `{"error": {"code", "message"}}` envelope with
+the RFC's code name inside it, so a client still has one error shape to parse.
+Field names in the two success bodies are the RFC's, which is why they are
+`snake_case` where the rest of this document is `camelCase`.
+
+Neither endpoint authenticates, which is why neither is under `/api/v1`.
+
+### `POST /device/code` — ask for a code
+
+`Content-Type: application/json`. The body is optional.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `label` | string | no | What this machine and agent are, for the person approving it and for the token afterwards. Control characters are stripped and it is cut at 80 characters. Missing or blank means the page names no machine. |
+
+```json
+{"label": "Claude Code on loganmac"}
+```
+
+```json
+{"device_code": "hy3m…",
+ "user_code": "WDJB-MJHT",
+ "verification_uri": "https://api.openartifacts.ai/approve",
+ "verification_uri_complete": "https://api.openartifacts.ai/approve?user_code=WDJB-MJHT",
+ "expires_in": 900,
+ "interval": 5}
+```
+
+- `device_code` is the secret half and never leaves the client. It is the only
+  thing that can collect the token, so a person who reads the `user_code` off a
+  screen has learned nothing.
+- `user_code` is eight letters from a twenty-consonant alphabet, shown as two
+  groups of four. No digits and no vowels, so nothing in it is confusable when
+  read aloud and no draw can spell a word.
+- `verification_uri_complete` is what a client prints and opens; the bare
+  `verification_uri` is for a person typing it on another device.
+- `expires_in` and `interval` are seconds. Use the `interval` the response gives
+  rather than a number of your own.
+
+`429 quota_exceeded`, with `Retry-After`, when one address asks for too many
+codes. The limit exists because an endpoint that mints approval urls is an
+endpoint somebody would otherwise use to send strangers approval urls. One
+person signing in a machine or two never reaches it.
+
+### `POST /device/token` — collect the token
+
+`Content-Type: application/json`.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `device_code` | string | yes | Exactly as `POST /device/code` returned it. |
+
+Poll no faster than the `interval` you were given, until the code expires.
+
+```json
+{"access_token": "oat_hy3m…",
+ "token_type": "Bearer",
+ "token_id": "tok_9f2k4mvq7t0xbz3n",
+ "label": "Claude Code on loganmac"}
+```
+
+**This response is the only time the token exists outside the client.** Store it
+with owner-only permissions and never print it. `token_id` is its public name,
+which `GET /api/v1/tokens` also reports and `DELETE` takes.
+
+Until then, every answer is a `400` carrying one of four codes:
+
+| `code` | Meaning | What a client does |
+| --- | --- | --- |
+| `authorization_pending` | Nobody has approved it yet. | Wait one interval and poll again. |
+| `slow_down` | You polled faster than the interval. | Wait longer, then poll again. |
+| `expired_token` | The code expired, was already collected, or was never issued. | Start again with a new code. |
+| `access_denied` | Someone pressed Deny on the approval page. | Stop. Do not start again on your own. |
+
+A device code is spent by the poll that collects it, so a replayed one is
+`expired_token` — the same answer an unknown code gets, deliberately, because a
+distinguishable reply would confirm which random strings are real.
+
+### A whole sign-in
+
+```bash
+BASE=https://api.openartifacts.ai
+
+MINT=$(curl -sS -X POST "$BASE/device/code" \
+  -H 'content-type: application/json' \
+  -d '{"label":"Claude Code on loganmac"}')
+
+DEVICE_CODE=$(printf '%s' "$MINT" | jq -r .device_code)
+printf '%s' "$MINT" | jq -r .verification_uri_complete   # open this, and approve
+
+# poll every `interval` seconds until it answers with a token
+curl -sS -X POST "$BASE/device/token" \
+  -H 'content-type: application/json' \
+  -d "{\"device_code\":\"$DEVICE_CODE\"}"
+# → {"error":{"code":"authorization_pending", …}}   before the approval
+# → {"access_token":"oat_…","token_type":"Bearer", …}  after it
+```
+
 ## Errors
 
 Every publisher-facing API failure, and every retired-host response, is JSON:
@@ -298,8 +517,21 @@ exposes this API payload to a reader.
 | `too_large` | 413 | `html` over 10MB. |
 | `quota_exceeded` | 429 | Daily push or doc-count ceiling reached. |
 | `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |
+| `authorization_pending` | 400 | `POST /device/token`: nobody has approved the code yet. |
+| `slow_down` | 400 | `POST /device/token`: polled faster than the `interval`. |
+| `expired_token` | 400 | `POST /device/token`: the code expired, was collected, or was never issued. |
+| `access_denied` | 400 | `POST /device/token`: someone pressed Deny on the approval page. |
 
-Two of these are worth handling deliberately in a client:
+The last four appear on `POST /device/token` and nowhere else. They are RFC 8628
+§3.5's names, carried in this envelope so a client parses one error shape.
+
+Three of these are worth handling deliberately in a client:
+
+- **`unauthorized` covers a token too.** A token this deployment never issued,
+  and one that has been revoked, are both refused with `401 unauthorized` and
+  `WWW-Authenticate: Bearer`, exactly like a bad key. Only the human-readable
+  `message` distinguishes them. A client holding a token that starts failing
+  this way should sign in again rather than retry.
 
 - **`internal` is not `unauthorized`.** A license-server outage answers `500
   internal`, never `401`, precisely so the client does not prompt for a new key
@@ -325,6 +557,16 @@ daily allowance and one 500-document ceiling rather than getting two.
 Both `POST` and `PUT` spend one push. A rejected push spends nothing: a `413`,
 a `400`, or a `PUT` at a doc you do not own leaves the day's allowance intact.
 Deleting a doc frees a slot against the 500.
+
+An account that authenticates with tokens is counted the same way and against
+the same numbers: every token it has issued shares one daily allowance and one
+document ceiling, because the ceiling follows the account and not the
+credential.
+
+One further limit sits outside all of this, on `POST /device/code`: a single
+client address may only ask for so many sign-in codes in a ten-minute window,
+and past that the mint answers `429 quota_exceeded` with `Retry-After`. It is
+not a publishing quota and no authenticated call can reach it.
 
 ## The docId round trip
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -444,7 +444,7 @@ browser.
  "verification_uri": "https://api.openartifacts.ai/approve",
  "verification_uri_complete": "https://api.openartifacts.ai/approve?user_code=WDJBM-JHTQR",
  "expires_in": 900,
- "interval": 5}
+ "interval": 10}
 ```
 
 - `device_code` is the secret half and never leaves the client. It is the only
@@ -499,9 +499,11 @@ Until then, every answer is a `400` carrying one of four codes:
 | `expired_token` | The code expired, was already collected, or was never issued. | Start again with a new code. |
 | `access_denied` | Someone pressed Deny on the approval page. | Stop. Do not start again on your own. |
 
-Exactly one poll per interval is served, so concurrent polls for one device
-code get `slow_down` too however they are spaced. Poll from one place, on the
-`interval` the mint returned.
+The hosted deployment rate-limits each device code to one poll per interval, so
+concurrent polls normally get `slow_down`. The limiter is deliberately not part
+of token-issue correctness: collection is transactional, so even permissive
+distributed counters or a self-hosted deployment without the limiter cannot
+issue twice. Poll from one place, on the `interval` the mint returned.
 
 A device code is spent by the poll that collects it, so a replayed one is
 `expired_token` — the same answer an unknown code gets, deliberately, because a
@@ -595,10 +597,12 @@ the same numbers: every token it has issued shares one daily allowance and one
 document ceiling, because the ceiling follows the account and not the
 credential.
 
-One further limit sits outside all of this, on `POST /device/code`: a single
+Two further limits sit outside all of this. On `POST /device/code`, a single
 client address may ask for five sign-in codes a minute, and past that the mint
-answers `429 quota_exceeded` with `Retry-After`. It is not a publishing quota,
-no authenticated call can reach it, and a self-hosted deployment can remove it.
+answers `429 quota_exceeded` with `Retry-After`. On `POST /device/token`, one
+poll per device code is served every ten seconds and faster requests answer
+`slow_down`. Neither is a publishing quota, no authenticated call can reach
+them, and a self-hosted deployment can remove either limiter.
 
 ## The docId round trip
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -440,9 +440,9 @@ browser.
 
 ```json
 {"device_code": "hy3m…",
- "user_code": "WDJB-MJHT",
+ "user_code": "WDJBM-JHTQR",
  "verification_uri": "https://api.openartifacts.ai/approve",
- "verification_uri_complete": "https://api.openartifacts.ai/approve?user_code=WDJB-MJHT",
+ "verification_uri_complete": "https://api.openartifacts.ai/approve?user_code=WDJBM-JHTQR",
  "expires_in": 900,
  "interval": 5}
 ```
@@ -450,9 +450,10 @@ browser.
 - `device_code` is the secret half and never leaves the client. It is the only
   thing that can collect the token, so a person who reads the `user_code` off a
   screen has learned nothing.
-- `user_code` is eight letters from a twenty-consonant alphabet, shown as two
-  groups of four. No digits and no vowels, so nothing in it is confusable when
-  read aloud and no draw can spell a word.
+- `user_code` is ten letters from a twenty-consonant alphabet, shown as two
+  groups of five — about 43 bits. No digits and no vowels, so nothing in it is
+  confusable when read aloud and no draw can spell a word. Case and surrounding
+  space do not matter: the approval page folds both.
 - `verification_uri_complete` is what a client prints and opens. The bare
   `verification_uri` is short enough to read off a terminal and type into a
   phone, and it shows a field for entering the `user_code` by hand. Print both:

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -432,7 +432,7 @@ browser.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `label` | string | no | What this machine and agent are, for the person approving it and for the token afterwards. Control characters are stripped and it is cut at 80 characters. Missing or blank means the page names no machine. |
+| `label` | string | no | What this machine and agent are, for the person approving it and for the token afterwards. Terminal and bidirectional controls are stripped, ordinary RTL text is isolated when rendered, and the result is cut at 80 characters. Missing or blank means the page names no machine. |
 
 ```json
 {"label": "Claude Code on loganmac"}

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -292,9 +292,11 @@ returned and cannot be: only hashes are stored.
   hour, and `null` for a token that has never been used. Coarse on purpose —
   refreshing it exactly would put a database write behind every read, and the
   question it answers is which machine is still using this.
-- Revoked tokens are not listed. There is no paging: a token exists because a
-  person approved a machine, so an account holds a handful, and at most 100 are
-  returned.
+- Revoked tokens are not listed. **There is no paging and none is needed**: an
+  account may hold at most 100 live tokens, which is also everything this
+  returns, so the list is always complete. Nothing an account holds can be
+  hidden behind a limit, which matters because revoking is the only way to
+  manage a token and a token nobody can see is a token nobody can withdraw.
 
 A license key's account holds no tokens, so it gets an empty list rather than a
 refusal.
@@ -319,6 +321,11 @@ authenticated, and the next one will not.
 `404 not_found` if the token does not exist, belongs to another account, or was
 already revoked, exactly as for a document. A retry after a timeout therefore
 sees `404`, not `200`; treat it as success.
+
+An account is capped at 100 live tokens. Past that, collecting a new one is
+refused with `429 quota_exceeded` and the sign-in waits until something here is
+revoked. Nobody reaches this by signing in machines; it is the bound that lets
+the list above have no cursor.
 
 ### `GET /d/{docId}` and `GET /d/{docId}/v{n}` — read
 
@@ -403,6 +410,15 @@ Field names in the two success bodies are the RFC's, which is why they are
 
 Neither endpoint authenticates, which is why neither is under `/api/v1`.
 
+**Both require `Content-Type: application/json`**, including a mint with no
+body, and anything else is `400 bad_request` before the request is looked at
+further. That is a security check rather than strictness about types: these are
+unauthenticated `POST`s, so a page a person happens to visit could otherwise aim
+a form-encoded request at them from that person's address. `application/json` is
+not a type a form can send, so a browser has to preflight it, and this host
+answers no CORS headers, so the preflight fails and the request never leaves the
+browser.
+
 ### `POST /device/code` — ask for a code
 
 `Content-Type: application/json`. The body is optional.
@@ -474,6 +490,11 @@ Until then, every answer is a `400` carrying one of four codes:
 | `slow_down` | You polled faster than the interval. | Wait longer, then poll again. |
 | `expired_token` | The code expired, was already collected, or was never issued. | Start again with a new code. |
 | `access_denied` | Someone pressed Deny on the approval page. | Stop. Do not start again on your own. |
+
+One further refusal is not a poll condition and carries `429` rather than `400`:
+`quota_exceeded`, when the account already holds the 100 live tokens it is
+allowed. The device code stays collectable, so revoking a token with another
+one and polling again finishes the sign-in already in flight.
 
 A device code is spent by the poll that collects it, so a replayed one is
 `expired_token` — the same answer an unknown code gets, deliberately, because a

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -124,6 +124,7 @@ paths are not part of the contract a client is written against. It is documented
 here only so nothing mistakes it for an API route.
 
 ```http
+GET  /approve                      the page that asks for a code
 GET  /approve?user_code=…          the page that offers the providers
 POST /approve/start/{provider}     redirects to the provider
 GET  /approve/callback/{provider}  where the provider redirects back
@@ -429,8 +430,11 @@ Neither endpoint authenticates, which is why neither is under `/api/v1`.
 - `user_code` is eight letters from a twenty-consonant alphabet, shown as two
   groups of four. No digits and no vowels, so nothing in it is confusable when
   read aloud and no draw can spell a word.
-- `verification_uri_complete` is what a client prints and opens; the bare
-  `verification_uri` is for a person typing it on another device.
+- `verification_uri_complete` is what a client prints and opens. The bare
+  `verification_uri` is short enough to read off a terminal and type into a
+  phone, and it shows a field for entering the `user_code` by hand. Print both:
+  the complete one is the fast path and the bare one is the one that works when
+  the terminal cannot be copied from.
 - `expires_in` and `interval` are seconds. Use the `interval` the response gives
   rather than a number of your own.
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -385,8 +385,6 @@ conditional `304` responses are unchanged.
 
 ## Signing in from a terminal
 
-<a id="signing-in-from-a-terminal"></a>
-
 A client with no credential gets one here. It asks for a code, prints a url,
 and polls; a person opens that url on any device, signs in, and approves. The
 client's next poll returns a token it stores and uses from then on. Nobody

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -491,6 +491,10 @@ Until then, every answer is a `400` carrying one of four codes:
 | `expired_token` | The code expired, was already collected, or was never issued. | Start again with a new code. |
 | `access_denied` | Someone pressed Deny on the approval page. | Stop. Do not start again on your own. |
 
+Exactly one poll per interval is served, so concurrent polls for one device
+code get `slow_down` too however they are spaced. Poll from one place, on the
+`interval` the mint returned.
+
 One further refusal is not a poll condition and carries `429` rather than `400`:
 `quota_exceeded`, when the account already holds the 100 live tokens it is
 allowed. The device code stays collectable, so revoking a token with another

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -500,10 +500,12 @@ Until then, every answer is a `400` carrying one of four codes:
 | `access_denied` | Someone pressed Deny on the approval page. | Stop. Do not start again on your own. |
 
 The hosted deployment rate-limits each device code to one poll per interval, so
-concurrent polls normally get `slow_down`. The limiter is deliberately not part
-of token-issue correctness: collection is transactional, so even permissive
-distributed counters or a self-hosted deployment without the limiter cannot
-issue twice. Poll from one place, on the `interval` the mint returned.
+concurrent polls normally get `slow_down`. It also caps aggregate polls from one
+client address, so inventing fresh random codes cannot create unbounded database
+misses. The limiters are deliberately not part of token-issue correctness:
+collection is transactional, so even permissive distributed counters or a
+self-hosted deployment without them cannot issue twice. Poll from one place, on
+the `interval` the mint returned.
 
 A device code is spent by the poll that collects it, so a replayed one is
 `expired_token` — the same answer an unknown code gets, deliberately, because a
@@ -600,9 +602,10 @@ credential.
 Two further limits sit outside all of this. On `POST /device/code`, a single
 client address may ask for five sign-in codes a minute, and past that the mint
 answers `429 quota_exceeded` with `Retry-After`. On `POST /device/token`, one
-poll per device code is served every ten seconds and faster requests answer
+poll per device code is served every ten seconds, with a separate ceiling of
+twenty polls per client address in that window; faster requests answer
 `slow_down`. Neither is a publishing quota, no authenticated call can reach
-them, and a self-hosted deployment can remove either limiter.
+them, and a self-hosted deployment can remove the corresponding bindings.
 
 ## The docId round trip
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -18,7 +18,13 @@ never mixed:
 | Credential | Owner id | Where it comes from |
 | --- | --- | --- |
 | A Brevilabs license key | an app-sites `User.id` (a uuid) | `license.validateLicenseKey` returns it as `accountId` |
-| An OpenArtifacts account | `oa_` and 26 base32 characters | `newAccountId`, minted by the first approval |
+| An OpenArtifacts token | `oa_` and 26 base32 characters | the `accounts` row the token was issued to |
+
+The second is the one an agent holds. `resolvePublisher` tells the two apart by
+the token's `oat_` prefix and never falls back from one to the other, which is a
+security property rather than an optimisation: without it a token would be sent
+to the license server to be identified, handing this deployment's own secret to
+another service on every request.
 
 An account here holds an id, one verified email address, and the time it was
 created. That is the whole `accounts` table. One further thing about a person is
@@ -60,7 +66,13 @@ is one approval page.
    is recorded against the code, a fresh confirm token is minted, and the page
    asks whether to approve it.
 6. They press Approve, which `POST`s that confirm token back and is the only
-   thing that marks the code approved.
+   thing that marks the code approved. Deny is the same press with the opposite
+   effect, and it exists so that someone who was sent a link can end the code
+   rather than leaving it live until it expires.
+7. The CLI's next poll collects a token, which consumes the device code. The
+   token is minted *there* rather than when Approve is pressed, so a raw token
+   is never written to a row and a terminal that never comes back leaves no
+   credential behind.
 
 The first approval an address makes is the registration. Nothing about the
 browser is remembered at any point, because the token the CLI holds is the
@@ -133,11 +145,23 @@ that verifier, so exactly one of them wins and only the winner is given a
 confirm token. The other is told to start again.
 
 The device flow either side of that page — minting the code, polling it, and
-issuing the token an approval earns — is
-[#57](https://github.com/Brevilabs/OpenArtifacts/issues/57). This repo owns the
-`accounts` row and the one write that binds a code to it.
+issuing the token an approval earns — is `src/device.ts`, and
+[`http-api.md`](http-api.md) is its contract.
 
 ## Three properties that are load-bearing
+
+**A token is a credential, never an identifier.** It is the mirror of the rule
+below, and the two together are why one column can hold both kinds of owner. A
+token is stored only as a SHA-256, is returned exactly once, and resolves to an
+account id that is safe to pass around precisely because holding it grants
+nothing. Nothing ever goes the other way: no endpoint accepts a token id, an
+account id or an email as proof of anything.
+
+Revocation is the visible difference between the two credentials. A token's
+owner is a row in this database, so revoking one takes effect on the next
+request; a license key's owner comes from another service and is cached for an
+hour, so revoking a key takes up to that long. Neither behaviour is
+configurable, and the reason for each is in `src/auth.ts`.
 
 **An owner id is an identifier, never a credential.** It is safe to store, log
 and pass between services only because holding one grants nothing: the owner is
@@ -217,6 +241,10 @@ and that is only acceptable while there is nothing on it for them to steal.
   or two machines' tokens on one account, share one list, one daily push
   allowance and one document ceiling. Isolation is per account, and
   [`http-api.md`](http-api.md) says so.
+- **It does not scope a token to anything.** A token can do everything its
+  account can, which is what Phase 4 of [`private-sharing.md`](private-sharing.md)
+  eventually wants narrowed to a single document. Suggested follow-up: `Scope an
+  agent token to one document`.
 - **It does not survive the account being deleted.** Nothing reacts to a `User`
   row disappearing upstream, and nothing deletes an `accounts` row here. The
   documents would simply stop being reachable by anyone. Worth solving before

--- a/migrations/0004_device_flow.sql
+++ b/migrations/0004_device_flow.sql
@@ -1,0 +1,112 @@
+-- The device flow, and the tokens an approval earns.
+--
+-- `0003_accounts.sql` left `device_codes` deliberately minimal: it held only
+-- what the approval page reads and writes, and said the device flow would
+-- extend this table rather than create a second one. This is that extension.
+--
+-- Two secrets are involved and they are not interchangeable. The `user_code`
+-- is short, spoken aloud, and typed into a phone; it identifies which approval
+-- page belongs to which terminal. The `device_code` is long, never displayed,
+-- and is what the terminal polls with — it is the only thing that can collect
+-- the token, so knowing a user code buys nothing.
+
+-- SHA-256 of the device code the terminal polls with. The raw value exists in
+-- the mint response and in the terminal's memory, and nowhere else — never in a
+-- row and never in a log, exactly like a license key.
+--
+-- Nullable because `ALTER TABLE ... ADD COLUMN` cannot be NOT NULL without a
+-- default, and because a row can predate a mint: the local development recipe
+-- in docs/development.md inserts a code by hand to exercise the approval page.
+ALTER TABLE device_codes ADD COLUMN device_code_hash TEXT;
+
+-- What the terminal said it was when it asked for the code, so the approval
+-- page can name the thing being approved and the token can carry that name
+-- afterwards. Client-supplied text, trimmed and capped by `readDeviceLabel`,
+-- escaped where it is rendered. Null when the client sent none.
+ALTER TABLE device_codes ADD COLUMN label TEXT;
+
+-- Epoch ms of a refusal on the approval page, and null until one is given.
+--
+-- Separate from simply letting the code expire, because the two are different
+-- news for the person at the terminal: a refusal is final and immediate, an
+-- expiry is "nobody got to it in time". It is also the only way to kill a code
+-- that someone else started — the RFC 8628 §5.4 phishing case, where a victim
+-- lands on a confirmation for a terminal that is not theirs.
+ALTER TABLE device_codes ADD COLUMN denied_at INTEGER;
+
+-- Epoch ms of the terminal's last poll, which is what `slow_down` is measured
+-- against. RFC 8628 §3.5 lets the server tell a client polling faster than the
+-- interval it was given to back off, and that needs the previous poll's time.
+ALTER TABLE device_codes ADD COLUMN last_polled_at INTEGER;
+
+-- The poll arrives knowing only the device code, so its hash has to name one
+-- row exactly. Partial, so hand-inserted rows and rows from before this
+-- migration do not collide on null.
+CREATE UNIQUE INDEX device_codes_by_device_code
+  ON device_codes (device_code_hash)
+  WHERE device_code_hash IS NOT NULL;
+
+-- The sweep on the mint path deletes by expiry, and `user_code` is the primary
+-- key: without this index that delete is a full scan, and without the delete a
+-- user code could never be reused.
+CREATE INDEX device_codes_by_expiry ON device_codes (expires_at);
+
+-- The credential an agent holds after an approval.
+--
+-- It is the *only* thing an agent ever presents, which is what keeps a secret
+-- out of the agent's own transcript: nobody types it, it is written to the
+-- user's config directory by the CLI and read back from there.
+--
+-- Only the hash is stored. The raw token is returned exactly once, in the
+-- response to the poll that collected it, and there is no path that can show it
+-- again — a lost token is replaced by approving again, never recovered.
+CREATE TABLE tokens (
+  -- The public name of the token: what `GET /api/v1/tokens` lists and what
+  -- revoke takes. Deliberately not derived from the secret, so listing tokens
+  -- reveals nothing that helps forge one.
+  id           TEXT    PRIMARY KEY,
+  token_hash   TEXT    NOT NULL UNIQUE,
+  -- The account the token publishes as. Holds an `oa_`-prefixed id from
+  -- `newAccountId`; an app-sites uuid can never appear here, because a license
+  -- key is a different credential with a different path through `src/auth.ts`.
+  --
+  -- No foreign key onto `accounts`, for the reason `identities` has none: D1
+  -- leaves `PRAGMA foreign_keys` off, so it would be documentation that does
+  -- not run, and the only writer already holds the account row.
+  account_id   TEXT    NOT NULL,
+  -- Copied from the device code at issue time, so the label survives the row
+  -- that carried it.
+  label        TEXT,
+  created_at   INTEGER NOT NULL,
+  -- Epoch ms, refreshed at most once an hour rather than on every request —
+  -- see `touchTokenUse`. Null until the token's first use.
+  last_used_at INTEGER,
+  -- Epoch ms of revocation, and null while the token is live. The row is kept
+  -- rather than deleted so its hash stays taken: a revoked token must go on
+  -- failing, and a deleted row would leave nothing to fail against.
+  revoked_at   INTEGER
+);
+
+-- Listing a token's account, newest first, is the only query this table serves
+-- besides the hash lookup the unique constraint already covers.
+CREATE INDEX tokens_by_account
+  ON tokens (account_id, created_at DESC)
+  WHERE revoked_at IS NULL;
+
+-- Fixed-window counter for the device-code mint endpoint.
+--
+-- Minting is unauthenticated by necessity — the whole point is that the caller
+-- has no credential yet — so without a limit anyone could mint codes in bulk
+-- and use the verification urls they produce to spam people with approval
+-- pages that look like ours because they are ours. The counter is per client
+-- address per window, and the address is stored hashed: it is a bucket to
+-- count against, not a record of who visited.
+CREATE TABLE device_code_requests (
+  -- SHA-256 of the client address, or of a fixed placeholder where the platform
+  -- reports none.
+  client       TEXT    NOT NULL,
+  -- Epoch ms of the start of the window this count belongs to.
+  window_start INTEGER NOT NULL,
+  requests     INTEGER NOT NULL,
+  PRIMARY KEY (client, window_start)
+);

--- a/migrations/0004_device_flow.sql
+++ b/migrations/0004_device_flow.sql
@@ -34,11 +34,6 @@ ALTER TABLE device_codes ADD COLUMN label TEXT;
 -- lands on a confirmation for a terminal that is not theirs.
 ALTER TABLE device_codes ADD COLUMN denied_at INTEGER;
 
--- Epoch ms of the terminal's last poll, which is what `slow_down` is measured
--- against. RFC 8628 §3.5 lets the server tell a client polling faster than the
--- interval it was given to back off, and that needs the previous poll's time.
-ALTER TABLE device_codes ADD COLUMN last_polled_at INTEGER;
-
 -- The poll arrives knowing only the device code, so its hash has to name one
 -- row exactly. Partial, so hand-inserted rows and rows from before this
 -- migration do not collide on null.
@@ -79,16 +74,13 @@ CREATE TABLE tokens (
   label        TEXT,
   created_at   INTEGER NOT NULL,
   -- Epoch ms, refreshed at most once an hour rather than on every request —
-  -- see `touchTokenUse`. Null until the token's first use.
-  last_used_at INTEGER,
-  -- Epoch ms of revocation, and null while the token is live. The row is kept
-  -- rather than deleted so its hash stays taken: a revoked token must go on
-  -- failing, and a deleted row would leave nothing to fail against.
-  revoked_at   INTEGER
+  -- see `touchTokenUse`. Null until the token's first use. Revocation deletes
+  -- the row: a random value cannot realistically be minted twice, and keeping
+  -- tombstones would let this table grow forever.
+  last_used_at INTEGER
 );
 
 -- Listing a token's account, newest first, is the only query this table serves
 -- besides the hash lookup the unique constraint already covers.
 CREATE INDEX tokens_by_account
-  ON tokens (account_id, created_at DESC)
-  WHERE revoked_at IS NULL;
+  ON tokens (account_id, created_at DESC);

--- a/migrations/0004_device_flow.sql
+++ b/migrations/0004_device_flow.sql
@@ -92,21 +92,3 @@ CREATE TABLE tokens (
 CREATE INDEX tokens_by_account
   ON tokens (account_id, created_at DESC)
   WHERE revoked_at IS NULL;
-
--- Fixed-window counter for the device-code mint endpoint.
---
--- Minting is unauthenticated by necessity — the whole point is that the caller
--- has no credential yet — so without a limit anyone could mint codes in bulk
--- and use the verification urls they produce to spam people with approval
--- pages that look like ours because they are ours. The counter is per client
--- address per window, and the address is stored hashed: it is a bucket to
--- count against, not a record of who visited.
-CREATE TABLE device_code_requests (
-  -- SHA-256 of the client address, or of a fixed placeholder where the platform
-  -- reports none.
-  client       TEXT    NOT NULL,
-  -- Epoch ms of the start of the window this count belongs to.
-  window_start INTEGER NOT NULL,
-  requests     INTEGER NOT NULL,
-  PRIMARY KEY (client, window_start)
-);

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -93,7 +93,7 @@ export async function revokeToken(
   // An id that cannot exist is answered without touching D1.
   if (!isTokenId(tokenId)) return tokenNotFound(tokenId);
 
-  if (!(await revokeAccountToken(env.DB, tokenId, publisher.owner, Date.now()))) {
+  if (!(await revokeAccountToken(env.DB, tokenId, publisher.owner))) {
     return tokenNotFound(tokenId);
   }
 

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -18,7 +18,7 @@
  */
 import type { Publisher } from "../auth.js";
 import type { Env } from "../config.js";
-import { MAX_TOKENS_LISTED } from "../config.js";
+import { MAX_TOKENS_PER_ACCOUNT } from "../config.js";
 import { countLiveTokens, listAccountTokens, revokeAccountToken } from "../db.js";
 import { errorResponse } from "../errors.js";
 import { isTokenId } from "../ids.js";
@@ -54,9 +54,15 @@ interface RevokedToken {
   remaining: number;
 }
 
-/** `GET /api/v1/tokens` — the live tokens this account has issued, newest first. */
+/**
+ * `GET /api/v1/tokens` — the live tokens this account has issued, newest first.
+ *
+ * Complete, with no cursor, because issuing is capped at the same number this
+ * reads. The limit is a bound on the query rather than a page: an account
+ * cannot hold more than it returns.
+ */
 export async function listTokens(env: Env, publisher: Publisher): Promise<Response> {
-  const rows = await listAccountTokens(env.DB, publisher.owner, MAX_TOKENS_LISTED);
+  const rows = await listAccountTokens(env.DB, publisher.owner, MAX_TOKENS_PER_ACCOUNT);
 
   const body: TokenListResponse = {
     tokens: rows.map((row) => ({

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -1,0 +1,112 @@
+/**
+ * Tokens: `GET /api/v1/tokens` lists the credentials an account has issued to
+ * its machines, `DELETE /api/v1/tokens/{tokenId}` withdraws one.
+ *
+ * These two calls are the entire account-management surface, because there is
+ * no dashboard and no session to hang one on. Someone who suspects a laptop is
+ * gone asks their agent to list their tokens, reads the labels its machines
+ * chose for themselves, and revokes the one that should not exist any more.
+ *
+ * **A value never appears here.** The list reports ids, labels and times; only
+ * hashes are stored, so there is nothing else it could report even if it wanted
+ * to. A token that has been lost is replaced by approving again.
+ *
+ * Both work with any live token on the account, and with a license key too —
+ * ownership is per account, not per credential, exactly as it is for documents.
+ * A license key's account can hold no tokens, so it sees an empty list, which
+ * is the honest answer rather than a special case.
+ */
+import type { Publisher } from "../auth.js";
+import type { Env } from "../config.js";
+import { MAX_TOKENS_LISTED } from "../config.js";
+import { countLiveTokens, listAccountTokens, revokeAccountToken } from "../db.js";
+import { errorResponse } from "../errors.js";
+import { isTokenId } from "../ids.js";
+
+/** One token as the list reports it. Times are epoch ms, like everywhere here. */
+interface ListedToken {
+  tokenId: string;
+  /** What the machine called itself when it asked for the code, or null. */
+  label: string | null;
+  createdAt: number;
+  /**
+   * Last request this token authenticated, to an hour's resolution, and null
+   * for a token that has never been used. Coarse on purpose: refreshing it on
+   * every request would put a write behind every read, and the question it
+   * answers — which of my machines is still using this — does not need minutes.
+   */
+  lastUsedAt: number | null;
+}
+
+interface TokenListResponse {
+  tokens: ListedToken[];
+}
+
+/** What a revoke tells the caller, which is mostly about what is left. */
+interface RevokedToken {
+  tokenId: string;
+  /**
+   * Live tokens the account still holds. Zero is allowed and is the point of
+   * reporting it: revoking your last token is a legitimate thing to do, and the
+   * client should be able to say that the next command will need a fresh
+   * browser approval rather than discovering it as a `401`.
+   */
+  remaining: number;
+}
+
+/** `GET /api/v1/tokens` — the live tokens this account has issued, newest first. */
+export async function listTokens(env: Env, publisher: Publisher): Promise<Response> {
+  const rows = await listAccountTokens(env.DB, publisher.owner, MAX_TOKENS_LISTED);
+
+  const body: TokenListResponse = {
+    tokens: rows.map((row) => ({
+      tokenId: row.id,
+      label: row.label,
+      createdAt: row.created_at,
+      lastUsedAt: row.last_used_at,
+    })),
+  };
+  return Response.json(body);
+}
+
+/**
+ * `DELETE /api/v1/tokens/{tokenId}` — withdraw one token.
+ *
+ * A body rather than the `204` a document delete gives, because the caller has
+ * to know what it has left: the same call can leave an account with three
+ * working machines or with none, and only one of those needs the person told.
+ *
+ * Revoking the token making the request is allowed and succeeds — this request
+ * has already authenticated, and the next one will not.
+ */
+export async function revokeToken(
+  env: Env,
+  publisher: Publisher,
+  tokenId: string,
+): Promise<Response> {
+  // An id that cannot exist is answered without touching D1.
+  if (!isTokenId(tokenId)) return tokenNotFound(tokenId);
+
+  if (!(await revokeAccountToken(env.DB, tokenId, publisher.owner, Date.now()))) {
+    return tokenNotFound(tokenId);
+  }
+
+  const body: RevokedToken = {
+    tokenId,
+    remaining: await countLiveTokens(env.DB, publisher.owner),
+  };
+  return Response.json(body);
+}
+
+/**
+ * The one answer for a token that does not exist, is not the caller's, or was
+ * already revoked.
+ *
+ * The same rule the documents follow, for the same reason: a `403` on another
+ * account's token would confirm that the id is real, and an id that can be
+ * confirmed is an id worth probing. Identical wording across all three causes
+ * is the property, so this exists once rather than at each call site.
+ */
+function tokenNotFound(tokenId: string): Response {
+  return errorResponse("not_found", `No token with id ${tokenId}.`);
+}

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -40,6 +40,7 @@ import {
   startDeviceHandshake,
 } from "../db.js";
 import { newAccountId, newHandshakeToken } from "../ids.js";
+import { withinClientLimit } from "../limits.js";
 import { readBodyWithin } from "../quota.js";
 import { ABOUT_LINK, brandPageHtml, escapeHtml, type BrandPage } from "../page.js";
 import {
@@ -101,6 +102,11 @@ export interface ApprovalDeps {
   now?: () => number;
   /** Injected by tests, since arctic's handshake reaches the network. */
   oauth?: OAuthClient;
+  /**
+   * Injected by tests that need a limiter a deployment has not declared, or a
+   * verdict they choose. Production reads `env.APPROVAL_LOOKUP_LIMITER`.
+   */
+  limiter?: RateLimit;
 }
 
 /**
@@ -150,7 +156,7 @@ export async function handleApproval(
 
   try {
     if (section === undefined && request.method === "GET") {
-      return await chooser(url, env, deps);
+      return await chooser(request, url, env, deps);
     }
     if (section === "confirm" && provider === undefined && request.method === "POST") {
       return await confirm(request, env, deps);
@@ -191,7 +197,12 @@ export async function handleApproval(
  * with the code on the url. The two `POST`s either side of it are the ones that
  * change what a code is worth, and they stay exactly as they are.
  */
-async function chooser(url: URL, env: Env, deps: ApprovalDeps): Promise<Response> {
+async function chooser(
+  request: Request,
+  url: URL,
+  env: Env,
+  deps: ApprovalDeps,
+): Promise<Response> {
   if (!approvalIsConfigured(env)) return page(NOT_CONFIGURED, 503);
 
   const submitted = url.searchParams.get(USER_CODE_PARAM);
@@ -199,6 +210,14 @@ async function chooser(url: URL, env: Env, deps: ApprovalDeps): Promise<Response
 
   const userCode = normalizeUserCode(submitted);
   if (userCode === null) return codeEntry(400, "That does not look like a code.");
+
+  // Counted before the row is read, so a client working through the code space
+  // is stopped by the limit rather than by how many rows it can afford to
+  // read. `CODE_GONE` on refusal, because a throttle and a miss have to look
+  // the same: telling them apart would turn the limit into an oracle for which
+  // codes are real (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928334751).
+  const limiter = deps.limiter ?? env.APPROVAL_LOOKUP_LIMITER;
+  if (!(await withinClientLimit(limiter, request))) return page(CODE_GONE, 404);
 
   const now = (deps.now ?? Date.now)();
   // Checked before the providers are offered rather than after the handshake,
@@ -245,6 +264,11 @@ async function begin(
 
   const userCode = normalizeUserCode(submitted.get(USER_CODE_PARAM));
   if (userCode === null) return codeEntry(400, "That does not look like a code.");
+
+  // Counted with the chooser's lookups and for the same reason: this route
+  // also says whether a code is live, and it writes when it is.
+  const limiter = deps.limiter ?? env.APPROVAL_LOOKUP_LIMITER;
+  if (!(await withinClientLimit(limiter, request))) return page(CODE_GONE, 404);
 
   const now = (deps.now ?? Date.now)();
   const state = newHandshakeToken();
@@ -509,7 +533,7 @@ function codeEntry(status: number, note?: string): Response {
 function codeForm(): string {
   return (
     `<form method="get" action="${APPROVAL_PREFIX}">` +
-    `<input type="text" name="${USER_CODE_PARAM}" placeholder="WDJB-MJHT" aria-label="Device code"` +
+    `<input type="text" name="${USER_CODE_PARAM}" placeholder="WDJBM-JHTQR" aria-label="Device code"` +
     ` autocomplete="off" autocapitalize="characters" autocorrect="off" spellcheck="false"` +
     ` autofocus required>` +
     `<button type="submit">Continue</button></form>`

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -121,6 +121,7 @@ export function normalizeUserCode(raw: string | null): string | null {
  * The four routes, and the one method each answers to:
  *
  * ```
+ * GET  /approve                      the page that asks for a code
  * GET  /approve?user_code=…          the page that offers the providers
  * POST /approve/start/{provider}     redirects to the provider
  * GET  /approve/callback/{provider}  where the provider redirects back
@@ -175,12 +176,29 @@ export async function handleApproval(
   }
 }
 
-/** The page that offers the providers, once the code is known to be waiting. */
+/**
+ * The page that offers the providers, once the code is known to be waiting —
+ * and, with no code on the url, the page that asks for one.
+ *
+ * Arriving without a code is the ordinary manual path rather than a mistake.
+ * The mint returns a bare `verification_uri` alongside the one with the code
+ * already in it, precisely so a person can read a short address off a terminal
+ * and type it into a phone; that address has to lead somewhere they can enter
+ * the code they are looking at, or the manual half of RFC 8628 is advertised
+ * and then unusable.
+ *
+ * The form is a `GET`, because submitting it only navigates to this same page
+ * with the code on the url. The two `POST`s either side of it are the ones that
+ * change what a code is worth, and they stay exactly as they are.
+ */
 async function chooser(url: URL, env: Env, deps: ApprovalDeps): Promise<Response> {
   if (!approvalIsConfigured(env)) return page(NOT_CONFIGURED, 503);
 
-  const userCode = normalizeUserCode(url.searchParams.get(USER_CODE_PARAM));
-  if (userCode === null) return page(NO_CODE, 400);
+  const submitted = url.searchParams.get(USER_CODE_PARAM);
+  if (submitted === null || submitted.trim() === "") return codeEntry(200);
+
+  const userCode = normalizeUserCode(submitted);
+  if (userCode === null) return codeEntry(400, "That does not look like a code.");
 
   const now = (deps.now ?? Date.now)();
   // Checked before the providers are offered rather than after the handshake,
@@ -226,7 +244,7 @@ async function begin(
   if (submitted === null) return page(NOT_FOUND, 404);
 
   const userCode = normalizeUserCode(submitted.get(USER_CODE_PARAM));
-  if (userCode === null) return page(NO_CODE, 400);
+  if (userCode === null) return codeEntry(400, "That does not look like a code.");
 
   const now = (deps.now ?? Date.now)();
   const state = newHandshakeToken();
@@ -464,6 +482,40 @@ function codeDetail(userCode: string): string {
   return `  <div class="code">${escapeHtml(userCode)}</div>`;
 }
 
+/**
+ * The page that asks for a code, with an optional line saying why it is being
+ * asked again.
+ *
+ * What was submitted is deliberately not put back in the field. Nothing a
+ * visitor types reaches this page's markup, which makes "the code cannot carry
+ * anything" a property of the page rather than of the escaping being right, and
+ * a nine-character code is not worth weakening that to save retyping.
+ */
+function codeEntry(status: number, note?: string): Response {
+  const message = note === undefined ? ENTER_CODE.message : `${note} ${ENTER_CODE.message}`;
+  return page({ ...ENTER_CODE, message, actions: actions(codeForm()) }, status);
+}
+
+/**
+ * The one field, and nothing else.
+ *
+ * `autocapitalize` and the uppercasing in the stylesheet are for the phone this
+ * is most often typed into; neither is what makes a lowercase code work, since
+ * `normalizeUserCode` folds case and trims whitespace on the way in. `required`
+ * is what stops an empty submission bouncing off the same page with nothing to
+ * say, and it is markup rather than script — this page has no JavaScript and
+ * gains none here.
+ */
+function codeForm(): string {
+  return (
+    `<form method="get" action="${APPROVAL_PREFIX}">` +
+    `<input type="text" name="${USER_CODE_PARAM}" placeholder="WDJB-MJHT" aria-label="Device code"` +
+    ` autocomplete="off" autocapitalize="characters" autocorrect="off" spellcheck="false"` +
+    ` autofocus required>` +
+    `<button type="submit">Continue</button></form>`
+  );
+}
+
 /** Every page is `no-store`: none of them is the same twice. */
 function page(copy: BrandPage, status: number): Response {
   return new Response(brandPageHtml(copy), {
@@ -502,12 +554,12 @@ const DENIED: BrandPage = {
   actions: ABOUT_LINK,
 };
 
-const NO_CODE: BrandPage = {
-  title: "Approval link incomplete",
-  heading: "This link is incomplete.",
+const ENTER_CODE: BrandPage = {
+  title: "Approve a device",
+  heading: "Enter your code.",
+  /** Always rendered with the form as its actions, and sometimes with a note. */
   message:
-    "Open the whole address your terminal printed, code and all. If you typed it by hand, check the code against the one still on screen.",
-  actions: ABOUT_LINK,
+    "Your terminal is waiting on a short code. Type it in exactly as it appears there. Signing in on the next page creates your account the first time, which stores your verified email address and the id your provider uses for you. Nothing else.",
 };
 
 const CODE_GONE: BrandPage = {

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -3,7 +3,7 @@
  * and the only way an account comes into existence.
  *
  * There is no sign-up form, no sign-in page and no session. A CLI prints a url
- * carrying the device code it is waiting on (#57), the person opens it, proves
+ * carrying the user code it is waiting on, the person opens it, proves
  * an email with Google or GitHub, and presses a button to approve. The first
  * approval an address makes is the registration; every one after it finds the
  * same account. When the page is done, nothing about the browser is remembered
@@ -32,6 +32,7 @@
 import { type Env } from "../config.js";
 import {
   confirmDeviceApproval,
+  denyDeviceApproval,
   deviceCodeIsPending,
   findPendingHandshake,
   holdProvenIdentity,
@@ -68,13 +69,17 @@ export const USER_CODE_PARAM = "user_code";
  */
 const CONFIRM_TOKEN_FIELD = "confirm_token";
 
+/** The words the confirmation page uses when the terminal named itself nothing. */
+const UNNAMED_DEVICE = "that terminal";
+
 /**
  * A device code as it may appear in a url.
  *
- * Deliberately a shape rather than a format: **#57 mints these codes** and is
- * free to choose their length and grouping, so this only has to exclude what
- * cannot be one. Upper case and dashes are what RFC 8628 codes look like when
- * a person reads one off a terminal onto a phone.
+ * Deliberately a shape rather than a format. `newUserCode` decides the length
+ * and the grouping, and this only has to exclude what cannot be a code at all,
+ * so changing the format there does not strand links already printed. Upper
+ * case and dashes are what RFC 8628 codes look like when a person reads one off
+ * a terminal onto a phone.
  */
 const USER_CODE_PATTERN = /^[A-Z0-9][A-Z0-9-]{0,63}$/;
 
@@ -120,10 +125,11 @@ export function normalizeUserCode(raw: string | null): string | null {
  * POST /approve/start/{provider}     redirects to the provider
  * GET  /approve/callback/{provider}  where the provider redirects back
  * POST /approve/confirm              the press that approves the code
+ * POST /approve/deny                 the press that refuses it
  * ```
  *
- * The methods are the design rather than a convention. Only the two `POST`s
- * change what a device code is worth, and neither can be caused by a link.
+ * The methods are the design rather than a convention. Only the three `POST`s
+ * change what a device code is worth, and none can be caused by a link.
  *
  * @param url the request url, whose origin is also the redirect uri the
  *   providers are registered against — the router has already refused every
@@ -147,6 +153,9 @@ export async function handleApproval(
     }
     if (section === "confirm" && provider === undefined && request.method === "POST") {
       return await confirm(request, env, deps);
+    }
+    if (section === "deny" && provider === undefined && request.method === "POST") {
+      return await deny(request, env, deps);
     }
     if (extra.length === 0 && provider !== undefined) {
       if (section === "start" && request.method === "POST") {
@@ -317,17 +326,26 @@ async function prove(
     return page(EXPIRED, 400);
   }
 
+  // The machine's own name for itself, which is the only thing on this page
+  // that tells someone whether the terminal waiting on this code is theirs. It
+  // is client-supplied text, so it is escaped like the address beside it.
+  const device =
+    handshake.label === null ? UNNAMED_DEVICE : `<b>${escapeHtml(handshake.label)}</b>`;
+
   return page(
     {
       ...CONFIRM,
-      message: `You are signed in as ${escapeHtml(email)}. Approving lets that terminal publish as you until you revoke it. If you did not start this, close the page and nothing happens.`,
+      message: `You are signed in as ${escapeHtml(email)}. Approving lets ${device} publish as you until you revoke it. If you did not start this, choose Deny: nothing is approved and the code stops working immediately.`,
       detail: codeDetail(handshake.user_code),
       actions: actions(
-        form(
-          `${APPROVAL_PREFIX}/confirm`,
-          { [CONFIRM_TOKEN_FIELD]: confirmToken },
-          "Approve this device",
-        ),
+        [
+          form(
+            `${APPROVAL_PREFIX}/confirm`,
+            { [CONFIRM_TOKEN_FIELD]: confirmToken },
+            "Approve this device",
+          ),
+          form(`${APPROVAL_PREFIX}/deny`, { [CONFIRM_TOKEN_FIELD]: confirmToken }, "Deny"),
+        ].join(""),
       ),
     },
     200,
@@ -356,6 +374,34 @@ async function confirm(request: Request, env: Env, deps: ApprovalDeps): Promise<
   if (userCode === null) return page(EXPIRED, 400);
 
   return page({ ...APPROVED, detail: codeDetail(userCode) }, 200);
+}
+
+/**
+ * The press that refuses the code.
+ *
+ * The other half of the defence the confirm token exists for. Closing the tab
+ * already refuses an approval, but it leaves the code live for the rest of its
+ * lifetime — so someone who lands here for a terminal that is not theirs, which
+ * is exactly the RFC 8628 §5.4 case, has no way to end it. This ends it now,
+ * and the terminal polling that code is told it was refused instead of waiting
+ * out the expiry to learn nothing.
+ *
+ * The token is cleared by whichever press lands first, so a code can be
+ * approved or refused but never both, and neither can be replayed.
+ */
+async function deny(request: Request, env: Env, deps: ApprovalDeps): Promise<Response> {
+  if (!approvalIsConfigured(env)) return page(NOT_CONFIGURED, 503);
+
+  const submitted = await readSmallForm(request);
+  if (submitted === null) return page(NOT_FOUND, 404);
+
+  const token = submitted.get(CONFIRM_TOKEN_FIELD);
+  const now = (deps.now ?? Date.now)();
+
+  const userCode = token === null ? null : await denyDeviceApproval(env.DB, token, now);
+  if (userCode === null) return page(EXPIRED, 400);
+
+  return page({ ...DENIED, detail: codeDetail(userCode) }, 200);
 }
 
 /**
@@ -445,6 +491,14 @@ const APPROVED: BrandPage = {
   heading: "Approved.",
   message:
     "Your terminal is finishing up now, and you can close this page. It keeps the token from here on, so you will not be asked again on this machine.",
+  actions: ABOUT_LINK,
+};
+
+const DENIED: BrandPage = {
+  title: "Device denied",
+  heading: "Denied.",
+  message:
+    "That code is now dead and the terminal waiting on it has been told so. Nothing was approved and no token was issued. If the request was not yours, there is nothing else to do.",
   actions: ABOUT_LINK,
 };
 

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -382,7 +382,7 @@ async function prove(
   // that tells someone whether the terminal waiting on this code is theirs. It
   // is client-supplied text, so it is escaped like the address beside it.
   const device =
-    handshake.label === null ? UNNAMED_DEVICE : `<b>${escapeHtml(handshake.label)}</b>`;
+    handshake.label === null ? UNNAMED_DEVICE : `<b><bdi>${escapeHtml(handshake.label)}</bdi></b>`;
 
   return page(
     {

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -523,7 +523,7 @@ function codeDetail(userCode: string): string {
  * What was submitted is deliberately not put back in the field. Nothing a
  * visitor types reaches this page's markup, which makes "the code cannot carry
  * anything" a property of the page rather than of the escaping being right, and
- * a nine-character code is not worth weakening that to save retyping.
+ * a ten-letter code is not worth weakening that to save retyping.
  */
 function codeEntry(status: number, note?: string): Response {
   const message = note === undefined ? ENTER_CODE.message : `${note} ${ENTER_CODE.message}`;

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -40,7 +40,7 @@ import {
   startDeviceHandshake,
 } from "../db.js";
 import { newAccountId, newHandshakeToken } from "../ids.js";
-import { withinClientLimit } from "../limits.js";
+import { isTopLevelRequest, withinClientLimit } from "../limits.js";
 import { readBodyWithin } from "../quota.js";
 import { ABOUT_LINK, brandPageHtml, escapeHtml, type BrandPage } from "../page.js";
 import {
@@ -211,6 +211,14 @@ async function chooser(
   const userCode = normalizeUserCode(submitted);
   if (userCode === null) return codeEntry(400, "That does not look like a code.");
 
+  // Gated before the limiter, not after. This route is a plain `GET`, so a
+  // hostile page can make a visitor's browser send it from their address with
+  // an `<img>` — and if that were counted, twenty of them would spend the
+  // visitor's allowance and their own approval would come back as `CODE_GONE`.
+  // Refusing a subresource first means only requests the visitor made are
+  // charged to them.
+  if (!isTopLevelRequest(request)) return page(CODE_GONE, 404);
+
   // Counted before the row is read, so a client working through the code space
   // is stopped by the limit rather than by how many rows it can afford to
   // read. `CODE_GONE` on refusal, because a throttle and a miss have to look
@@ -265,8 +273,10 @@ async function begin(
   const userCode = normalizeUserCode(submitted.get(USER_CODE_PARAM));
   if (userCode === null) return codeEntry(400, "That does not look like a code.");
 
-  // Counted with the chooser's lookups and for the same reason: this route
-  // also says whether a code is live, and it writes when it is.
+  // Gated and counted with the chooser's lookups, for the same two reasons:
+  // this route also says whether a code is live, and it writes when it is.
+  if (!isTopLevelRequest(request)) return page(CODE_GONE, 404);
+
   const limiter = deps.limiter ?? env.APPROVAL_LOOKUP_LIMITER;
   if (!(await withinClientLimit(limiter, request))) return page(CODE_GONE, 404);
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,10 +27,22 @@
  * The fallback covers outages only, never rejections. A key the server actively
  * refuses is denied even when it has a warm cache row — otherwise revoking a key
  * would never take effect, since the fallback would re-admit it on every request.
+ *
+ * **A second credential resolves here too.** An OpenArtifacts token, issued by
+ * the device flow to an account this deployment owns, arrives in the same
+ * header and answers the same question. The two are told apart by the token's
+ * `oat_` prefix rather than by trying one path and falling back to the other,
+ * and that is a security property, not a shortcut: without it a token would be
+ * handed to the Brevilabs license server to be identified, which would leak our
+ * own secret to a third party on every request. Neither path can reach the
+ * other's store, so a token can never be validated as a license key and a
+ * license key can never be looked up as a token.
  */
-import { LICENSE_CACHE_TTL_MS, type Env } from "./config.js";
-import { d1PublisherStore, type PublisherStore } from "./db.js";
+import { LICENSE_CACHE_TTL_MS, TOKEN_LAST_USED_RESOLUTION_MS, type Env } from "./config.js";
+import { d1PublisherStore, findLiveToken, touchTokenUse, type PublisherStore } from "./db.js";
 import { errorResponse, type ErrorCode } from "./errors.js";
+import { sha256Hex } from "./hash.js";
+import { TOKEN_PREFIX } from "./ids.js";
 
 /** tRPC endpoint on the license server, appended to `LICENSE_API_URL`. */
 const VALIDATE_PATH = "/api/trpc/license.validateLicenseKey";
@@ -46,6 +58,23 @@ const LICENSE_TIMEOUT_MS = 5_000;
 const UNKNOWN_PLAN = "unknown";
 
 /**
+ * The plan an account authenticated by its own token publishes under.
+ *
+ * A token account holds no license, so it has no plan the license server could
+ * name, and `mayPublish` is the only gate on the push path — a brand-new
+ * account that could not publish would make the whole approval flow end in a
+ * refusal. It therefore has to be a value the license server can never return:
+ * naming it `free` would hand publishing to every FREE license key at the same
+ * time, which is the one mistake this constant exists to make impossible.
+ *
+ * It is a placeholder for `accounts.plan` and the per-plan limits config in
+ * [#60](https://github.com/Brevilabs/OpenArtifacts/issues/60). Until then a
+ * token account publishes under the same ceilings a license key does, since
+ * both are counted per owner.
+ */
+export const ACCOUNT_TOKEN_PLAN = "account";
+
+/**
  * The paid Copilot plans entitled to publish.
  *
  * The license server currently has two paid plans: Plus subscriptions and the
@@ -56,7 +85,7 @@ const UNKNOWN_PLAN = "unknown";
  * Lowercase because `validateLicense` folds the license server's uppercase enum
  * before it gets here, and because `publishers.plan` stores the folded form.
  */
-const PUBLISHING_PLANS: ReadonlySet<string> = new Set(["plus", "believer"]);
+const PUBLISHING_PLANS: ReadonlySet<string> = new Set(["plus", "believer", ACCOUNT_TOKEN_PLAN]);
 
 /**
  * Entitlement is per *operation*, not per identity, so this is deliberately not
@@ -80,11 +109,15 @@ export const INELIGIBLE_PLAN: { reason: PublisherFailure; message: string } = {
 
 export interface Publisher {
   /**
-   * The app-sites `User.id` whose documents these are. Every doc query keys off
-   * it, which is what makes two keys on one account see one shelf and lets a
-   * openartifacts.ai session find the same documents from `session.user.id` alone.
+   * Whose documents these are. Every doc query keys off it, which is what makes
+   * two keys on one account see one shelf.
    *
-   * The license key itself appears nowhere outside this module: it identifies a
+   * It holds an app-sites `User.id` for a license key and an `oa_`-prefixed
+   * account id for a token, and nothing downstream can tell or cares — the two
+   * id spaces cannot collide, so one column carries both safely
+   * (`docs/identity.md`).
+   *
+   * The credential itself appears nowhere outside this module. It identifies a
    * credential, and nothing downstream has any business knowing which one was
    * used.
    */
@@ -97,6 +130,8 @@ export type PublisherFailure =
   | "missing_credentials"
   /** The license server answered, and the answer was no. */
   | "invalid_license"
+  /** The credential looked like one of our tokens, and no live token matches. */
+  | "invalid_token"
   /**
    * The key is real and current, but its plan may not publish. Raised by the
    * router on `POST`/`PUT` only — never by authentication, which would take
@@ -137,7 +172,7 @@ export async function authenticateRequest(
     return {
       ok: false,
       reason: "missing_credentials",
-      message: "Expected an Authorization: Bearer <license key> header.",
+      message: "Expected an Authorization: Bearer <token> header.",
     };
   }
   // `return await`: see the note on the router's catch in index.ts.
@@ -149,6 +184,14 @@ export async function resolvePublisher(
   env: Env,
   deps: AuthDeps = {},
 ): Promise<PublisherResolution> {
+  // Prefix first, and never a fallback between the two paths: a value that
+  // announces itself as one of our tokens is only ever checked against our own
+  // table, so it cannot be sent to the license server by accident.
+  if (token.startsWith(TOKEN_PREFIX)) {
+    // `return await`: see the note on the router's catch in index.ts.
+    return await resolveAccountToken(token, env, deps);
+  }
+
   const now = deps.now ?? Date.now;
   const store = deps.store ?? d1PublisherStore(env.DB);
 
@@ -199,9 +242,46 @@ export async function resolvePublisher(
   }
 }
 
+/**
+ * Resolve one of this deployment's own tokens to the account it publishes as.
+ *
+ * There is no cache and no outage story, because there is nothing to be out:
+ * the token's owner is a row in this database rather than an answer from
+ * another service. That is also why a revoked token stops working on its very
+ * next request, where a revoked license key keeps working until its cached
+ * validation ages out.
+ */
+async function resolveAccountToken(
+  token: string,
+  env: Env,
+  deps: AuthDeps,
+): Promise<PublisherResolution> {
+  const now = deps.now ?? Date.now;
+  const live = await findLiveToken(env.DB, await sha256Hex(token));
+
+  if (live === null) {
+    // The same answer for an unknown token, a revoked one and a typo. Which of
+    // the three it was is not the caller's business, and telling them would
+    // turn a refusal into a probe.
+    return {
+      ok: false,
+      reason: "invalid_token",
+      message: "That token is not valid. Sign in again to get a new one.",
+    };
+  }
+
+  const at = now();
+  if (live.last_used_at === null || live.last_used_at < at - TOKEN_LAST_USED_RESOLUTION_MS) {
+    await touchTokenUse(env.DB, live.id, at, at - TOKEN_LAST_USED_RESOLUTION_MS);
+  }
+
+  return { ok: true, publisher: { owner: live.account_id, plan: ACCOUNT_TOKEN_PLAN } };
+}
+
 const FAILURE_STATUS: Record<PublisherFailure, ErrorCode> = {
   missing_credentials: "unauthorized",
   invalid_license: "unauthorized",
+  invalid_token: "unauthorized",
   // `unauthorized`, not a new code: the contract in docs/http-api.md is frozen,
   // and `message` is the part of it that is free to change. A client matching
   // on `code` keeps working; a human reads why. Only `POST` and `PUT` can
@@ -339,9 +419,4 @@ async function validateLicense(token: string, env: Env, deps: AuthDeps): Promise
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
-}
-
-async function sha256Hex(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,3 +66,57 @@ export const MAX_PUSHES_PER_DAY = 100;
 
 /** Live (non-deleted) docs a single publisher key may hold. */
 export const MAX_DOCS_PER_PUBLISHER = 500;
+
+/**
+ * How long a device code is worth approving.
+ *
+ * Long enough to find a phone, open a browser and sign in with a provider;
+ * short enough that a code left on a screen is worthless by the time anyone
+ * else walks past it. RFC 8628 leaves the number to the deployment.
+ */
+export const DEVICE_CODE_TTL_MS = 15 * 60 * 1000;
+
+/** The polling interval the mint response tells the terminal to use. */
+export const DEVICE_POLL_INTERVAL_SECONDS = 5;
+
+/**
+ * The gap below which a poll is answered `slow_down` instead of being served.
+ *
+ * A second under the advertised interval rather than the interval itself: a
+ * client that sleeps exactly five seconds still arrives a little early or late
+ * depending on the network, and refusing a well-behaved client for jitter would
+ * make the flow flaky for the one thing it exists to keep orderly.
+ */
+export const MIN_DEVICE_POLL_GAP_MS = (DEVICE_POLL_INTERVAL_SECONDS - 1) * 1000;
+
+/** Window the device-code mint limit is counted over. */
+export const DEVICE_MINT_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Device codes one client address may mint per window.
+ *
+ * Minting is unauthenticated by necessity, so the address is the only thing to
+ * count against. Twenty in ten minutes is far above one person signing in a
+ * machine or two and leaves room for an office behind one address, while
+ * capping what a script can produce to spam people with approval pages.
+ */
+export const MAX_DEVICE_MINTS_PER_WINDOW = 20;
+
+/**
+ * How stale a token's `last_used_at` may get before a request refreshes it.
+ *
+ * Writing it on every request would put a D1 write behind every read, which is
+ * the wrong trade for a column whose only reader is a human deciding which
+ * machine to revoke. An hour's resolution answers that question just as well,
+ * and a token's first use still records itself immediately.
+ */
+export const TOKEN_LAST_USED_RESOLUTION_MS = 60 * 60 * 1000;
+
+/**
+ * Tokens `GET /api/v1/tokens` returns.
+ *
+ * There is no paging: a token is minted by a human approving a machine, so an
+ * account holds a handful. The cap is what stops a pathological account turning
+ * one request into an unbounded D1 scan.
+ */
+export const MAX_TOKENS_LISTED = 100;

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,17 @@ export interface Env {
    */
   DEVICE_POLL_LIMITER?: RateLimit;
 
+  /**
+   * Aggregate limiter on `POST /device/token`, keyed by client address.
+   *
+   * The per-code limiter above enforces the advertised interval, but an
+   * attacker can otherwise invent a fresh code for every request and force a
+   * D1 miss each time. This second bucket bounds those misses without making
+   * ordinary device codes behind one address share the one-per-interval rule.
+   * Optional like the other limiters; absent means no aggregate ceiling.
+   */
+  DEVICE_POLL_CLIENT_LIMITER?: RateLimit;
+
   /** Canonical host that serves public docs. Empty in local development. */
   SERVING_HOST?: string;
   /** Canonical host that exposes /api/v1. Empty in local development. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,15 +127,20 @@ export const DEVICE_MINT_PERIOD_SECONDS = 60;
 export const TOKEN_LAST_USED_RESOLUTION_MS = 60 * 60 * 1000;
 
 /**
- * Live tokens one account may hold, which is also every token the list returns.
+ * Live tokens one account holds at once, which is also every token the list
+ * returns.
  *
  * One number, not two, and that is the whole design. `GET /api/v1/tokens` has
  * no cursor, because a token exists only when a human approves a machine and an
  * account has a handful. A list capped below what an account can hold would
  * eventually hide a live token behind the cap — and since revoking is the only
- * way to manage one, a token nobody can see is a token nobody can withdraw
- * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3927574073).
- * Capping issuance at the same number instead makes the list complete by
+ * way to manage one, a token nobody can see is a token nobody can withdraw.
+ * Holding the count at this number instead makes the list complete by
  * construction.
+ *
+ * It is a rolling window rather than a ceiling that refuses: the hundred and
+ * first collection evicts the account's least recently used token. Refusing
+ * would strand an owner who no longer holds any of the hundred values, because
+ * revoking needs one of them — see `collectDeviceToken`.
  */
 export const MAX_TOKENS_PER_ACCOUNT = 100;

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,10 +127,15 @@ export const DEVICE_MINT_PERIOD_SECONDS = 60;
 export const TOKEN_LAST_USED_RESOLUTION_MS = 60 * 60 * 1000;
 
 /**
- * Tokens `GET /api/v1/tokens` returns.
+ * Live tokens one account may hold, which is also every token the list returns.
  *
- * There is no paging: a token is minted by a human approving a machine, so an
- * account holds a handful. The cap is what stops a pathological account turning
- * one request into an unbounded D1 scan.
+ * One number, not two, and that is the whole design. `GET /api/v1/tokens` has
+ * no cursor, because a token exists only when a human approves a machine and an
+ * account has a handful. A list capped below what an account can hold would
+ * eventually hide a live token behind the cap — and since revoking is the only
+ * way to manage one, a token nobody can see is a token nobody can withdraw
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3927574073).
+ * Capping issuance at the same number instead makes the list complete by
+ * construction.
  */
-export const MAX_TOKENS_LISTED = 100;
+export const MAX_TOKENS_PER_ACCOUNT = 100;

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,22 @@ export interface Env {
   /** D1 pointer index. Rebuildable from R2; never holds content. */
   DB: D1Database;
 
+  /**
+   * Rate limiter on `POST /device/code`, declared in wrangler.jsonc.
+   *
+   * **Optional, and its absence is a supported deployment rather than a
+   * misconfiguration.** A self-hoster who declares no limiter gets no limit on
+   * that endpoint, which is the right default for a private deployment nobody
+   * else can reach and a deliberate choice for a public one. The alternative —
+   * failing closed when it is undefined — would mean a Worker that refuses to
+   * sign anybody in until an operator has read a configuration reference.
+   *
+   * The hosted deployment declares it, and should carry a WAF rate limiting
+   * rule on the same path as a second layer, since the binding runs inside the
+   * Worker and a request that reaches it has already been paid for.
+   */
+  DEVICE_CODE_LIMITER?: RateLimit;
+
   /** Canonical host that serves public docs. Empty in local development. */
   SERVING_HOST?: string;
   /** Canonical host that exposes /api/v1. Empty in local development. */
@@ -89,18 +105,16 @@ export const DEVICE_POLL_INTERVAL_SECONDS = 5;
  */
 export const MIN_DEVICE_POLL_GAP_MS = (DEVICE_POLL_INTERVAL_SECONDS - 1) * 1000;
 
-/** Window the device-code mint limit is counted over. */
-export const DEVICE_MINT_WINDOW_MS = 10 * 60 * 1000;
-
 /**
- * Device codes one client address may mint per window.
+ * The window the device-code limiter counts over, in seconds.
  *
- * Minting is unauthenticated by necessity, so the address is the only thing to
- * count against. Twenty in ten minutes is far above one person signing in a
- * machine or two and leaves room for an office behind one address, while
- * capping what a script can produce to spam people with approval pages.
+ * The limit itself lives in wrangler.jsonc, where the binding is declared, and
+ * is not readable from here — a rate limiter binding reports no numbers, only a
+ * verdict. This copy exists solely so a refusal can carry a `Retry-After` the
+ * caller can act on, and **it has to match the `period` on the binding**. The
+ * binding accepts 10 or 60 and nothing else.
  */
-export const MAX_DEVICE_MINTS_PER_WINDOW = 20;
+export const DEVICE_MINT_PERIOD_SECONDS = 60;
 
 /**
  * How stale a token's `last_used_at` may get before a request refreshes it.

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,16 @@ export interface Env {
    */
   APPROVAL_LOOKUP_LIMITER?: RateLimit;
 
+  /**
+   * Rate limiter on `POST /device/token`, keyed by the device-code hash.
+   *
+   * Keeping the poll interval here makes a pending poll read-only in D1. A
+   * timestamp in the device row would turn every well-behaved poll into a write
+   * and exhaust the hosted database allowance under ordinary sustained use.
+   * Optional like the other two limiters; absent means the interval is advisory.
+   */
+  DEVICE_POLL_LIMITER?: RateLimit;
+
   /** Canonical host that serves public docs. Empty in local development. */
   SERVING_HOST?: string;
   /** Canonical host that exposes /api/v1. Empty in local development. */
@@ -108,18 +118,13 @@ export const MAX_DOCS_PER_PUBLISHER = 500;
  */
 export const DEVICE_CODE_TTL_MS = 15 * 60 * 1000;
 
-/** The polling interval the mint response tells the terminal to use. */
-export const DEVICE_POLL_INTERVAL_SECONDS = 5;
-
 /**
- * The gap below which a poll is answered `slow_down` instead of being served.
+ * The polling interval the mint response tells the terminal to use.
  *
- * A second under the advertised interval rather than the interval itself: a
- * client that sleeps exactly five seconds still arrives a little early or late
- * depending on the network, and refusing a well-behaved client for jitter would
- * make the flow flaky for the one thing it exists to keep orderly.
+ * It matches `DEVICE_POLL_LIMITER`'s period. Workers rate limiter bindings only
+ * accept periods of 10 or 60 seconds.
  */
-export const MIN_DEVICE_POLL_GAP_MS = (DEVICE_POLL_INTERVAL_SECONDS - 1) * 1000;
+export const DEVICE_POLL_INTERVAL_SECONDS = 10;
 
 /**
  * The window the device-code limiter counts over, in seconds.

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,22 @@ export interface Env {
    */
   DEVICE_CODE_LIMITER?: RateLimit;
 
+  /**
+   * Rate limiter on the two approval routes that take a user code: the page
+   * that looks one up, and the button that starts a handshake against it.
+   *
+   * A separate namespace from the mint's, and a much larger allowance, because
+   * the two limits are protecting different things. A mint writes a row, so its
+   * limit is about the write budget. These two read a row and conditionally
+   * update one, and their limit is only defence in depth behind the user code's
+   * own entropy. Sharing one bucket would also mean one ordinary sign-in spent
+   * three of it — mint, look up, start — and a person who reloaded the approval
+   * page twice would be told their code had expired.
+   *
+   * Optional for the same reason as the mint's, and absent means no limit.
+   */
+  APPROVAL_LOOKUP_LIMITER?: RateLimit;
+
   /** Canonical host that serves public docs. Empty in local development. */
   SERVING_HOST?: string;
   /** Canonical host that exposes /api/v1. Empty in local development. */

--- a/src/db.ts
+++ b/src/db.ts
@@ -121,8 +121,6 @@ export interface DeviceCodeRow {
   label: string | null;
   /** Epoch ms of a refusal on the approval page, and null until one is given. */
   denied_at: number | null;
-  /** Epoch ms of the terminal's last poll, which `slow_down` is measured from. */
-  last_polled_at: number | null;
   expires_at: number;
   created_at: number;
 }
@@ -150,7 +148,6 @@ export interface TokenRow {
   label: string | null;
   created_at: number;
   last_used_at: number | null;
-  revoked_at: number | null;
 }
 
 /** A live token as `GET /api/v1/tokens` reports it. The hash never leaves D1. */
@@ -930,7 +927,7 @@ export async function denyDeviceApproval(
  * terminal's code at a different device code, and the approval a person then
  * gave would land on somebody else's terminal. The caller redraws instead.
  *
- * Eight characters of a twenty-letter alphabet against the handful of codes
+ * Ten characters of a twenty-letter alphabet against the handful of codes
  * alive at once makes a collision vanishingly rare; the sweep is what keeps it
  * that way, since a code that is never deleted is a code that can never be
  * drawn again.
@@ -984,74 +981,31 @@ export type PolledDeviceCode = Pick<
   "user_code" | "approved_at" | "denied_at" | "expires_at"
 >;
 
-/** The outcome of asking for this interval's poll. */
-export interface DevicePoll {
-  /** The code as it stands, or null when no code answers to that hash. */
-  code: PolledDeviceCode | null;
-  /**
-   * Whether this request is the one poll this interval serves. False means
-   * another already had it, which is what `slow_down` reports.
-   */
-  claimed: boolean;
-}
-
 /**
- * Claim this interval's poll for one device code, and read the code's state in
- * the same round trip.
+ * Read the state a device-code poll needs.
  *
- * **Claim rather than check.** Reading `last_polled_at` and then writing it
- * cannot enforce an interval at all: overlapping polls all read the same value,
- * none of them sees one too recent, and every one of them proceeds and writes.
- * A client holding a single legitimately minted code could then fire concurrent
- * bursts for the whole of that code's lifetime and turn the interval check into
- * a source of unbounded writes — which is the one thing the interval exists to
- * bound. The predicate rides on the `UPDATE`, so exactly one poll per interval
- * wins it and the rest are told to slow down (
- * https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928181821).
- * `holdProvenIdentity` above is the same shape for the same reason.
- *
- * An expired or refused code is never claimed, so polling one writes nothing at
- * all rather than once an interval until the sweep reaches it. The `SELECT`
- * beside it is what tells those two apart from a hash no row answers to: all
- * three fail to claim, and only the row says which happened.
+ * The polling interval lives in the Workers rate limiter rather than this row.
+ * That makes every pending poll a read instead of a D1 write while the binding
+ * still tells a fast client to slow down. Token collection remains transactional
+ * below, so correctness does not depend on the limiter being exact.
  *
  * The device code is the lookup key rather than the user code because it is the
  * half the terminal keeps to itself. A user code is read aloud and typed into
  * phones; if it could collect a token, every approval page would be showing the
  * credential to the room.
  *
- * @param minGapMs how close to the previous served poll is too close, from
- *   `MIN_DEVICE_POLL_GAP_MS`
  */
-export async function claimDevicePoll(
+export async function findPolledDeviceCode(
   db: D1Database,
   deviceCodeHash: string,
-  nowMs: number,
-  minGapMs: number,
-): Promise<DevicePoll> {
-  const [claimed, current] = await db.batch<PolledDeviceCode>([
-    db
-      .prepare(
-        `UPDATE device_codes SET last_polled_at = ?
-          WHERE device_code_hash = ?
-            AND expires_at > ?
-            AND denied_at IS NULL
-            AND (last_polled_at IS NULL OR last_polled_at <= ?)
-         RETURNING user_code, approved_at, denied_at, expires_at`,
-      )
-      .bind(nowMs, deviceCodeHash, nowMs, nowMs - minGapMs),
-    db
-      .prepare(
-        `SELECT user_code, approved_at, denied_at, expires_at
-           FROM device_codes WHERE device_code_hash = ?`,
-      )
-      .bind(deviceCodeHash),
-  ]);
-
-  return {
-    code: current?.results[0] ?? null,
-    claimed: (claimed?.results.length ?? 0) > 0,
-  };
+): Promise<PolledDeviceCode | null> {
+  return await db
+    .prepare(
+      `SELECT user_code, approved_at, denied_at, expires_at
+         FROM device_codes WHERE device_code_hash = ?`,
+    )
+    .bind(deviceCodeHash)
+    .first<PolledDeviceCode>();
 }
 
 /**
@@ -1119,21 +1073,20 @@ export async function collectDeviceToken(
   const [, issued] = await db.batch<{ label: string | null }>([
     db
       .prepare(
-        `UPDATE tokens SET revoked_at = ?
+        `DELETE FROM tokens
           WHERE id = (
             SELECT victim.id
               FROM tokens victim
               JOIN device_codes code ON code.account_id = victim.account_id
              WHERE code.device_code_hash = ?
                AND code.approved_at IS NOT NULL
-               AND victim.revoked_at IS NULL
                AND (SELECT COUNT(*) FROM tokens live
-                     WHERE live.account_id = code.account_id AND live.revoked_at IS NULL) >= ?
+                     WHERE live.account_id = code.account_id) >= ?
              ORDER BY victim.last_used_at ASC NULLS FIRST, victim.created_at ASC, victim.id ASC
              LIMIT 1
           )`,
       )
-      .bind(token.created_at, deviceCodeHash, maxTokens),
+      .bind(deviceCodeHash, maxTokens),
     db
       .prepare(
         `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
@@ -1141,7 +1094,7 @@ export async function collectDeviceToken(
            FROM device_codes
           WHERE device_code_hash = ? AND approved_at IS NOT NULL AND account_id IS NOT NULL
             AND (SELECT COUNT(*) FROM tokens
-                  WHERE account_id = device_codes.account_id AND revoked_at IS NULL) < ?
+                  WHERE account_id = device_codes.account_id) < ?
          RETURNING label`,
       )
       .bind(token.id, token.token_hash, token.created_at, deviceCodeHash, maxTokens),
@@ -1162,9 +1115,9 @@ export async function collectDeviceToken(
  *
  * Looked up by hash, like a license key, so the value the caller sent is never
  * compared against anything stored — there is nothing stored to compare it to.
- * A revoked token keeps its row so that its hash stays taken and it goes on
- * failing; deleting the row would leave nothing for the next request to fail
- * against, and the same value could in principle be minted again.
+ * Revocation deletes the row, so an unknown and a revoked value take the same
+ * path. Tokens carry enough entropy that minting the same value again is not a
+ * storage concern worth an unbounded tombstone table.
  */
 export async function findLiveToken(
   db: D1Database,
@@ -1173,8 +1126,7 @@ export async function findLiveToken(
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT id, account_id, last_used_at FROM tokens
-        WHERE token_hash = ? AND revoked_at IS NULL`,
+      `SELECT id, account_id, last_used_at FROM tokens WHERE token_hash = ?`,
     )
     .bind(tokenHash)
     .first<Pick<TokenRow, "id" | "account_id" | "last_used_at">>();
@@ -1215,7 +1167,7 @@ export async function listAccountTokens(
   const { results } = await db
     .prepare(
       `SELECT id, label, created_at, last_used_at FROM tokens
-        WHERE account_id = ? AND revoked_at IS NULL
+        WHERE account_id = ?
         ORDER BY created_at DESC, id DESC
         LIMIT ?`,
     )
@@ -1242,15 +1194,14 @@ export async function revokeAccountToken(
   db: D1Database,
   id: string,
   accountId: string,
-  atMs: number,
 ): Promise<boolean> {
   const revoked = await db
     .prepare(
-      `UPDATE tokens SET revoked_at = ?
-        WHERE id = ? AND account_id = ? AND revoked_at IS NULL
+      `DELETE FROM tokens
+        WHERE id = ? AND account_id = ?
         RETURNING id`,
     )
-    .bind(atMs, id, accountId)
+    .bind(id, accountId)
     .first<{ id: string }>();
 
   return revoked !== null;
@@ -1259,7 +1210,7 @@ export async function revokeAccountToken(
 /** Live tokens an account still holds, which is what a revoke reports back. */
 export async function countLiveTokens(db: D1Database, accountId: string): Promise<number> {
   const row = await db
-    .prepare("SELECT COUNT(*) AS n FROM tokens WHERE account_id = ? AND revoked_at IS NULL")
+    .prepare("SELECT COUNT(*) AS n FROM tokens WHERE account_id = ?")
     .bind(accountId)
     .first<{ n: number }>();
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1054,14 +1054,6 @@ export async function claimDevicePoll(
   };
 }
 
-/** What became of a poll that arrived at an approved code. */
-export type TokenCollection =
-  | { status: "issued"; label: string | null }
-  /** The account is at `MAX_TOKENS_PER_ACCOUNT`. The code is left collectable. */
-  | { status: "at_capacity" }
-  /** Another poll collected it first, so there is nothing left to collect. */
-  | { status: "gone" };
-
 /**
  * Issue the token an approved code earned, and consume the code doing it.
  *
@@ -1083,31 +1075,65 @@ export type TokenCollection =
  * been collected is gone, and a second poll with it gets exactly what a poll
  * with an expired code gets.
  *
- * The account's ceiling is a predicate on the insert rather than a count read
- * before it, for the reason `insertDocWithinQuota` gives: two approvals
- * collected at the same moment would otherwise both read the same number and
- * both insert, and a cap the list depends on being complete has to behave like
- * a hard number under the concurrency an agent produces.
+ * **An account at its ceiling loses its least recently used token rather than
+ * being refused a new one.** Refusing looks safer and is not: tokens never
+ * expire, so an account fills up through ordinary device loss over years, and
+ * an owner who no longer holds any of those hundred values could then neither
+ * revoke one (revoking needs a token) nor collect one. That is a permanent
+ * lockout produced entirely by the cap
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928231361).
+ * Evicting is safe because whoever is collecting has just proved the account's
+ * identity through an OAuth approval, which is a stronger claim than any token
+ * they might have lost, and it is self-healing: the token that ages out is the
+ * one belonging to the machine nobody uses any more.
+ *
+ * Least recently used means never used first — a token issued to a machine that
+ * never came back is the emptiest thing to drop — then oldest use, then oldest
+ * issue. SQLite orders nulls first under `ASC` anyway; the clause says so
+ * explicitly because the tie-break is the rule rather than an accident of the
+ * engine.
+ *
+ * The eviction carries the same predicates as the insert, so a poll at a code
+ * nobody has approved revokes nothing. The ceiling stays a predicate on the
+ * insert as well, which is what makes it hold under concurrent collections:
+ * two approvals collected at the same moment cannot both read the same count
+ * and both insert.
  *
  * The delete keys off the token row the insert left behind rather than
  * restating that ceiling. Restating it would be wrong in a way that is easy to
  * miss: the statements run in order inside the batch, so by the time the delete
- * is evaluated the count already includes the row just inserted, and an
- * off-by-one there would consume a device code without issuing anything. Keying
- * off the row means the code survives exactly when nothing was issued, so a
- * caller refused by the ceiling can revoke a token and poll again with the same
- * code.
+ * is evaluated the count already includes the row just inserted. Keying off the
+ * row means the code survives exactly when nothing was issued.
  *
  * @param maxTokens live tokens the account may hold, from
  *   `MAX_TOKENS_PER_ACCOUNT`
+ * @returns the label the new token carries, or null when there was nothing left
+ *   to collect
  */
 export async function collectDeviceToken(
   db: D1Database,
   deviceCodeHash: string,
   token: Pick<TokenRow, "id" | "token_hash" | "created_at">,
   maxTokens: number,
-): Promise<TokenCollection> {
-  const [issued] = await db.batch<{ label: string | null }>([
+): Promise<{ label: string | null } | null> {
+  const [, issued] = await db.batch<{ label: string | null }>([
+    db
+      .prepare(
+        `UPDATE tokens SET revoked_at = ?
+          WHERE id = (
+            SELECT victim.id
+              FROM tokens victim
+              JOIN device_codes code ON code.account_id = victim.account_id
+             WHERE code.device_code_hash = ?
+               AND code.approved_at IS NOT NULL
+               AND victim.revoked_at IS NULL
+               AND (SELECT COUNT(*) FROM tokens live
+                     WHERE live.account_id = code.account_id AND live.revoked_at IS NULL) >= ?
+             ORDER BY victim.last_used_at ASC NULLS FIRST, victim.created_at ASC, victim.id ASC
+             LIMIT 1
+          )`,
+      )
+      .bind(token.created_at, deviceCodeHash, maxTokens),
     db
       .prepare(
         `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
@@ -1128,17 +1154,7 @@ export async function collectDeviceToken(
   ]);
 
   const row = issued?.results[0];
-  if (row !== undefined) return { status: "issued", label: row.label };
-
-  // Nothing was issued, and the surviving row is what says why: the delete only
-  // fires when the insert did, so a code still here was refused by the ceiling
-  // and a code that is gone was collected by somebody else.
-  const remaining = await db
-    .prepare("SELECT 1 FROM device_codes WHERE device_code_hash = ? AND approved_at IS NOT NULL")
-    .bind(deviceCodeHash)
-    .first();
-
-  return remaining === null ? { status: "gone" } : { status: "at_capacity" };
+  return row === undefined ? null : { label: row.label };
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -729,15 +729,17 @@ export async function deviceCodeIsPending(
  * costs nothing: the browser is not the thing being authorized, so it has
  * nothing to remember between the three requests.
  *
- * Starting a second handshake overwrites the first, which is what a person
- * pressing the other provider's button means. Only one can ever be finished,
- * because only the surviving `state` can be looked up.
+ * Starting a second handshake overwrites the first while neither provider has
+ * proved an identity, which is what a person pressing the other provider's
+ * button means. Once a callback has rendered a confirmation page,
+ * `confirm_token` is non-null and that page remains authoritative: somebody
+ * who merely knows the short user code cannot invalidate its Approve and Deny
+ * controls by starting again.
  *
- * It also drops any identity the first handshake proved. Confirmation trusts
- * `account_id` as the person who signed in for *this* `state`; carrying it
- * across a restart would let anyone who knows the user code start a fresh
- * handshake, read its state off the provider redirect, and press approve for
- * an identity they never proved (https://github.com/Brevilabs/OpenArtifacts/pull/61#discussion_r3919988470).
+ * The update still clears identity fields defensively. Confirmation trusts
+ * `account_id` as the person who signed in for *this* `state`, so a malformed
+ * partial row must never carry an identity across a restart
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/61#discussion_r3919988470).
  */
 export async function startDeviceHandshake(
   db: D1Database,
@@ -752,7 +754,8 @@ export async function startDeviceHandshake(
       `UPDATE device_codes
           SET provider = ?, state = ?, verifier = ?,
               account_id = NULL, confirm_token = NULL
-        WHERE user_code = ? AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
+        WHERE user_code = ? AND confirm_token IS NULL
+          AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
         RETURNING user_code`,
     )
     .bind(provider, state, verifier, userCode, nowMs)

--- a/src/db.ts
+++ b/src/db.ts
@@ -1019,6 +1019,14 @@ export async function recordDevicePoll(
     .run();
 }
 
+/** What became of a poll that arrived at an approved code. */
+export type TokenCollection =
+  | { status: "issued"; label: string | null }
+  /** The account is at `MAX_TOKENS_PER_ACCOUNT`. The code is left collectable. */
+  | { status: "at_capacity" }
+  /** Another poll collected it first, so there is nothing left to collect. */
+  | { status: "gone" };
+
 /**
  * Issue the token an approved code earned, and consume the code doing it.
  *
@@ -1040,14 +1048,30 @@ export async function recordDevicePoll(
  * been collected is gone, and a second poll with it gets exactly what a poll
  * with an expired code gets.
  *
- * @returns the label the token carries, or null when there was nothing to
- *   collect
+ * The account's ceiling is a predicate on the insert rather than a count read
+ * before it, for the reason `insertDocWithinQuota` gives: two approvals
+ * collected at the same moment would otherwise both read the same number and
+ * both insert, and a cap the list depends on being complete has to behave like
+ * a hard number under the concurrency an agent produces.
+ *
+ * The delete keys off the token row the insert left behind rather than
+ * restating that ceiling. Restating it would be wrong in a way that is easy to
+ * miss: the statements run in order inside the batch, so by the time the delete
+ * is evaluated the count already includes the row just inserted, and an
+ * off-by-one there would consume a device code without issuing anything. Keying
+ * off the row means the code survives exactly when nothing was issued, so a
+ * caller refused by the ceiling can revoke a token and poll again with the same
+ * code.
+ *
+ * @param maxTokens live tokens the account may hold, from
+ *   `MAX_TOKENS_PER_ACCOUNT`
  */
 export async function collectDeviceToken(
   db: D1Database,
   deviceCodeHash: string,
   token: Pick<TokenRow, "id" | "token_hash" | "created_at">,
-): Promise<{ label: string | null } | null> {
+  maxTokens: number,
+): Promise<TokenCollection> {
   const [issued] = await db.batch<{ label: string | null }>([
     db
       .prepare(
@@ -1055,19 +1079,31 @@ export async function collectDeviceToken(
          SELECT ?, ?, account_id, label, ?
            FROM device_codes
           WHERE device_code_hash = ? AND approved_at IS NOT NULL AND account_id IS NOT NULL
+            AND (SELECT COUNT(*) FROM tokens
+                  WHERE account_id = device_codes.account_id AND revoked_at IS NULL) < ?
          RETURNING label`,
       )
-      .bind(token.id, token.token_hash, token.created_at, deviceCodeHash),
+      .bind(token.id, token.token_hash, token.created_at, deviceCodeHash, maxTokens),
     db
       .prepare(
         `DELETE FROM device_codes
-          WHERE device_code_hash = ? AND approved_at IS NOT NULL AND account_id IS NOT NULL`,
+          WHERE device_code_hash = ? AND EXISTS (SELECT 1 FROM tokens WHERE id = ?)`,
       )
-      .bind(deviceCodeHash),
+      .bind(deviceCodeHash, token.id),
   ]);
 
   const row = issued?.results[0];
-  return row === undefined ? null : { label: row.label };
+  if (row !== undefined) return { status: "issued", label: row.label };
+
+  // Nothing was issued, and the surviving row is what says why: the delete only
+  // fires when the insert did, so a code still here was refused by the ceiling
+  // and a code that is gone was collected by somebody else.
+  const remaining = await db
+    .prepare("SELECT 1 FROM device_codes WHERE device_code_hash = ? AND approved_at IS NOT NULL")
+    .bind(deviceCodeHash)
+    .first();
+
+  return remaining === null ? { status: "gone" } : { status: "at_capacity" };
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -87,12 +87,14 @@ export interface IdentityRow {
 }
 
 /**
- * A device code the CLI is polling, and the OAuth handshake proving who is
+ * A device code a terminal is polling, and the OAuth handshake proving who is
  * approving it.
  *
- * **#57 owns the device flow and extends this table.** The columns here are
- * only the ones approval reads and writes; the device code itself, its token
- * and the machine label belong to that issue.
+ * One row carries three lifetimes that overlap: the code itself, which lives
+ * until it is collected or expires; a handshake, which lives from a provider
+ * button to the confirmation page; and the outcome, which is an approval, a
+ * refusal, or neither. Every column that is null between handshakes is null
+ * because the handshake that set it is over.
  */
 export interface DeviceCodeRow {
   /** Uppercase, as `normalizeUserCode` folds it. */
@@ -113,12 +115,46 @@ export interface DeviceCodeRow {
   account_id: string | null;
   /** Epoch ms of the human's approval, and null until it is given. */
   approved_at: number | null;
+  /** SHA-256 of the device code the terminal polls with. Never the raw value. */
+  device_code_hash: string | null;
+  /** What the terminal called itself when it asked for the code. */
+  label: string | null;
+  /** Epoch ms of a refusal on the approval page, and null until one is given. */
+  denied_at: number | null;
+  /** Epoch ms of the terminal's last poll, which `slow_down` is measured from. */
+  last_polled_at: number | null;
   expires_at: number;
   created_at: number;
 }
 
-/** The half of a pending handshake the callback needs to finish it. */
-export type PendingHandshake = Pick<DeviceCodeRow, "user_code" | "provider" | "verifier">;
+/**
+ * The half of a pending handshake the callback needs to finish it. The label
+ * rides along so the confirmation page can name the machine being approved
+ * instead of calling it "that terminal".
+ */
+export type PendingHandshake = Pick<
+  DeviceCodeRow,
+  "user_code" | "provider" | "verifier" | "label"
+>;
+
+/**
+ * A token an approval issued.
+ *
+ * The value itself is not here and cannot be: only `token_hash` is stored, and
+ * the raw token exists once, in the response to the poll that collected it.
+ */
+export interface TokenRow {
+  id: string;
+  token_hash: string;
+  account_id: string;
+  label: string | null;
+  created_at: number;
+  last_used_at: number | null;
+  revoked_at: number | null;
+}
+
+/** A live token as `GET /api/v1/tokens` reports it. The hash never leaves D1. */
+export type ListedTokenRow = Pick<TokenRow, "id" | "label" | "created_at" | "last_used_at">;
 
 /**
  * The publisher row as auth needs it: read the cached validation, write it back
@@ -679,7 +715,7 @@ export async function deviceCodeIsPending(
   const row = await db
     .prepare(
       `SELECT 1 FROM device_codes
-        WHERE user_code = ? AND approved_at IS NULL AND expires_at > ?`,
+        WHERE user_code = ? AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?`,
     )
     .bind(userCode, nowMs)
     .first();
@@ -719,7 +755,7 @@ export async function startDeviceHandshake(
       `UPDATE device_codes
           SET provider = ?, state = ?, verifier = ?,
               account_id = NULL, confirm_token = NULL
-        WHERE user_code = ? AND approved_at IS NULL AND expires_at > ?
+        WHERE user_code = ? AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
         RETURNING user_code`,
     )
     .bind(provider, state, verifier, userCode, nowMs)
@@ -745,8 +781,8 @@ export async function findPendingHandshake(
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT user_code, provider, verifier FROM device_codes
-        WHERE state = ? AND approved_at IS NULL AND expires_at > ?`,
+      `SELECT user_code, provider, verifier, label FROM device_codes
+        WHERE state = ? AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?`,
     )
     .bind(state, nowMs)
     .first<PendingHandshake>();
@@ -798,6 +834,7 @@ export async function holdProvenIdentity(
         WHERE state = ?
           AND verifier IS NOT NULL
           AND approved_at IS NULL
+          AND denied_at IS NULL
           AND expires_at > ?
         RETURNING user_code`,
     )
@@ -836,6 +873,7 @@ export async function confirmDeviceApproval(
           SET approved_at = ?, state = NULL, confirm_token = NULL
         WHERE confirm_token = ?
           AND approved_at IS NULL
+          AND denied_at IS NULL
           AND account_id IS NOT NULL
           AND expires_at > ?
         RETURNING user_code`,
@@ -844,4 +882,340 @@ export async function confirmDeviceApproval(
     .first<{ user_code: string }>();
 
   return approved?.user_code ?? null;
+}
+
+/**
+ * Refuse the device code a proven handshake belongs to, returning the code
+ * refused or null when there is nothing to refuse.
+ *
+ * The mirror image of `confirmDeviceApproval`, and it exists for the attack
+ * that split confirmation into two steps in the first place. Someone who lands
+ * on a confirmation page for a terminal that is not theirs — the RFC 8628 §5.4
+ * case — can close the tab and let the code expire, but that leaves the
+ * attacker's code live for the rest of its lifetime. This ends it now, and the
+ * terminal polling it is told `access_denied` rather than waiting out the
+ * expiry for news.
+ *
+ * Keyed on the confirm token for the same reason the approval is: only the
+ * token is a secret from whoever started the handshake, so only the browser
+ * that completed it can press either button.
+ */
+export async function denyDeviceApproval(
+  db: D1Database,
+  confirmToken: string,
+  atMs: number,
+): Promise<string | null> {
+  const denied = await db
+    .prepare(
+      `UPDATE device_codes
+          SET denied_at = ?, state = NULL, confirm_token = NULL, verifier = NULL
+        WHERE confirm_token = ?
+          AND approved_at IS NULL
+          AND denied_at IS NULL
+          AND expires_at > ?
+        RETURNING user_code`,
+    )
+    .bind(atMs, confirmToken, atMs)
+    .first<{ user_code: string }>();
+
+  return denied?.user_code ?? null;
+}
+
+/**
+ * Put a freshly minted code in the table, or answer false when its user code is
+ * already taken.
+ *
+ * `user_code` is the primary key, so a collision is a refused insert rather than
+ * an overwrite — which is the safe direction: overwriting would point a waiting
+ * terminal's code at a different device code, and the approval a person then
+ * gave would land on somebody else's terminal. The caller redraws instead.
+ *
+ * Eight characters of a twenty-letter alphabet against the handful of codes
+ * alive at once makes a collision vanishingly rare; the sweep is what keeps it
+ * that way, since a code that is never deleted is a code that can never be
+ * drawn again.
+ */
+export async function insertDeviceCode(
+  db: D1Database,
+  code: Pick<
+    DeviceCodeRow,
+    "user_code" | "device_code_hash" | "label" | "expires_at" | "created_at"
+  >,
+): Promise<boolean> {
+  const inserted = await db
+    .prepare(
+      `INSERT INTO device_codes (user_code, device_code_hash, label, expires_at, created_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT DO NOTHING
+       RETURNING user_code`,
+    )
+    .bind(code.user_code, code.device_code_hash, code.label, code.expires_at, code.created_at)
+    .first<{ user_code: string }>();
+
+  return inserted !== null;
+}
+
+/**
+ * Delete every device code that has expired, and every rate-limit window that
+ * has closed.
+ *
+ * **`user_code` is the primary key, so this is what makes a code reusable.**
+ * Without it, the twenty-letter alphabet would be drawing against every code
+ * ever issued rather than the few alive right now, and `insertDeviceCode` would
+ * start refusing draws for codes nobody is waiting on.
+ *
+ * It runs on the mint path rather than on a cron trigger, because minting is
+ * the only thing that creates these rows and the only thing that needs a free
+ * code — so the sweep is exactly co-located with the need, and a deployment
+ * that never mints never accumulates anything to sweep. A cron trigger would be
+ * a second deployment concern and a scheduled handler to maintain for work one
+ * indexed delete does in the request that cares about it.
+ *
+ * An expired code that was approved but never collected takes its token with
+ * it. The token was minted for a terminal that never came back for it, so
+ * nobody holds the value and leaving the row would put a live credential in the
+ * account's token list that its owner could not explain.
+ */
+export async function sweepExpired(db: D1Database, nowMs: number, windowMs: number): Promise<void> {
+  await db.batch([
+    db.prepare("DELETE FROM device_codes WHERE expires_at <= ?").bind(nowMs),
+    db
+      .prepare("DELETE FROM device_code_requests WHERE window_start <= ?")
+      .bind(nowMs - windowMs),
+  ]);
+}
+
+/**
+ * Claim one of a client's device-code mints for the current window, returning
+ * false when it has none left.
+ *
+ * Claim rather than check, exactly as `reserveDailyPush` does and for the same
+ * reason: the count is read and incremented by one statement, so a burst of
+ * concurrent requests cannot all see the same number and all proceed. The
+ * `WHERE` on the update branch is the limit; when it fails, `RETURNING` yields
+ * nothing and that is the refusal.
+ *
+ * @param client an opaque bucket for the caller, which `deviceClientBucket`
+ *   makes by hashing the client address — a thing to count against rather than
+ *   a record of who visited
+ * @param windowStart epoch ms of the start of the fixed window being counted
+ */
+export async function claimDeviceMint(
+  db: D1Database,
+  client: string,
+  windowStart: number,
+  limit: number,
+): Promise<boolean> {
+  const claimed = await db
+    .prepare(
+      `INSERT INTO device_code_requests (client, window_start, requests) VALUES (?, ?, 1)
+       ON CONFLICT(client, window_start) DO UPDATE SET requests = device_code_requests.requests + 1
+         WHERE device_code_requests.requests < ?
+       RETURNING requests`,
+    )
+    .bind(client, windowStart, limit)
+    .first<{ requests: number }>();
+
+  return claimed !== null;
+}
+
+/** What a poll needs to decide what to tell the terminal. */
+export type PolledDeviceCode = Pick<
+  DeviceCodeRow,
+  "user_code" | "approved_at" | "denied_at" | "expires_at" | "last_polled_at"
+>;
+
+/**
+ * Find the code a poll is asking about, by the hash of the device code it
+ * presented.
+ *
+ * The device code is the lookup key rather than the user code because it is the
+ * half the terminal keeps to itself. A user code is read aloud and typed into
+ * phones; if it could collect a token, every approval page would be showing the
+ * credential to the room.
+ */
+export async function findPolledDeviceCode(
+  db: D1Database,
+  deviceCodeHash: string,
+): Promise<PolledDeviceCode | null> {
+  // `return await`: see the note on the router's catch in index.ts.
+  return await db
+    .prepare(
+      `SELECT user_code, approved_at, denied_at, expires_at, last_polled_at
+         FROM device_codes WHERE device_code_hash = ?`,
+    )
+    .bind(deviceCodeHash)
+    .first<PolledDeviceCode>();
+}
+
+/** Record that the terminal polled, which is what the next `slow_down` is measured from. */
+export async function recordDevicePoll(
+  db: D1Database,
+  deviceCodeHash: string,
+  atMs: number,
+): Promise<void> {
+  await db
+    .prepare("UPDATE device_codes SET last_polled_at = ? WHERE device_code_hash = ?")
+    .bind(atMs, deviceCodeHash)
+    .run();
+}
+
+/**
+ * Issue the token an approved code earned, and consume the code doing it.
+ *
+ * **The token is minted here rather than when the person presses Approve**, and
+ * that ordering is the whole reason a raw token never touches the database. If
+ * approval issued it, the value would have to sit in a column until the
+ * terminal came back for it — a bearer credential at rest, and one left behind
+ * as a live token nobody holds whenever the terminal never comes back.
+ * Minting on collection means a token exists exactly when someone holds it.
+ *
+ * Both statements are one D1 batch, which is one transaction. The insert is
+ * predicated on the code being approved and the delete on the same condition,
+ * so a poll that arrives before the approval changes nothing, and two polls
+ * that arrive together cannot both collect: the second finds no row and
+ * inserts nothing.
+ *
+ * Deleting the code rather than marking it spent is also what makes a replay
+ * answer honestly. There is no third state to explain — a device code that has
+ * been collected is gone, and a second poll with it gets exactly what a poll
+ * with an expired code gets.
+ *
+ * @returns the label the token carries, or null when there was nothing to
+ *   collect
+ */
+export async function collectDeviceToken(
+  db: D1Database,
+  deviceCodeHash: string,
+  token: Pick<TokenRow, "id" | "token_hash" | "created_at">,
+): Promise<{ label: string | null } | null> {
+  const [issued] = await db.batch<{ label: string | null }>([
+    db
+      .prepare(
+        `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
+         SELECT ?, ?, account_id, label, ?
+           FROM device_codes
+          WHERE device_code_hash = ? AND approved_at IS NOT NULL AND account_id IS NOT NULL
+         RETURNING label`,
+      )
+      .bind(token.id, token.token_hash, token.created_at, deviceCodeHash),
+    db
+      .prepare(
+        `DELETE FROM device_codes
+          WHERE device_code_hash = ? AND approved_at IS NOT NULL AND account_id IS NOT NULL`,
+      )
+      .bind(deviceCodeHash),
+  ]);
+
+  const row = issued?.results[0];
+  return row === undefined ? null : { label: row.label };
+}
+
+/**
+ * The account behind a token, or null when the token is unknown or revoked.
+ *
+ * Looked up by hash, like a license key, so the value the caller sent is never
+ * compared against anything stored — there is nothing stored to compare it to.
+ * A revoked token keeps its row so that its hash stays taken and it goes on
+ * failing; deleting the row would leave nothing for the next request to fail
+ * against, and the same value could in principle be minted again.
+ */
+export async function findLiveToken(
+  db: D1Database,
+  tokenHash: string,
+): Promise<Pick<TokenRow, "id" | "account_id" | "last_used_at"> | null> {
+  // `return await`: see the note on the router's catch in index.ts.
+  return await db
+    .prepare(
+      `SELECT id, account_id, last_used_at FROM tokens
+        WHERE token_hash = ? AND revoked_at IS NULL`,
+    )
+    .bind(tokenHash)
+    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at">>();
+}
+
+/**
+ * Move a token's `last_used_at` forward, but only when it is already stale.
+ *
+ * The predicate is what keeps this off the hot path: without it every
+ * authenticated request — including every read — would carry a D1 write. The
+ * column answers "which of my machines is still using this", and an hour's
+ * resolution answers that as well as a millisecond's would.
+ *
+ * @param staleBefore the timestamp a recorded use has to predate to be worth
+ *   rewriting, which the caller derives from `TOKEN_LAST_USED_RESOLUTION_MS`
+ */
+export async function touchTokenUse(
+  db: D1Database,
+  id: string,
+  atMs: number,
+  staleBefore: number,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE tokens SET last_used_at = ?
+        WHERE id = ? AND (last_used_at IS NULL OR last_used_at < ?)`,
+    )
+    .bind(atMs, id, staleBefore)
+    .run();
+}
+
+/** The live tokens on an account, newest first. Values and hashes stay in D1. */
+export async function listAccountTokens(
+  db: D1Database,
+  accountId: string,
+  limit: number,
+): Promise<ListedTokenRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT id, label, created_at, last_used_at FROM tokens
+        WHERE account_id = ? AND revoked_at IS NULL
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?`,
+    )
+    .bind(accountId, limit)
+    .all<ListedTokenRow>();
+
+  return results;
+}
+
+/**
+ * Revoke one of an account's tokens, answering false when it has no such live
+ * token.
+ *
+ * The account is a predicate on the write rather than a check before it, which
+ * is what makes another account's token indistinguishable from one that never
+ * existed — the 404-never-403 rule the doc endpoints follow, applied to the one
+ * other thing this API can name.
+ *
+ * Revoking twice answers false the second time, like deleting a doc twice
+ * answers 404. What repeats safely is the outcome: the token is dead either
+ * way.
+ */
+export async function revokeAccountToken(
+  db: D1Database,
+  id: string,
+  accountId: string,
+  atMs: number,
+): Promise<boolean> {
+  const revoked = await db
+    .prepare(
+      `UPDATE tokens SET revoked_at = ?
+        WHERE id = ? AND account_id = ? AND revoked_at IS NULL
+        RETURNING id`,
+    )
+    .bind(atMs, id, accountId)
+    .first<{ id: string }>();
+
+  return revoked !== null;
+}
+
+/** Live tokens an account still holds, which is what a revoke reports back. */
+export async function countLiveTokens(db: D1Database, accountId: string): Promise<number> {
+  const row = await db
+    .prepare("SELECT COUNT(*) AS n FROM tokens WHERE account_id = ? AND revoked_at IS NULL")
+    .bind(accountId)
+    .first<{ n: number }>();
+
+  return row?.n ?? 0;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1048,10 +1048,12 @@ export async function findPolledDeviceCode(
  * engine.
  *
  * The eviction carries the same predicates as the insert, so a poll at a code
- * nobody has approved revokes nothing. The ceiling stays a predicate on the
- * insert as well, which is what makes it hold under concurrent collections:
- * two approvals collected at the same moment cannot both read the same count
- * and both insert.
+ * nobody has approved or whose deadline passed deletes nothing. Expiry is
+ * checked against the token's fresh creation time inside both statements, so a
+ * request delayed between its state read and this batch cannot redeem a stale
+ * code. The ceiling stays a predicate on the insert as well, which is what makes
+ * it hold under concurrent collections: two approvals collected at the same
+ * moment cannot both read the same count and both insert.
  *
  * The delete keys off the token row the insert left behind rather than
  * restating that ceiling. Restating it would be wrong in a way that is easy to
@@ -1080,24 +1082,33 @@ export async function collectDeviceToken(
               JOIN device_codes code ON code.account_id = victim.account_id
              WHERE code.device_code_hash = ?
                AND code.approved_at IS NOT NULL
+               AND code.expires_at > ?
                AND (SELECT COUNT(*) FROM tokens live
                      WHERE live.account_id = code.account_id) >= ?
              ORDER BY victim.last_used_at ASC NULLS FIRST, victim.created_at ASC, victim.id ASC
              LIMIT 1
           )`,
       )
-      .bind(deviceCodeHash, maxTokens),
+      .bind(deviceCodeHash, token.created_at, maxTokens),
     db
       .prepare(
         `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
          SELECT ?, ?, account_id, label, ?
            FROM device_codes
           WHERE device_code_hash = ? AND approved_at IS NOT NULL AND account_id IS NOT NULL
+            AND expires_at > ?
             AND (SELECT COUNT(*) FROM tokens
                   WHERE account_id = device_codes.account_id) < ?
          RETURNING label`,
       )
-      .bind(token.id, token.token_hash, token.created_at, deviceCodeHash, maxTokens),
+      .bind(
+        token.id,
+        token.token_hash,
+        token.created_at,
+        deviceCodeHash,
+        token.created_at,
+        maxTokens,
+      ),
     db
       .prepare(
         `DELETE FROM device_codes

--- a/src/db.ts
+++ b/src/db.ts
@@ -981,42 +981,77 @@ export async function sweepExpired(db: D1Database, nowMs: number): Promise<void>
 /** What a poll needs to decide what to tell the terminal. */
 export type PolledDeviceCode = Pick<
   DeviceCodeRow,
-  "user_code" | "approved_at" | "denied_at" | "expires_at" | "last_polled_at"
+  "user_code" | "approved_at" | "denied_at" | "expires_at"
 >;
 
+/** The outcome of asking for this interval's poll. */
+export interface DevicePoll {
+  /** The code as it stands, or null when no code answers to that hash. */
+  code: PolledDeviceCode | null;
+  /**
+   * Whether this request is the one poll this interval serves. False means
+   * another already had it, which is what `slow_down` reports.
+   */
+  claimed: boolean;
+}
+
 /**
- * Find the code a poll is asking about, by the hash of the device code it
- * presented.
+ * Claim this interval's poll for one device code, and read the code's state in
+ * the same round trip.
+ *
+ * **Claim rather than check.** Reading `last_polled_at` and then writing it
+ * cannot enforce an interval at all: overlapping polls all read the same value,
+ * none of them sees one too recent, and every one of them proceeds and writes.
+ * A client holding a single legitimately minted code could then fire concurrent
+ * bursts for the whole of that code's lifetime and turn the interval check into
+ * a source of unbounded writes — which is the one thing the interval exists to
+ * bound. The predicate rides on the `UPDATE`, so exactly one poll per interval
+ * wins it and the rest are told to slow down (
+ * https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928181821).
+ * `holdProvenIdentity` above is the same shape for the same reason.
+ *
+ * An expired or refused code is never claimed, so polling one writes nothing at
+ * all rather than once an interval until the sweep reaches it. The `SELECT`
+ * beside it is what tells those two apart from a hash no row answers to: all
+ * three fail to claim, and only the row says which happened.
  *
  * The device code is the lookup key rather than the user code because it is the
  * half the terminal keeps to itself. A user code is read aloud and typed into
  * phones; if it could collect a token, every approval page would be showing the
  * credential to the room.
+ *
+ * @param minGapMs how close to the previous served poll is too close, from
+ *   `MIN_DEVICE_POLL_GAP_MS`
  */
-export async function findPolledDeviceCode(
+export async function claimDevicePoll(
   db: D1Database,
   deviceCodeHash: string,
-): Promise<PolledDeviceCode | null> {
-  // `return await`: see the note on the router's catch in index.ts.
-  return await db
-    .prepare(
-      `SELECT user_code, approved_at, denied_at, expires_at, last_polled_at
-         FROM device_codes WHERE device_code_hash = ?`,
-    )
-    .bind(deviceCodeHash)
-    .first<PolledDeviceCode>();
-}
+  nowMs: number,
+  minGapMs: number,
+): Promise<DevicePoll> {
+  const [claimed, current] = await db.batch<PolledDeviceCode>([
+    db
+      .prepare(
+        `UPDATE device_codes SET last_polled_at = ?
+          WHERE device_code_hash = ?
+            AND expires_at > ?
+            AND denied_at IS NULL
+            AND (last_polled_at IS NULL OR last_polled_at <= ?)
+         RETURNING user_code, approved_at, denied_at, expires_at`,
+      )
+      .bind(nowMs, deviceCodeHash, nowMs, nowMs - minGapMs),
+    db
+      .prepare(
+        `SELECT user_code, approved_at, denied_at, expires_at
+           FROM device_codes WHERE device_code_hash = ?`,
+      )
+      .bind(deviceCodeHash),
+  ]);
 
-/** Record that the terminal polled, which is what the next `slow_down` is measured from. */
-export async function recordDevicePoll(
-  db: D1Database,
-  deviceCodeHash: string,
-  atMs: number,
-): Promise<void> {
-  await db
-    .prepare("UPDATE device_codes SET last_polled_at = ? WHERE device_code_hash = ?")
-    .bind(atMs, deviceCodeHash)
-    .run();
+  return {
+    code: current?.results[0] ?? null,
+    claimed: (claimed?.results.length ?? 0) > 0,
+  };
 }
 
 /** What became of a poll that arrived at an approved code. */

--- a/src/db.ts
+++ b/src/db.ts
@@ -956,8 +956,7 @@ export async function insertDeviceCode(
 }
 
 /**
- * Delete every device code that has expired, and every rate-limit window that
- * has closed.
+ * Delete every device code that has expired.
  *
  * **`user_code` is the primary key, so this is what makes a code reusable.**
  * Without it, the twenty-letter alphabet would be drawing against every code
@@ -971,52 +970,12 @@ export async function insertDeviceCode(
  * a second deployment concern and a scheduled handler to maintain for work one
  * indexed delete does in the request that cares about it.
  *
- * An expired code that was approved but never collected takes its token with
- * it. The token was minted for a terminal that never came back for it, so
- * nobody holds the value and leaving the row would put a live credential in the
- * account's token list that its owner could not explain.
+ * An approved code that is never collected takes nothing with it, because a
+ * token is minted by the poll that collects one. There is no such thing here as
+ * a credential nobody holds.
  */
-export async function sweepExpired(db: D1Database, nowMs: number, windowMs: number): Promise<void> {
-  await db.batch([
-    db.prepare("DELETE FROM device_codes WHERE expires_at <= ?").bind(nowMs),
-    db
-      .prepare("DELETE FROM device_code_requests WHERE window_start <= ?")
-      .bind(nowMs - windowMs),
-  ]);
-}
-
-/**
- * Claim one of a client's device-code mints for the current window, returning
- * false when it has none left.
- *
- * Claim rather than check, exactly as `reserveDailyPush` does and for the same
- * reason: the count is read and incremented by one statement, so a burst of
- * concurrent requests cannot all see the same number and all proceed. The
- * `WHERE` on the update branch is the limit; when it fails, `RETURNING` yields
- * nothing and that is the refusal.
- *
- * @param client an opaque bucket for the caller, which `deviceClientBucket`
- *   makes by hashing the client address — a thing to count against rather than
- *   a record of who visited
- * @param windowStart epoch ms of the start of the fixed window being counted
- */
-export async function claimDeviceMint(
-  db: D1Database,
-  client: string,
-  windowStart: number,
-  limit: number,
-): Promise<boolean> {
-  const claimed = await db
-    .prepare(
-      `INSERT INTO device_code_requests (client, window_start, requests) VALUES (?, ?, 1)
-       ON CONFLICT(client, window_start) DO UPDATE SET requests = device_code_requests.requests + 1
-         WHERE device_code_requests.requests < ?
-       RETURNING requests`,
-    )
-    .bind(client, windowStart, limit)
-    .first<{ requests: number }>();
-
-  return claimed !== null;
+export async function sweepExpired(db: D1Database, nowMs: number): Promise<void> {
+  await db.prepare("DELETE FROM device_codes WHERE expires_at <= ?").bind(nowMs).run();
 }
 
 /** What a poll needs to decide what to tell the terminal. */

--- a/src/device.ts
+++ b/src/device.ts
@@ -40,6 +40,7 @@ import { claimDevicePoll, collectDeviceToken, insertDeviceCode, sweepExpired } f
 import { errorResponse } from "./errors.js";
 import { sha256Hex } from "./hash.js";
 import { newApiToken, newDeviceCode, newTokenId, newUserCode } from "./ids.js";
+import { withinClientLimit } from "./limits.js";
 import { readBodyWithin } from "./quota.js";
 
 /** Path prefix of the device surface, used by the router on the API host. */
@@ -95,9 +96,6 @@ const USER_CODE_ATTEMPTS = 3;
  * headers is a simple request too.
  */
 const JSON_CONTENT_TYPE = "application/json";
-
-/** Bucket a request with no client address falls into. */
-const ANONYMOUS_CLIENT = "anonymous";
 
 /**
  * Everything a terminal could hide in a label that a terminal would then act
@@ -187,8 +185,7 @@ async function mint(
   if (label === undefined) return badRequest("`label` must be a string.");
 
   const limiter = deps.limiter ?? env.DEVICE_CODE_LIMITER;
-  const key = await deviceClientBucket(request);
-  if (limiter !== undefined && !(await limiter.limit({ key })).success) {
+  if (!(await withinClientLimit(limiter, request))) {
     // `Retry-After` is the limiter's whole window, because the binding reports
     // a verdict and nothing else: no reset time, no remaining count. Telling
     // the caller to wait the full period is the only honest number available,
@@ -405,16 +402,3 @@ async function claimUserCode(
   return null;
 }
 
-/**
- * The key a mint is counted against.
- *
- * The client's address, hashed. Hashed because it is a bucket to count against
- * rather than a record of who visited: nothing here ever needs to read an
- * address back, and the limiter only ever compares keys for equality. Where the
- * platform reports no address — local development, and the tests — every caller
- * shares one key, which is the safe direction for a limit.
- */
-async function deviceClientBucket(request: Request): Promise<string> {
-  const address = request.headers.get("cf-connecting-ip")?.trim();
-  return await sha256Hex(address === undefined || address === "" ? ANONYMOUS_CLIENT : address);
-}

--- a/src/device.ts
+++ b/src/device.ts
@@ -97,10 +97,12 @@ const USER_CODE_ATTEMPTS = 3;
 const JSON_CONTENT_TYPE = "application/json";
 
 /**
- * Everything a terminal could hide in a label that a terminal would then act
- * on: newlines, and the escape that starts an ANSI sequence.
+ * Everything a terminal could hide in a label that could alter the question a
+ * person sees: terminal controls, and Unicode bidirectional controls that HTML
+ * escaping does not neutralize.
  */
-const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/gu;
+const TERMINAL_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/gu;
+const BIDI_CONTROL_CHARACTERS = /\p{Bidi_Control}/gu;
 
 export interface DeviceDeps {
   now?: () => number;
@@ -363,10 +365,10 @@ async function readJsonBody(request: Request): Promise<Record<string, unknown> |
  * one.
  *
  * Control characters go before anything else, because this string is rendered
- * on the approval page and printed in CLI output: a newline or an escape
- * sequence in it would let a terminal's chosen name draw over the question the
- * person is being asked. Blank after that means the caller effectively sent
- * none, and the page falls back to its own words.
+ * on the approval page and printed in CLI output. Newlines and escape sequences
+ * can draw over the question; Unicode bidi controls can reorder it even after
+ * HTML escaping. Natural RTL letters remain intact and the page isolates them
+ * when rendered. Blank after cleaning means the caller effectively sent none.
  *
  * @param raw the `label` field exactly as it arrived, which may be anything
  */
@@ -374,7 +376,11 @@ export function readDeviceLabel(raw: unknown): string | null | undefined {
   if (raw === undefined || raw === null) return null;
   if (typeof raw !== "string") return undefined;
 
-  const cleaned = raw.replace(CONTROL_CHARACTERS, " ").trim().slice(0, MAX_LABEL_LENGTH);
+  const cleaned = raw
+    .replace(TERMINAL_CONTROL_CHARACTERS, " ")
+    .replace(BIDI_CONTROL_CHARACTERS, "")
+    .trim()
+    .slice(0, MAX_LABEL_LENGTH);
   return cleaned === "" ? null : cleaned;
 }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -255,7 +255,7 @@ interface IssuedToken {
  * transactional collection below still makes token issue exclusive.
  */
 async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Response> {
-  const now = (deps.now ?? Date.now)();
+  const clock = deps.now ?? Date.now;
 
   const body = await readJsonBody(request);
   if (body === null) {
@@ -276,11 +276,15 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
     );
   }
 
+  // Read the clock after the streaming body and limiter have completed. A
+  // caller that begins before expiry but delays its body must not preserve the
+  // earlier request-start time and redeem a code after its deadline.
+  const checkedAt = clock();
   const code = await findPolledDeviceCode(env.DB, deviceCodeHash);
 
   // Unknown, already collected, or swept — one answer for all three. A
   // collected code is deleted rather than marked spent, so a replay lands here.
-  if (code === null || code.expires_at <= now) {
+  if (code === null || code.expires_at <= checkedAt) {
     return device("expired_token", "That sign-in has expired. Start again.");
   }
   if (code.denied_at !== null) {
@@ -292,10 +296,15 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
 
   const token = newApiToken();
   const tokenId = newTokenId();
+  const tokenHash = await sha256Hex(token);
+  // Fresh again immediately before the transaction. The transaction repeats
+  // the expiry predicate with this timestamp, so expiry after the read above
+  // cannot issue a token or evict an existing one.
+  const collectedAt = clock();
   const issued = await collectDeviceToken(
     env.DB,
     deviceCodeHash,
-    { id: tokenId, token_hash: await sha256Hex(token), created_at: now },
+    { id: tokenId, token_hash: tokenHash, created_at: collectedAt },
     MAX_TOKENS_PER_ACCOUNT,
   );
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -101,7 +101,7 @@ const JSON_CONTENT_TYPE = "application/json";
  * person sees: terminal controls, and Unicode bidirectional controls that HTML
  * escaping does not neutralize.
  */
-const TERMINAL_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/gu;
+const TERMINAL_CONTROL_CHARACTERS = /\p{Cc}/gu;
 const BIDI_CONTROL_CHARACTERS = /\p{Bidi_Control}/gu;
 
 export interface DeviceDeps {

--- a/src/device.ts
+++ b/src/device.ts
@@ -21,18 +21,21 @@
  * carries one. The mint is rate limited per client address instead, because an
  * endpoint that produces approval urls is an endpoint someone would otherwise
  * use to send people approval urls.
+ *
+ * That limit is a Workers rate limiter binding rather than a counter in D1. A
+ * counter in a row costs a write for every attempt including the refused ones,
+ * so under sustained abuse the limiter would be what exhausts a self-hoster's
+ * daily write budget — the endpoint's own defence paying the attacker's bill.
  */
 import {
   DEVICE_CODE_TTL_MS,
-  DEVICE_MINT_WINDOW_MS,
+  DEVICE_MINT_PERIOD_SECONDS,
   DEVICE_POLL_INTERVAL_SECONDS,
-  MAX_DEVICE_MINTS_PER_WINDOW,
   MIN_DEVICE_POLL_GAP_MS,
   type Env,
 } from "./config.js";
 import { APPROVAL_PREFIX, USER_CODE_PARAM } from "./approval/handler.js";
 import {
-  claimDeviceMint,
   collectDeviceToken,
   findPolledDeviceCode,
   insertDeviceCode,
@@ -90,6 +93,11 @@ const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/gu;
 
 export interface DeviceDeps {
   now?: () => number;
+  /**
+   * Injected by tests that need a limiter a deployment has not declared, or a
+   * verdict they choose. Production always reads `env.DEVICE_CODE_LIMITER`.
+   */
+  limiter?: RateLimit;
 }
 
 /**
@@ -134,10 +142,13 @@ interface DeviceAuthorization {
 /**
  * `POST /device/code` — mint a code for a terminal that has no credential.
  *
- * The order is deliberate. The rate limit is claimed before anything else, so a
- * refused caller costs one write and never reaches the sweep or a draw; the
- * sweep runs next, because a user code cannot be reused until the row holding
- * it is gone and minting is the only thing that needs one free.
+ * The order is deliberate. The rate limit is asked first, so a refused caller
+ * touches no storage at all; the sweep runs next, because a user code cannot be
+ * reused until the row holding it is gone and minting is the only thing that
+ * needs one free.
+ *
+ * A deployment that declares no limiter mints freely. That is a supported
+ * deployment, not a hole to close: see `Env.DEVICE_CODE_LIMITER`.
  */
 async function mint(
   request: Request,
@@ -147,14 +158,17 @@ async function mint(
 ): Promise<Response> {
   const now = (deps.now ?? Date.now)();
 
-  const client = await deviceClientBucket(request);
-  const windowStart = Math.floor(now / DEVICE_MINT_WINDOW_MS) * DEVICE_MINT_WINDOW_MS;
-  if (!(await claimDeviceMint(env.DB, client, windowStart, MAX_DEVICE_MINTS_PER_WINDOW))) {
-    const retryAfter = Math.ceil((windowStart + DEVICE_MINT_WINDOW_MS - now) / 1000);
+  const limiter = deps.limiter ?? env.DEVICE_CODE_LIMITER;
+  const key = await deviceClientBucket(request);
+  if (limiter !== undefined && !(await limiter.limit({ key })).success) {
+    // `Retry-After` is the limiter's whole window, because the binding reports
+    // a verdict and nothing else: no reset time, no remaining count. Telling
+    // the caller to wait the full period is the only honest number available,
+    // and it is never an underestimate.
     return errorResponse(
       "quota_exceeded",
       "Too many sign-in codes from this address. Try again shortly.",
-      { "retry-after": String(retryAfter), "cache-control": "no-store" },
+      { "retry-after": String(DEVICE_MINT_PERIOD_SECONDS), "cache-control": "no-store" },
     );
   }
 
@@ -164,7 +178,7 @@ async function mint(
   const label = readDeviceLabel(body.label);
   if (label === undefined) return badRequest("`label` must be a string.");
 
-  await sweepExpired(env.DB, now, DEVICE_MINT_WINDOW_MS);
+  await sweepExpired(env.DB, now);
 
   const deviceCode = newDeviceCode();
   const deviceCodeHash = await sha256Hex(deviceCode);
@@ -345,13 +359,13 @@ async function claimUserCode(
 }
 
 /**
- * The bucket a mint is counted against.
+ * The key a mint is counted against.
  *
- * The client's address, hashed. Hashed because it is a counter key rather than
- * a record of who visited: nothing here ever needs to read an address back, and
- * a table of them is a table someone would eventually be right to ask about.
- * Where the platform reports no address — local development, and the tests —
- * every caller shares one bucket, which is the safe direction for a limit.
+ * The client's address, hashed. Hashed because it is a bucket to count against
+ * rather than a record of who visited: nothing here ever needs to read an
+ * address back, and the limiter only ever compares keys for equality. Where the
+ * platform reports no address — local development, and the tests — every caller
+ * shares one key, which is the safe direction for a limit.
  */
 async function deviceClientBucket(request: Request): Promise<string> {
   const address = request.headers.get("cf-connecting-ip")?.trim();

--- a/src/device.ts
+++ b/src/device.ts
@@ -401,4 +401,3 @@ async function claimUserCode(
   }
   return null;
 }
-

--- a/src/device.ts
+++ b/src/device.ts
@@ -32,15 +32,14 @@ import {
   DEVICE_MINT_PERIOD_SECONDS,
   DEVICE_POLL_INTERVAL_SECONDS,
   MAX_TOKENS_PER_ACCOUNT,
-  MIN_DEVICE_POLL_GAP_MS,
   type Env,
 } from "./config.js";
 import { APPROVAL_PREFIX, USER_CODE_PARAM } from "./approval/handler.js";
-import { claimDevicePoll, collectDeviceToken, insertDeviceCode, sweepExpired } from "./db.js";
+import { collectDeviceToken, findPolledDeviceCode, insertDeviceCode, sweepExpired } from "./db.js";
 import { errorResponse } from "./errors.js";
 import { sha256Hex } from "./hash.js";
 import { newApiToken, newDeviceCode, newTokenId, newUserCode } from "./ids.js";
-import { withinClientLimit } from "./limits.js";
+import { withinClientLimit, withinLimit } from "./limits.js";
 import { readBodyWithin } from "./quota.js";
 
 /** Path prefix of the device surface, used by the router on the API host. */
@@ -109,7 +108,9 @@ export interface DeviceDeps {
    * Injected by tests that need a limiter a deployment has not declared, or a
    * verdict they choose. Production always reads `env.DEVICE_CODE_LIMITER`.
    */
-  limiter?: RateLimit;
+  mintLimiter?: RateLimit;
+  /** Injected poll limiter; production reads `env.DEVICE_POLL_LIMITER`. */
+  pollLimiter?: RateLimit;
 }
 
 /**
@@ -184,7 +185,7 @@ async function mint(
   const label = readDeviceLabel(body.label);
   if (label === undefined) return badRequest("`label` must be a string.");
 
-  const limiter = deps.limiter ?? env.DEVICE_CODE_LIMITER;
+  const limiter = deps.mintLimiter ?? env.DEVICE_CODE_LIMITER;
   if (!(await withinClientLimit(limiter, request))) {
     // `Retry-After` is the limiter's whole window, because the binding reports
     // a verdict and nothing else: no reset time, no remaining count. Telling
@@ -247,10 +248,9 @@ interface IssuedToken {
  * code answers exactly like an expired one, because the alternative is an
  * endpoint that confirms which random strings are real.
  *
- * The interval is claimed rather than checked, so exactly one poll per interval
- * is served however many arrive at once, and this endpoint writes at most once
- * per interval per code. `claimDevicePoll` says why a read followed by a write
- * cannot enforce an interval.
+ * The interval is enforced by a Workers rate limiter keyed by the device-code
+ * hash. Pending polls are therefore reads, never timestamp writes, while the
+ * transactional collection below still makes token issue exclusive.
  */
 async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Response> {
   const now = (deps.now ?? Date.now)();
@@ -266,17 +266,16 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
   }
 
   const deviceCodeHash = await sha256Hex(deviceCode);
-  const { code, claimed } = await claimDevicePoll(
-    env.DB,
-    deviceCodeHash,
-    now,
-    MIN_DEVICE_POLL_GAP_MS,
-  );
+  const pollLimiter = deps.pollLimiter ?? env.DEVICE_POLL_LIMITER;
+  if (!(await withinLimit(pollLimiter, deviceCodeHash))) {
+    return device(
+      "slow_down",
+      `Polling too fast. Wait ${DEVICE_POLL_INTERVAL_SECONDS} seconds between requests.`,
+    );
+  }
 
-  // The code's own state is read before the claim is consulted, so a code that
-  // is over or refused says so on every poll rather than sometimes answering
-  // `slow_down` about a sign-in that is already finished.
-  //
+  const code = await findPolledDeviceCode(env.DB, deviceCodeHash);
+
   // Unknown, already collected, or swept — one answer for all three. A
   // collected code is deleted rather than marked spent, so a replay lands here.
   if (code === null || code.expires_at <= now) {
@@ -285,14 +284,6 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
   if (code.denied_at !== null) {
     return device("access_denied", "That sign-in was refused in the browser.");
   }
-  // Nothing else can have refused the claim by this point.
-  if (!claimed) {
-    return device(
-      "slow_down",
-      `Polling too fast. Wait ${DEVICE_POLL_INTERVAL_SECONDS} seconds between requests.`,
-    );
-  }
-
   if (code.approved_at === null) {
     return device("authorization_pending", "Waiting for the sign-in to be approved.");
   }
@@ -306,7 +297,7 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
     MAX_TOKENS_PER_ACCOUNT,
   );
 
-  // Null only when another poll collected between the claim above and this
+  // Null only when another poll collected between the read above and this
   // write. The code is spent, and the terminal that lost has nothing left to
   // wait for. An account at its ceiling is not a refusal: the collection
   // evicts that account's least recently used token instead.

--- a/src/device.ts
+++ b/src/device.ts
@@ -309,18 +309,11 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
     MAX_TOKENS_PER_ACCOUNT,
   );
 
-  if (issued.status === "at_capacity") {
-    // The code is deliberately still collectable, so revoking a token and
-    // polling again with the same code finishes the sign-in already in flight.
-    return errorResponse(
-      "quota_exceeded",
-      `This account already holds ${MAX_TOKENS_PER_ACCOUNT} tokens. Revoke one, then poll again.`,
-      { "cache-control": "no-store" },
-    );
-  }
-  if (issued.status === "gone") {
-    // Another poll collected between the read above and this write. The code is
-    // spent, and the terminal that lost has nothing left to wait for.
+  // Null only when another poll collected between the claim above and this
+  // write. The code is spent, and the terminal that lost has nothing left to
+  // wait for. An account at its ceiling is not a refusal: the collection
+  // evicts that account's least recently used token instead.
+  if (issued === null) {
     return device("expired_token", "That sign-in has expired. Start again.");
   }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -244,9 +244,10 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
     return device("access_denied", "That sign-in was refused in the browser.");
   }
 
-  await recordDevicePoll(env.DB, deviceCodeHash, now);
-
   if (code.approved_at === null) {
+    // Only the waiting path records the poll. The collecting one is about to
+    // delete this row, so writing to it first would be a write for nobody.
+    await recordDevicePoll(env.DB, deviceCodeHash, now);
     return device("authorization_pending", "Waiting for the sign-in to be approved.");
   }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -36,13 +36,7 @@ import {
   type Env,
 } from "./config.js";
 import { APPROVAL_PREFIX, USER_CODE_PARAM } from "./approval/handler.js";
-import {
-  collectDeviceToken,
-  findPolledDeviceCode,
-  insertDeviceCode,
-  recordDevicePoll,
-  sweepExpired,
-} from "./db.js";
+import { claimDevicePoll, collectDeviceToken, insertDeviceCode, sweepExpired } from "./db.js";
 import { errorResponse } from "./errors.js";
 import { sha256Hex } from "./hash.js";
 import { newApiToken, newDeviceCode, newTokenId, newUserCode } from "./ids.js";
@@ -255,6 +249,11 @@ interface IssuedToken {
  * caller gets is deliberately not a way to learn anything: an unknown device
  * code answers exactly like an expired one, because the alternative is an
  * endpoint that confirms which random strings are real.
+ *
+ * The interval is claimed rather than checked, so exactly one poll per interval
+ * is served however many arrive at once, and this endpoint writes at most once
+ * per interval per code. `claimDevicePoll` says why a read followed by a write
+ * cannot enforce an interval.
  */
 async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Response> {
   const now = (deps.now ?? Date.now)();
@@ -270,28 +269,34 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
   }
 
   const deviceCodeHash = await sha256Hex(deviceCode);
-  const code = await findPolledDeviceCode(env.DB, deviceCodeHash);
+  const { code, claimed } = await claimDevicePoll(
+    env.DB,
+    deviceCodeHash,
+    now,
+    MIN_DEVICE_POLL_GAP_MS,
+  );
+
+  // The code's own state is read before the claim is consulted, so a code that
+  // is over or refused says so on every poll rather than sometimes answering
+  // `slow_down` about a sign-in that is already finished.
+  //
   // Unknown, already collected, or swept — one answer for all three. A
   // collected code is deleted rather than marked spent, so a replay lands here.
-  if (code === null) return device("expired_token", "That sign-in has expired. Start again.");
-
-  if (code.last_polled_at !== null && now - code.last_polled_at < MIN_DEVICE_POLL_GAP_MS) {
-    return device(
-      "slow_down",
-      `Polling too fast. Wait ${DEVICE_POLL_INTERVAL_SECONDS} seconds between requests.`,
-    );
-  }
-  if (code.expires_at <= now) {
+  if (code === null || code.expires_at <= now) {
     return device("expired_token", "That sign-in has expired. Start again.");
   }
   if (code.denied_at !== null) {
     return device("access_denied", "That sign-in was refused in the browser.");
   }
+  // Nothing else can have refused the claim by this point.
+  if (!claimed) {
+    return device(
+      "slow_down",
+      `Polling too fast. Wait ${DEVICE_POLL_INTERVAL_SECONDS} seconds between requests.`,
+    );
+  }
 
   if (code.approved_at === null) {
-    // Only the waiting path records the poll. The collecting one is about to
-    // delete this row, so writing to it first would be a write for nobody.
-    await recordDevicePoll(env.DB, deviceCodeHash, now);
     return device("authorization_pending", "Waiting for the sign-in to be approved.");
   }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -113,6 +113,8 @@ export interface DeviceDeps {
   mintLimiter?: RateLimit;
   /** Injected poll limiter; production reads `env.DEVICE_POLL_LIMITER`. */
   pollLimiter?: RateLimit;
+  /** Injected aggregate poll limiter; production reads `env.DEVICE_POLL_CLIENT_LIMITER`. */
+  pollClientLimiter?: RateLimit;
 }
 
 /**
@@ -177,8 +179,6 @@ async function mint(
   env: Env,
   deps: DeviceDeps,
 ): Promise<Response> {
-  const now = (deps.now ?? Date.now)();
-
   const body = await readJsonBody(request);
   if (body === null) {
     return badRequest("The request body must be JSON, sent as `content-type: application/json`.");
@@ -200,6 +200,10 @@ async function mint(
     );
   }
 
+  // Read the clock after the streaming body and limiter have completed. A
+  // delayed body must still receive the full advertised lifetime from the
+  // moment its code is actually persisted.
+  const now = (deps.now ?? Date.now)();
   await sweepExpired(env.DB, now);
 
   const deviceCode = newDeviceCode();
@@ -250,8 +254,9 @@ interface IssuedToken {
  * code answers exactly like an expired one, because the alternative is an
  * endpoint that confirms which random strings are real.
  *
- * The interval is enforced by a Workers rate limiter keyed by the device-code
- * hash. Pending polls are therefore reads, never timestamp writes, while the
+ * An address-keyed ceiling bounds random misses before D1, then the interval is
+ * enforced by a separate Workers rate limiter keyed by the device-code hash.
+ * Pending polls are therefore reads, never timestamp writes, while the
  * transactional collection below still makes token issue exclusive.
  */
 async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Response> {
@@ -265,6 +270,14 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
   const deviceCode = body.device_code;
   if (typeof deviceCode !== "string" || deviceCode === "") {
     return badRequest("`device_code` must be the device code from POST /device/code.");
+  }
+
+  const pollClientLimiter = deps.pollClientLimiter ?? env.DEVICE_POLL_CLIENT_LIMITER;
+  if (!(await withinClientLimit(pollClientLimiter, request))) {
+    return device(
+      "slow_down",
+      `Too many polling attempts from this address. Wait ${DEVICE_POLL_INTERVAL_SECONDS} seconds.`,
+    );
   }
 
   const deviceCodeHash = await sha256Hex(deviceCode);

--- a/src/device.ts
+++ b/src/device.ts
@@ -31,6 +31,7 @@ import {
   DEVICE_CODE_TTL_MS,
   DEVICE_MINT_PERIOD_SECONDS,
   DEVICE_POLL_INTERVAL_SECONDS,
+  MAX_TOKENS_PER_ACCOUNT,
   MIN_DEVICE_POLL_GAP_MS,
   type Env,
 } from "./config.js";
@@ -81,6 +82,25 @@ const MAX_LABEL_LENGTH = 80;
  * request that never returns.
  */
 const USER_CODE_ATTEMPTS = 3;
+
+/**
+ * The only content type either endpoint accepts, and the reason it is required
+ * rather than merely expected.
+ *
+ * Both endpoints are unauthenticated `POST`s, so a page anybody visits can aim
+ * a cross-origin request at them. `application/json` is not one of the three
+ * types a form can send, so a browser has to preflight it — and this host
+ * answers no `Access-Control-Allow-Origin`, so the preflight fails and the
+ * request never leaves the browser. A form-encoded or `text/plain` body, by
+ * contrast, is a simple request that arrives whether the visitor meant it or
+ * not. Refusing those before the mint touches its rate limiter is what stops a
+ * hostile page spending a visitor's sign-in allowance for them
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3927574066).
+ *
+ * Required even when the body is empty, since a `fetch` with no body and no
+ * headers is a simple request too.
+ */
+const JSON_CONTENT_TYPE = "application/json";
 
 /** Bucket a request with no client address falls into. */
 const ANONYMOUS_CLIENT = "anonymous";
@@ -142,10 +162,16 @@ interface DeviceAuthorization {
 /**
  * `POST /device/code` — mint a code for a terminal that has no credential.
  *
- * The order is deliberate. The rate limit is asked first, so a refused caller
- * touches no storage at all; the sweep runs next, because a user code cannot be
- * reused until the row holding it is gone and minting is the only thing that
- * needs one free.
+ * The order is deliberate, and the first half of it is a security property
+ * rather than tidiness. **Nothing a browser can send cross-site reaches the
+ * rate limiter**: the content type and the body shape are checked first, so a
+ * page a victim happens to visit cannot burn their sign-in allowance by firing
+ * simple `POST`s at this endpoint. `JSON_CONTENT_TYPE` says why that check is
+ * the one that closes it.
+ *
+ * The limiter comes next, so a refused caller still touches no storage. The
+ * sweep comes after that, because a user code cannot be reused until the row
+ * holding it is gone and minting is the only thing that needs one free.
  *
  * A deployment that declares no limiter mints freely. That is a supported
  * deployment, not a hole to close: see `Env.DEVICE_CODE_LIMITER`.
@@ -157,6 +183,14 @@ async function mint(
   deps: DeviceDeps,
 ): Promise<Response> {
   const now = (deps.now ?? Date.now)();
+
+  const body = await readJsonBody(request);
+  if (body === null) {
+    return badRequest("The request body must be JSON, sent as `content-type: application/json`.");
+  }
+
+  const label = readDeviceLabel(body.label);
+  if (label === undefined) return badRequest("`label` must be a string.");
 
   const limiter = deps.limiter ?? env.DEVICE_CODE_LIMITER;
   const key = await deviceClientBucket(request);
@@ -171,12 +205,6 @@ async function mint(
       { "retry-after": String(DEVICE_MINT_PERIOD_SECONDS), "cache-control": "no-store" },
     );
   }
-
-  const body = await readJsonBody(request);
-  if (body === null) return badRequest("The request body must be a JSON object.");
-
-  const label = readDeviceLabel(body.label);
-  if (label === undefined) return badRequest("`label` must be a string.");
 
   await sweepExpired(env.DB, now);
 
@@ -232,7 +260,9 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
   const now = (deps.now ?? Date.now)();
 
   const body = await readJsonBody(request);
-  if (body === null) return badRequest("The request body must be a JSON object.");
+  if (body === null) {
+    return badRequest("The request body must be JSON, sent as `content-type: application/json`.");
+  }
 
   const deviceCode = body.device_code;
   if (typeof deviceCode !== "string" || deviceCode === "") {
@@ -267,15 +297,25 @@ async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Respo
 
   const token = newApiToken();
   const tokenId = newTokenId();
-  const issued = await collectDeviceToken(env.DB, deviceCodeHash, {
-    id: tokenId,
-    token_hash: await sha256Hex(token),
-    created_at: now,
-  });
-  // Null only when another poll collected between the read above and this
-  // write. The code is gone either way, and the terminal that lost has nothing
-  // to wait for.
-  if (issued === null) {
+  const issued = await collectDeviceToken(
+    env.DB,
+    deviceCodeHash,
+    { id: tokenId, token_hash: await sha256Hex(token), created_at: now },
+    MAX_TOKENS_PER_ACCOUNT,
+  );
+
+  if (issued.status === "at_capacity") {
+    // The code is deliberately still collectable, so revoking a token and
+    // polling again with the same code finishes the sign-in already in flight.
+    return errorResponse(
+      "quota_exceeded",
+      `This account already holds ${MAX_TOKENS_PER_ACCOUNT} tokens. Revoke one, then poll again.`,
+      { "cache-control": "no-store" },
+    );
+  }
+  if (issued.status === "gone") {
+    // Another poll collected between the read above and this write. The code is
+    // spent, and the terminal that lost has nothing left to wait for.
     return device("expired_token", "That sign-in has expired. Start again.");
   }
 
@@ -301,13 +341,22 @@ function badRequest(message: string): Response {
 }
 
 /**
- * The parsed JSON body, or null when it is not an object.
+ * The parsed JSON body, or null when the request is not one a client of this
+ * API could have sent.
  *
- * An absent or empty body is an empty object rather than an error: the mint has
- * nothing it requires, and a CLI that sends no label should not have to send
- * `{}` to say so.
+ * The content type is checked here rather than at each caller so that neither
+ * endpoint can be reached by a request a browser would send without a
+ * preflight — see `JSON_CONTENT_TYPE`. It is required even of a bodyless
+ * request for that reason, and only for that reason.
+ *
+ * An empty body is then an empty object rather than an error: the mint requires
+ * no field, and a client that sends no label should not have to send `{}` to
+ * say so.
  */
 async function readJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  const contentType = request.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+  if (contentType !== JSON_CONTENT_TYPE) return null;
+
   const bytes = await readBodyWithin(request, MAX_DEVICE_BODY_BYTES);
   if (bytes === null) return null;
   if (bytes.byteLength === 0) return {};

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,0 +1,358 @@
+/**
+ * The device flow: how a terminal with no credential gets one.
+ *
+ * An agent's CLI has nothing to publish with, and the one thing it must never
+ * do is ask the person to paste a secret — a secret pasted into an agent's
+ * conversation is a secret in a transcript, a log and a context window. So it
+ * asks for a code instead, prints a url, and waits. The person approves in a
+ * browser on any device, and the terminal's next poll collects a token nobody
+ * ever read aloud.
+ *
+ * RFC 8628 shaped, not RFC 8628 wire compatible. The two endpoints, the two
+ * codes, the polling interval and the four poll conditions are the standard's;
+ * the request bodies are JSON like the rest of this API rather than form
+ * encoded, and a failure carries this API's `{error: {code, message}}` envelope
+ * with the RFC's code names inside it. A client written against the standard
+ * recognises everything that matters, and a client written against
+ * `docs/http-api.md` still has exactly one error shape to parse.
+ *
+ * **Neither endpoint authenticates**, which is the whole point — the caller has
+ * no credential yet — so both are outside `/api/v1`, where every request
+ * carries one. The mint is rate limited per client address instead, because an
+ * endpoint that produces approval urls is an endpoint someone would otherwise
+ * use to send people approval urls.
+ */
+import {
+  DEVICE_CODE_TTL_MS,
+  DEVICE_MINT_WINDOW_MS,
+  DEVICE_POLL_INTERVAL_SECONDS,
+  MAX_DEVICE_MINTS_PER_WINDOW,
+  MIN_DEVICE_POLL_GAP_MS,
+  type Env,
+} from "./config.js";
+import { APPROVAL_PREFIX, USER_CODE_PARAM } from "./approval/handler.js";
+import {
+  claimDeviceMint,
+  collectDeviceToken,
+  findPolledDeviceCode,
+  insertDeviceCode,
+  recordDevicePoll,
+  sweepExpired,
+} from "./db.js";
+import { errorResponse } from "./errors.js";
+import { sha256Hex } from "./hash.js";
+import { newApiToken, newDeviceCode, newTokenId, newUserCode } from "./ids.js";
+import { readBodyWithin } from "./quota.js";
+
+/** Path prefix of the device surface, used by the router on the API host. */
+export const DEVICE_PREFIX = "/device";
+
+/**
+ * Ceiling on a request body here.
+ *
+ * Both endpoints are unauthenticated, so without a bound anyone who can reach
+ * the API host could make the Worker hold an arbitrary body. A device code and
+ * a label are a few hundred bytes; a kilobyte is room neither request will grow
+ * into. Enforced on bytes actually read rather than on `Content-Length`, for
+ * the reason the approval page's form reader gives: the header is the client's
+ * own assertion and a body is free to under-declare itself.
+ */
+const MAX_DEVICE_BODY_BYTES = 1024;
+
+/**
+ * Longest label kept from a mint request.
+ *
+ * It is client-supplied text that a person reads on the approval page while
+ * deciding whether to approve, so it has to fit on that page and stay one
+ * glance long. Anything past this is cut rather than refused: a terminal with a
+ * verbose idea of its own name should still be able to sign in.
+ */
+const MAX_LABEL_LENGTH = 80;
+
+/**
+ * Attempts at drawing an unused user code before giving up.
+ *
+ * Three, because a collision at this alphabet size against the codes alive at
+ * once is already unlikely and three independent draws make it absurd. Looping
+ * without a bound would turn a table the sweep has stopped clearing into a
+ * request that never returns.
+ */
+const USER_CODE_ATTEMPTS = 3;
+
+/** Bucket a request with no client address falls into. */
+const ANONYMOUS_CLIENT = "anonymous";
+
+/**
+ * Everything a terminal could hide in a label that a terminal would then act
+ * on: newlines, and the escape that starts an ANSI sequence.
+ */
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/gu;
+
+export interface DeviceDeps {
+  now?: () => number;
+}
+
+/**
+ * Two routes, and one method each:
+ *
+ * ```
+ * POST /device/code    mint a device code and the user code a person approves
+ * POST /device/token   collect the token that approval earned
+ * ```
+ *
+ * `POST` for both because both write, and because a `GET` that minted a code
+ * would mint one every time a link was followed.
+ */
+export async function handleDevice(
+  request: Request,
+  url: URL,
+  env: Env,
+  deps: DeviceDeps = {},
+): Promise<Response> {
+  const [route, ...extra] = url.pathname.slice(DEVICE_PREFIX.length).split("/").filter(Boolean);
+
+  if (extra.length === 0 && request.method === "POST") {
+    // `return await`: see the note on the router's catch in index.ts.
+    if (route === "code") return await mint(request, url, env, deps);
+    if (route === "token") return await poll(request, env, deps);
+  }
+  return errorResponse("not_found", `No device route for ${url.pathname}`);
+}
+
+/** One mint, as RFC 8628 §3.2 names its fields. */
+interface DeviceAuthorization {
+  device_code: string;
+  user_code: string;
+  /** Where to send the person when their terminal cannot open a browser. */
+  verification_uri: string;
+  /** The same page with the code already filled in, which is what a CLI prints. */
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+/**
+ * `POST /device/code` — mint a code for a terminal that has no credential.
+ *
+ * The order is deliberate. The rate limit is claimed before anything else, so a
+ * refused caller costs one write and never reaches the sweep or a draw; the
+ * sweep runs next, because a user code cannot be reused until the row holding
+ * it is gone and minting is the only thing that needs one free.
+ */
+async function mint(
+  request: Request,
+  url: URL,
+  env: Env,
+  deps: DeviceDeps,
+): Promise<Response> {
+  const now = (deps.now ?? Date.now)();
+
+  const client = await deviceClientBucket(request);
+  const windowStart = Math.floor(now / DEVICE_MINT_WINDOW_MS) * DEVICE_MINT_WINDOW_MS;
+  if (!(await claimDeviceMint(env.DB, client, windowStart, MAX_DEVICE_MINTS_PER_WINDOW))) {
+    const retryAfter = Math.ceil((windowStart + DEVICE_MINT_WINDOW_MS - now) / 1000);
+    return errorResponse(
+      "quota_exceeded",
+      "Too many sign-in codes from this address. Try again shortly.",
+      { "retry-after": String(retryAfter), "cache-control": "no-store" },
+    );
+  }
+
+  const body = await readJsonBody(request);
+  if (body === null) return badRequest("The request body must be a JSON object.");
+
+  const label = readDeviceLabel(body.label);
+  if (label === undefined) return badRequest("`label` must be a string.");
+
+  await sweepExpired(env.DB, now, DEVICE_MINT_WINDOW_MS);
+
+  const deviceCode = newDeviceCode();
+  const deviceCodeHash = await sha256Hex(deviceCode);
+  const expiresAt = now + DEVICE_CODE_TTL_MS;
+
+  const userCode = await claimUserCode(env.DB, {
+    device_code_hash: deviceCodeHash,
+    label,
+    expires_at: expiresAt,
+    created_at: now,
+  });
+  if (userCode === null) {
+    return errorResponse("internal", "Could not start a sign-in. Please try again.");
+  }
+
+  const verificationUri = `${url.origin}${APPROVAL_PREFIX}`;
+  const authorization: DeviceAuthorization = {
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: verificationUri,
+    verification_uri_complete: `${verificationUri}?${USER_CODE_PARAM}=${encodeURIComponent(userCode)}`,
+    expires_in: Math.floor(DEVICE_CODE_TTL_MS / 1000),
+    interval: DEVICE_POLL_INTERVAL_SECONDS,
+  };
+  // `no-store` on both routes, as RFC 6749 §5.1 requires of anything carrying a
+  // credential. The device code is one, even though it is not the token.
+  return Response.json(authorization, { headers: { "cache-control": "no-store" } });
+}
+
+/** The token a collected approval hands back, once and only once. */
+interface IssuedToken {
+  /** RFC 6749 §5.1's name for it. This is the value the CLI stores on disk. */
+  access_token: string;
+  token_type: "Bearer";
+  /** The public name of the token, which `GET /api/v1/tokens` also reports. */
+  token_id: string;
+  /** What the mint request called this machine, so the CLI can confirm it. */
+  label: string | null;
+}
+
+/**
+ * `POST /device/token` — ask whether the code has been approved, and collect
+ * the token if it has.
+ *
+ * Every refusal is one of RFC 8628 §3.5's four conditions, and which one a
+ * caller gets is deliberately not a way to learn anything: an unknown device
+ * code answers exactly like an expired one, because the alternative is an
+ * endpoint that confirms which random strings are real.
+ */
+async function poll(request: Request, env: Env, deps: DeviceDeps): Promise<Response> {
+  const now = (deps.now ?? Date.now)();
+
+  const body = await readJsonBody(request);
+  if (body === null) return badRequest("The request body must be a JSON object.");
+
+  const deviceCode = body.device_code;
+  if (typeof deviceCode !== "string" || deviceCode === "") {
+    return badRequest("`device_code` must be the device code from POST /device/code.");
+  }
+
+  const deviceCodeHash = await sha256Hex(deviceCode);
+  const code = await findPolledDeviceCode(env.DB, deviceCodeHash);
+  // Unknown, already collected, or swept — one answer for all three. A
+  // collected code is deleted rather than marked spent, so a replay lands here.
+  if (code === null) return device("expired_token", "That sign-in has expired. Start again.");
+
+  if (code.last_polled_at !== null && now - code.last_polled_at < MIN_DEVICE_POLL_GAP_MS) {
+    return device(
+      "slow_down",
+      `Polling too fast. Wait ${DEVICE_POLL_INTERVAL_SECONDS} seconds between requests.`,
+    );
+  }
+  if (code.expires_at <= now) {
+    return device("expired_token", "That sign-in has expired. Start again.");
+  }
+  if (code.denied_at !== null) {
+    return device("access_denied", "That sign-in was refused in the browser.");
+  }
+
+  await recordDevicePoll(env.DB, deviceCodeHash, now);
+
+  if (code.approved_at === null) {
+    return device("authorization_pending", "Waiting for the sign-in to be approved.");
+  }
+
+  const token = newApiToken();
+  const tokenId = newTokenId();
+  const issued = await collectDeviceToken(env.DB, deviceCodeHash, {
+    id: tokenId,
+    token_hash: await sha256Hex(token),
+    created_at: now,
+  });
+  // Null only when another poll collected between the read above and this
+  // write. The code is gone either way, and the terminal that lost has nothing
+  // to wait for.
+  if (issued === null) {
+    return device("expired_token", "That sign-in has expired. Start again.");
+  }
+
+  const collected: IssuedToken = {
+    access_token: token,
+    token_type: "Bearer",
+    token_id: tokenId,
+    label: issued.label,
+  };
+  return Response.json(collected, { headers: { "cache-control": "no-store" } });
+}
+
+/** A poll condition, in this API's envelope and with RFC 8628's name inside it. */
+function device(
+  code: "authorization_pending" | "slow_down" | "expired_token" | "access_denied",
+  message: string,
+): Response {
+  return errorResponse(code, message, { "cache-control": "no-store" });
+}
+
+function badRequest(message: string): Response {
+  return errorResponse("bad_request", message, { "cache-control": "no-store" });
+}
+
+/**
+ * The parsed JSON body, or null when it is not an object.
+ *
+ * An absent or empty body is an empty object rather than an error: the mint has
+ * nothing it requires, and a CLI that sends no label should not have to send
+ * `{}` to say so.
+ */
+async function readJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  const bytes = await readBodyWithin(request, MAX_DEVICE_BODY_BYTES);
+  if (bytes === null) return null;
+  if (bytes.byteLength === 0) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return null;
+  }
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * The label to store, or `undefined` when the caller sent something that is not
+ * one.
+ *
+ * Control characters go before anything else, because this string is rendered
+ * on the approval page and printed in CLI output: a newline or an escape
+ * sequence in it would let a terminal's chosen name draw over the question the
+ * person is being asked. Blank after that means the caller effectively sent
+ * none, and the page falls back to its own words.
+ *
+ * @param raw the `label` field exactly as it arrived, which may be anything
+ */
+export function readDeviceLabel(raw: unknown): string | null | undefined {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") return undefined;
+
+  const cleaned = raw.replace(CONTROL_CHARACTERS, " ").trim().slice(0, MAX_LABEL_LENGTH);
+  return cleaned === "" ? null : cleaned;
+}
+
+/**
+ * Insert the code under a freshly drawn user code, redrawing on the one thing
+ * that can refuse the insert: a code still in use.
+ */
+async function claimUserCode(
+  db: D1Database,
+  code: { device_code_hash: string; label: string | null; expires_at: number; created_at: number },
+): Promise<string | null> {
+  for (let attempt = 0; attempt < USER_CODE_ATTEMPTS; attempt += 1) {
+    const userCode = newUserCode();
+    if (await insertDeviceCode(db, { user_code: userCode, ...code })) return userCode;
+  }
+  return null;
+}
+
+/**
+ * The bucket a mint is counted against.
+ *
+ * The client's address, hashed. Hashed because it is a counter key rather than
+ * a record of who visited: nothing here ever needs to read an address back, and
+ * a table of them is a table someone would eventually be right to ask about.
+ * Where the platform reports no address — local development, and the tests —
+ * every caller shares one bucket, which is the safe direction for a limit.
+ */
+async function deviceClientBucket(request: Request): Promise<string> {
+  const address = request.headers.get("cf-connecting-ip")?.trim();
+  return await sha256Hex(address === undefined || address === "" ? ANONYMOUS_CLIENT : address);
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,7 +9,16 @@ export type ErrorCode =
   | "gone"
   | "too_large"
   | "quota_exceeded"
-  | "internal";
+  | "internal"
+  // The four conditions RFC 8628 §3.5 defines for a device-flow poll. They keep
+  // the RFC's names so a client written against the standard recognises them,
+  // and they travel in this API's own error envelope rather than OAuth's, so a
+  // client still has exactly one error shape to parse. Only `/device/token`
+  // emits them.
+  | "authorization_pending"
+  | "slow_down"
+  | "expired_token"
+  | "access_denied";
 
 const ERROR_STATUS: Record<ErrorCode, number> = {
   bad_request: 400,
@@ -19,6 +28,14 @@ const ERROR_STATUS: Record<ErrorCode, number> = {
   too_large: 413,
   quota_exceeded: 429,
   internal: 500,
+  // 400 for all four, as RFC 6749 §5.2 requires of a token endpoint. None of
+  // them is a failure of the request: three are the state of an approval nobody
+  // has finished yet, and the fourth is a client polling too eagerly. A client
+  // reads the code, never the status.
+  authorization_pending: 400,
+  slow_down: 400,
+  expired_token: 400,
+  access_denied: 400,
 };
 
 /** The wire shape. Clients match on `code`; `message` is human-facing only. */

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,0 +1,16 @@
+/**
+ * The one way a secret becomes a database key.
+ *
+ * Three credentials are looked up by hash rather than by value — a Brevilabs
+ * license key, an OpenArtifacts token, and the device code a terminal polls
+ * with — and they all have to agree on what "the hash" means, since a mismatch
+ * would not be a bug that fails, it would be a credential that silently never
+ * matches. It lives in its own module because `src/auth.ts` and `src/db.ts`
+ * both need it and neither should import the other.
+ */
+
+/** Lowercase hex SHA-256, which is the form every `*_hash` column stores. */
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -139,7 +139,7 @@ export function newDeviceCode(): string {
 }
 
 /**
- * The alphabet a user code is drawn from. Shown grouped: `WDJB-MJHT`.
+ * The alphabet a user code is drawn from. Shown grouped: `WDJBM-JHTQR`.
  *
  * Twenty consonants, exactly RFC 8628 §6.1's recommended set. Two properties
  * matter and neither is obvious:
@@ -151,18 +151,28 @@ export function newDeviceCode(): string {
  * - **No vowels.** Without them no draw can spell a word, which is what keeps a
  *   code from being an obscenity or somebody's brand name on screen. That is
  *   worth more than the entropy it costs.
- *
- * Twenty to the eighth is about 2^34.6, which is what the RFC asks for when the
- * endpoint is rate limited — and the code is not a credential in any case,
- * since polling needs the device code and approving needs a sign-in.
  */
 export const USER_CODE_ALPHABET = "BCDFGHJKLMNPQRSTVWXZ";
 
-/** Characters of randomness in a user code, excluding the grouping dash. */
-export const USER_CODE_LENGTH = 8;
+/**
+ * Characters of randomness in a user code, excluding the grouping dash.
+ *
+ * Ten of a twenty-letter alphabet is 20^10, about **2^43.2**. The RFC's own
+ * eight-character example is 2^34.6, and that is enough only where guessing is
+ * throttled hard; guessing here is throttled, but the consequence of a hit is
+ * bad enough to want margin rather than sufficiency. Somebody who finds a live
+ * code can approve it with their own provider account and the terminal waiting
+ * on it collects a token for *their* account, so the person who started the
+ * sign-in ends up publishing into a stranger's shelf. The confirm step is no
+ * defence, because the attacker is the one confirming
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928334751).
+ *
+ * Two extra characters cost one more spoken syllable and buy a factor of 400.
+ */
+export const USER_CODE_LENGTH = 10;
 
-/** Where the dash goes. Two groups of four is what people read back correctly. */
-const USER_CODE_GROUP = 4;
+/** Where the dash goes. Two groups of five stay readable off a screen. */
+const USER_CODE_GROUP = 5;
 
 /**
  * The short code a person reads off their terminal and types into the approval

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -113,7 +113,132 @@ export const HANDSHAKE_TOKEN_BYTES = 32;
  * has plus a second one nobody needs.
  */
 export function newHandshakeToken(): string {
-  const bytes = new Uint8Array(HANDSHAKE_TOKEN_BYTES);
+  return randomBase32(HANDSHAKE_TOKEN_BYTES);
+}
+
+/** CSPRNG bytes as base32, which is the shape of every secret minted here. */
+function randomBase32(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
   crypto.getRandomValues(bytes);
   return encodeBase32(bytes);
+}
+
+/**
+ * Bytes in the device code a terminal polls with.
+ *
+ * 256 bits, the same as a handshake token and for the same reason: it is the
+ * only thing that can collect the token an approval earns, so guessing one
+ * would be taking somebody's credential. It is never displayed and never typed,
+ * so its length costs nothing.
+ */
+export const DEVICE_CODE_BYTES = 32;
+
+/** The secret half of a device authorization, held only by the terminal. */
+export function newDeviceCode(): string {
+  return randomBase32(DEVICE_CODE_BYTES);
+}
+
+/**
+ * The alphabet a user code is drawn from. Shown grouped: `WDJB-MJHT`.
+ *
+ * Twenty consonants, exactly RFC 8628 §6.1's recommended set. Two properties
+ * matter and neither is obvious:
+ *
+ * - **No digits.** A code is read off one screen and typed into another, often
+ *   a phone, so `0`/`O` and `1`/`I`/`l` would each be a support request. The
+ *   doc-id alphabet solves the same problem by dropping those letters instead;
+ *   here the digits go, because a code is spoken as letters.
+ * - **No vowels.** Without them no draw can spell a word, which is what keeps a
+ *   code from being an obscenity or somebody's brand name on screen. That is
+ *   worth more than the entropy it costs.
+ *
+ * Twenty to the eighth is about 2^34.6, which is what the RFC asks for when the
+ * endpoint is rate limited — and the code is not a credential in any case,
+ * since polling needs the device code and approving needs a sign-in.
+ */
+export const USER_CODE_ALPHABET = "BCDFGHJKLMNPQRSTVWXZ";
+
+/** Characters of randomness in a user code, excluding the grouping dash. */
+export const USER_CODE_LENGTH = 8;
+
+/** Where the dash goes. Two groups of four is what people read back correctly. */
+const USER_CODE_GROUP = 4;
+
+/**
+ * The short code a person reads off their terminal and types into the approval
+ * page.
+ *
+ * Rejection sampling rather than `byte % 20`: 256 is not a multiple of 20, so a
+ * plain modulo would make the first sixteen letters likelier than the last
+ * four. The bias is small and the fix is one comparison, and an alphabet with
+ * quietly uneven letters is how the entropy claim above stops being true.
+ */
+export function newUserCode(): string {
+  const size = USER_CODE_ALPHABET.length;
+  // Largest multiple of the alphabet size that fits in a byte. A draw at or
+  // above it is discarded rather than folded.
+  const ceiling = Math.floor(256 / size) * size;
+  const draw = new Uint8Array(1);
+
+  let code = "";
+  let drawn = 0;
+  while (drawn < USER_CODE_LENGTH) {
+    crypto.getRandomValues(draw);
+    const byte = draw[0] ?? 0;
+    // Discarded before the dash is placed, so a rejected draw cannot leave two.
+    if (byte >= ceiling) continue;
+    if (drawn === USER_CODE_GROUP) code += "-";
+    code += USER_CODE_ALPHABET[byte % size];
+    drawn += 1;
+  }
+  return code;
+}
+
+/**
+ * The prefix every token this deployment issues carries.
+ *
+ * It is what tells `resolvePublisher` which credential it is holding, and that
+ * matters for more than tidiness: without it a token would be sent to the
+ * Brevilabs license server to be identified, handing our own secret to a third
+ * party on every request. It also makes a leaked token recognisable to a secret
+ * scanner, which a bare random string is not.
+ */
+export const TOKEN_PREFIX = "oat_";
+
+/** Bytes of entropy in a token. It is a bearer credential; treat it as one. */
+export const TOKEN_BYTES = 32;
+
+/** A token an approval earns. Returned once, stored only as a hash. */
+export function newApiToken(): string {
+  return `${TOKEN_PREFIX}${randomBase32(TOKEN_BYTES)}`;
+}
+
+/**
+ * The prefix on a token's public id, so a person reading CLI output can tell it
+ * from the token itself and from a doc id.
+ */
+export const TOKEN_ID_PREFIX = "tok_";
+
+/**
+ * Bytes in a token id. Like an account id it grants nothing and is never
+ * accepted as proof of anything, so it only has to stay unique.
+ */
+export const TOKEN_ID_BYTES = 10;
+
+/** The name a token is listed and revoked by. Never derived from its value. */
+export function newTokenId(): string {
+  return `${TOKEN_ID_PREFIX}${randomBase32(TOKEN_ID_BYTES)}`;
+}
+
+/** 80 / 5 — the characters `TOKEN_ID_BYTES` encodes to, with nothing left over. */
+const TOKEN_ID_LENGTH = 16;
+
+const TOKEN_ID_PATTERN = new RegExp(`^${TOKEN_ID_PREFIX}[${ALPHABET}]{${TOKEN_ID_LENGTH}}$`);
+
+/**
+ * Cheap shape check, so revoking a junk id costs no D1 read. Passing it says
+ * nothing about whether the token exists or whose it is.
+ */
+export function isTokenId(value: string): boolean {
+  return TOKEN_ID_PATTERN.test(value);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ import {
   publisherErrorResponse,
 } from "./auth.js";
 import type { Env } from "./config.js";
+import { DEVICE_PREFIX, handleDevice } from "./device.js";
 import { errorResponse } from "./errors.js";
+import { listTokens, revokeToken } from "./api/tokens.js";
 import {
   handleServing,
   servingError,
@@ -83,9 +85,11 @@ export function resolveSurface(hostname: string, pathname: string, config: Surfa
   if (hostsAreConfigured(config)) return "unknown";
 
   if (pathIsUnder(pathname, API_PREFIX)) return "api";
-  // The approval page shares the API host in production; locally it shares the
-  // API surface's path fallback, so `wrangler dev` can serve it too.
+  // The approval page and the device flow share the API host in production;
+  // locally they share the API surface's path fallback, so `wrangler dev` can
+  // serve them too.
   if (pathIsUnder(pathname, APPROVAL_PREFIX)) return "api";
+  if (pathIsUnder(pathname, DEVICE_PREFIX)) return "api";
   if (pathIsUnder(pathname, SERVING_PREFIX)) return "serving";
   return "unknown";
 }
@@ -98,9 +102,9 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
   const auth = await authenticateRequest(request, env);
   if (!auth.ok) return publisherErrorResponse(auth);
 
-  // `/api/v1/docs` and `/api/v1/docs/{docId}` are the whole surface. Anything
-  // the host matched into the API but that no route claims is a 404, never a
-  // fall-through to the serving surface.
+  // `/api/v1/docs`, `/api/v1/docs/{docId}` and `/api/v1/tokens/{tokenId}` are
+  // the whole surface. Anything the host matched into the API but that no route
+  // claims is a 404, never a fall-through to the serving surface.
   const [collection, docId, ...extra] = url.pathname
     .slice(API_PREFIX.length)
     .split("/")
@@ -137,6 +141,18 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
     }
     if (docId !== undefined && request.method === "DELETE") {
       return await deleteDoc(env, auth.publisher, docId);
+    }
+  }
+
+  // `docId` here is a token id: the same two path segments, named for the
+  // collection they follow. Managing tokens is not gated on a plan — losing the
+  // ability to publish must never cost someone the ability to revoke a machine.
+  if (collection === "tokens" && extra.length === 0) {
+    if (docId === undefined && request.method === "GET") {
+      return await listTokens(env, auth.publisher);
+    }
+    if (docId !== undefined && request.method === "DELETE") {
+      return await revokeToken(env, auth.publisher, docId);
     }
   }
 
@@ -204,6 +220,13 @@ export default {
           // `/api/v1`, so nothing in the frozen contract moves.
           if (pathIsUnder(url.pathname, APPROVAL_PREFIX)) {
             return await handleApproval(request, url, env);
+          }
+          // Likewise before `handleApi`: a terminal asking for a device code
+          // has no credential yet, which is the entire reason it is asking.
+          // Outside `/api/v1`, so the promise that every request under that
+          // prefix authenticates stays exactly true.
+          if (pathIsUnder(url.pathname, DEVICE_PREFIX)) {
+            return await handleDevice(request, url, env);
           }
           return await handleApi(request, url, env);
         case "serving":

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,10 +1,12 @@
 /**
- * The per-client limits on the three routes that answer without a credential.
+ * The limits on routes that answer without a credential.
  *
  * Minting a device code, looking one up on the approval page, and starting a
  * handshake all have to work for somebody who has nothing to present, so the
- * caller's address is the only thing there is to count against. This module is
- * how that address becomes a limiter key, and it lives apart from both callers
+ * caller's address is the only thing there is to count against. Device polling
+ * is counted against the hash of the secret device code instead, so one machine
+ * cannot make another wait. This module is how those become limiter keys, and it
+ * lives apart from both callers
  * because `src/device.ts` and `src/approval/handler.ts` already point at each
  * other and neither should import the other for this.
  *
@@ -33,7 +35,7 @@ const ANONYMOUS_CLIENT = "anonymous";
  * and staying under a limit that may or may not exist costs one `slice` where
  * being wrong about it costs every hosted sign-in.
  */
-const CLIENT_KEY_LENGTH = 32;
+const LIMITER_KEY_LENGTH = 32;
 
 /**
  * The key a request is counted against.
@@ -47,7 +49,7 @@ const CLIENT_KEY_LENGTH = 32;
 export async function clientBucket(request: Request): Promise<string> {
   const address = request.headers.get("cf-connecting-ip")?.trim();
   const bucket = address === undefined || address === "" ? ANONYMOUS_CLIENT : address;
-  return (await sha256Hex(bucket)).slice(0, CLIENT_KEY_LENGTH);
+  return (await sha256Hex(bucket)).slice(0, LIMITER_KEY_LENGTH);
 }
 
 /**
@@ -90,6 +92,20 @@ export async function withinClientLimit(
   limiter: RateLimit | undefined,
   request: Request,
 ): Promise<boolean> {
+  return await withinLimit(limiter, await clientBucket(request));
+}
+
+/**
+ * Whether a key is within an optional limiter's allowance.
+ *
+ * Keys are truncated to 128 bits. Callers pass hashes, never raw credentials,
+ * and 128 bits is ample collision resistance for an equality-only bucket while
+ * staying inside any undocumented key-size ceiling.
+ */
+export async function withinLimit(
+  limiter: RateLimit | undefined,
+  key: string,
+): Promise<boolean> {
   if (limiter === undefined) return true;
-  return (await limiter.limit({ key: await clientBucket(request) })).success;
+  return (await limiter.limit({ key: key.slice(0, LIMITER_KEY_LENGTH) })).success;
 }

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -7,6 +7,14 @@
  * how that address becomes a limiter key, and it lives apart from both callers
  * because `src/device.ts` and `src/approval/handler.ts` already point at each
  * other and neither should import the other for this.
+ *
+ * A limit keyed on an address is only as good as the requests that reach it. A
+ * page anybody visits can make that visitor's browser send requests from their
+ * address, so anything counted has to refuse those first, or the limit becomes
+ * a way to spend somebody else's allowance rather than a way to bound their
+ * own. `isTopLevelRequest` is that gate for the routes a browser reaches with a
+ * `GET`; the device endpoints use a content type instead, since they take a
+ * body and a browser cannot send that one cross-site without a preflight.
  */
 import { sha256Hex } from "./hash.js";
 
@@ -40,6 +48,33 @@ export async function clientBucket(request: Request): Promise<string> {
   const address = request.headers.get("cf-connecting-ip")?.trim();
   const bucket = address === undefined || address === "" ? ANONYMOUS_CLIENT : address;
   return (await sha256Hex(bucket)).slice(0, CLIENT_KEY_LENGTH);
+}
+
+/**
+ * Whether this request is a person arriving at a page, rather than something a
+ * page loaded on their behalf.
+ *
+ * `Sec-Fetch-Dest` is set by the browser and cannot be written by script, which
+ * is what makes it worth trusting where `Referer` and `Origin` are not: those
+ * are trivially forged by anything that is not a browser, and the threat here
+ * is specifically a browser being aimed at us. Opening a link is
+ * `document`; an `<img>`, an iframe or a `fetch` is `image`, `iframe` or
+ * `empty`, and none of those is a person approving anything
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928455536).
+ *
+ * **`Dest`, not `Site`.** A same-site `<img>` is still a subresource nobody
+ * asked for, and a cross-site *navigation* is exactly how somebody opens the
+ * link their terminal printed — so the site relationship answers the wrong
+ * question in both directions. What matters is whether a person is looking at
+ * the result.
+ *
+ * An absent header is allowed. Curl, older browsers and anything scripted send
+ * none, and refusing them would break the manual path this page exists for;
+ * they stay bounded by the limiter, which is what it is for.
+ */
+export function isTopLevelRequest(request: Request): boolean {
+  const destination = request.headers.get("sec-fetch-dest");
+  return destination === null || destination === "document";
 }
 
 /**

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -4,9 +4,10 @@
  * Minting a device code, looking one up on the approval page, and starting a
  * handshake all have to work for somebody who has nothing to present, so the
  * caller's address is the only thing there is to count against. Device polling
- * is counted against the hash of the secret device code instead, so one machine
- * cannot make another wait. This module is how those become limiter keys, and it
- * lives apart from both callers
+ * uses both: an address bucket bounds random misses, while the secret device
+ * code's hash enforces the advertised interval without making one machine wait
+ * for another behind the same NAT. This module is how those become limiter
+ * keys, and it lives apart from both callers
  * because `src/device.ts` and `src/approval/handler.ts` already point at each
  * other and neither should import the other for this.
  *

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,0 +1,60 @@
+/**
+ * The per-client limits on the three routes that answer without a credential.
+ *
+ * Minting a device code, looking one up on the approval page, and starting a
+ * handshake all have to work for somebody who has nothing to present, so the
+ * caller's address is the only thing there is to count against. This module is
+ * how that address becomes a limiter key, and it lives apart from both callers
+ * because `src/device.ts` and `src/approval/handler.ts` already point at each
+ * other and neither should import the other for this.
+ */
+import { sha256Hex } from "./hash.js";
+
+/** Bucket a request with no client address falls into. */
+const ANONYMOUS_CLIENT = "anonymous";
+
+/**
+ * Hex characters kept from the hashed address.
+ *
+ * 128 bits, which is far more than a bucket key needs: the limiter only ever
+ * compares keys for equality, so all this has to do is not collide. The
+ * published binding reference documents no ceiling on key length and the
+ * runtime's own validation checks only that a key is a string, but a review
+ * raised a possible 32-byte cap
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928334734),
+ * and staying under a limit that may or may not exist costs one `slice` where
+ * being wrong about it costs every hosted sign-in.
+ */
+const CLIENT_KEY_LENGTH = 32;
+
+/**
+ * The key a request is counted against.
+ *
+ * The client's address, hashed and truncated. Hashed because it is a bucket to
+ * count against rather than a record of who visited: nothing ever needs to read
+ * an address back out. Where the platform reports no address — local
+ * development, and the tests — every caller shares one key, which is the safe
+ * direction for a limit.
+ */
+export async function clientBucket(request: Request): Promise<string> {
+  const address = request.headers.get("cf-connecting-ip")?.trim();
+  const bucket = address === undefined || address === "" ? ANONYMOUS_CLIENT : address;
+  return (await sha256Hex(bucket)).slice(0, CLIENT_KEY_LENGTH);
+}
+
+/**
+ * Whether this request is within its client's allowance.
+ *
+ * **An undeclared limiter allows everything, deliberately.** A self-hoster who
+ * configures none gets no limit, which is the right default for a deployment
+ * nobody else can reach; failing closed would mean a Worker that signs nobody
+ * in until an operator had read a configuration reference. `docs/deploying.md`
+ * says so where an operator will find it.
+ */
+export async function withinClientLimit(
+  limiter: RateLimit | undefined,
+  request: Request,
+): Promise<boolean> {
+  if (limiter === undefined) return true;
+  return (await limiter.limit({ key: await clientBucket(request) })).success;
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -62,6 +62,9 @@ ${FAVICON_LINK}
   .actions form { display: contents; }
   .actions a, .actions button { margin-top: 2rem; padding: 0.85rem 1.5rem; border: 1px solid #2c313b; border-radius: 0.75rem; background: none; color: #f4f5f7; font: inherit; font-weight: 600; text-decoration: none; cursor: pointer; }
   .actions a:hover, .actions button:hover { border-color: #f6ae52; color: #f9c47f; }
+  .actions input { margin-top: 2rem; padding: 0.85rem 1.25rem; min-width: 11rem; border: 1px solid #2c313b; border-radius: 0.75rem; background: #07080b; color: #f4f5f7; font-family: "IBM Plex Mono", ui-monospace, Menlo, Consolas, monospace; font-size: 1rem; letter-spacing: 0.16em; text-transform: uppercase; }
+  .actions input::placeholder { color: #5b626e; }
+  .actions input:focus { outline: none; border-color: #f6ae52; }
 </style>
 </head>
 <body>

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -232,6 +232,7 @@ describe("startDeviceHandshake", () => {
       user_code: "START-2",
       provider: "github",
       verifier: "v2",
+      label: null,
     });
   });
 
@@ -265,6 +266,7 @@ describe("findPendingHandshake", () => {
       user_code: "FIND-1",
       provider: "github",
       verifier: "verifier-find",
+      label: null,
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -209,16 +209,18 @@ describe("startDeviceHandshake", () => {
     expect(row?.approved_at).toBeNull();
   });
 
-  it("drops an earlier handshake's identity and confirm token when it restarts", async () => {
+  it("keeps a rendered confirmation authoritative and refuses a restart", async () => {
     await seedCode("START-5", NOW + 1000);
-    await proven("START-5", "state-abandoned", "oa_owner");
+    const confirmToken = await proven("START-5", "state-proved", "oa_owner");
 
-    await startDeviceHandshake(env.DB, "START-5", "github", "state-new", "verifier-new", NOW);
+    expect(
+      await startDeviceHandshake(env.DB, "START-5", "github", "state-new", "verifier-new", NOW),
+    ).toBe(false);
 
     const row = await readCode("START-5");
-    // A page from the abandoned attempt must not be able to approve the new one.
-    expect(row?.account_id).toBeNull();
-    expect(row?.confirm_token).toBeNull();
+    expect(row?.account_id).toBe("oa_owner");
+    expect(row?.confirm_token).toBe(confirmToken);
+    expect(row?.state).toBe("state-proved");
   });
 
   it("replaces an earlier handshake, so only the newest one can be finished", async () => {
@@ -236,13 +238,15 @@ describe("startDeviceHandshake", () => {
     });
   });
 
-  it("drops the identity an earlier handshake proved, so a restart cannot be approved for it (https://github.com/Brevilabs/OpenArtifacts/pull/61#discussion_r3919988470)", async () => {
+  it("does not let a restart transfer a proven identity to a new state", async () => {
     await seedCode("START-5", NOW + 1000);
     await proven("START-5", "state-proved", "oa_victim");
 
-    await startDeviceHandshake(env.DB, "START-5", "google", "state-restarted", "v2", NOW);
+    expect(
+      await startDeviceHandshake(env.DB, "START-5", "google", "state-restarted", "v2", NOW),
+    ).toBe(false);
 
-    expect((await readCode("START-5"))?.account_id).toBeNull();
+    expect((await readCode("START-5"))?.account_id).toBe("oa_victim");
     expect(await confirmDeviceApproval(env.DB, "state-restarted", NOW)).toBeNull();
   });
 
@@ -361,13 +365,15 @@ describe("confirmDeviceApproval", () => {
     expect((await readCode("NOID-1"))?.approved_at).toBeNull();
   });
 
-  it("refuses a token left over from a handshake that was restarted", async () => {
+  it("keeps a rendered confirmation usable when someone tries to restart", async () => {
     await seedCode("RESTART-1", NOW + 1000);
-    const stale = await proven("RESTART-1", "state-stale", "oa_owner");
-    await startDeviceHandshake(env.DB, "RESTART-1", "github", "state-fresh", "verifier", NOW);
+    const confirmation = await proven("RESTART-1", "state-proved", "oa_owner");
+    expect(
+      await startDeviceHandshake(env.DB, "RESTART-1", "github", "state-fresh", "verifier", NOW),
+    ).toBe(false);
 
-    expect(await confirmDeviceApproval(env.DB, stale, NOW)).toBeNull();
-    expect((await readCode("RESTART-1"))?.approved_at).toBeNull();
+    expect(await confirmDeviceApproval(env.DB, confirmation, NOW)).toBe("RESTART-1");
+    expect((await readCode("RESTART-1"))?.approved_at).toBe(NOW);
   });
 
   it("refuses an unknown token, an expired code and a second press alike", async () => {

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -35,6 +35,11 @@ const configured = (over: Partial<Env> = {}): Env =>
     OAUTH_GOOGLE_CLIENT_SECRET: "google-secret",
     OAUTH_GITHUB_CLIENT_ID: "github-client",
     OAUTH_GITHUB_CLIENT_SECRET: "github-secret",
+    // No limiter unless a case asks for one. The limiter's state lives in the
+    // runtime rather than in storage, so it does not reset between tests, and a
+    // suite that looked codes up through it would start refusing itself. The
+    // cases about the limit reach for `env.APPROVAL_LOOKUP_LIMITER` themselves.
+    APPROVAL_LOOKUP_LIMITER: undefined,
     ...over,
   }) as Env;
 
@@ -47,6 +52,18 @@ async function send(path: string, init: RequestInit = {}, over: Partial<Env> = {
   );
   await waitOnExecutionContext(ctx);
   return response;
+}
+
+/** The allowance declared on `APPROVAL_LOOKUP_LIMITER` in wrangler.jsonc. */
+const LOOKUPS_PER_PERIOD = 20;
+
+/** A lookup from one address on a deployment that declares the limiter. */
+function lookupFrom(address: string, userCode = USER_CODE): Promise<Response> {
+  return send(
+    `/approve?user_code=${userCode}`,
+    { headers: { "cf-connecting-ip": address } },
+    { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
+  );
 }
 
 /** A form submission, as the chooser's and the confirm page's buttons make one. */
@@ -307,6 +324,65 @@ describe("GET /approve", () => {
     expect(html).not.toContain("<img src=x>");
     // Nor escaped: what was submitted is not put back in the field at all.
     expect(html).not.toContain("&lt;img");
+  });
+});
+
+/**
+ * A user code is short enough to read aloud, so the page that takes one says
+ * whether it is live. Without a limit that is an enumeration oracle, and a hit
+ * is worth having: whoever finds a pending code can approve it with their own
+ * provider account, and the terminal waiting on it then collects a token for
+ * *their* account (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928334751).
+ */
+describe("guessing a user code", () => {
+  it("stops a client working through the code space, and says only that the code is gone", async () => {
+    const address = "198.51.100.5";
+    for (let i = 0; i < LOOKUPS_PER_PERIOD; i += 1) {
+      expect((await lookupFrom(address, "ZZZZZ-ZZZZZ")).status).toBe(404);
+    }
+
+    // A live code from the same address now answers exactly like a miss, so the
+    // limit tells the guesser nothing it did not already have.
+    const refused = await lookupFrom(address);
+    expect(refused.status).toBe(404);
+    expect(await refused.text()).toContain("no longer waiting");
+  });
+
+  it("reads no row once the client is over its allowance", async () => {
+    const address = "198.51.100.6";
+    for (let i = 0; i < LOOKUPS_PER_PERIOD; i += 1) await lookupFrom(address, "ZZZZZ-ZZZZZ");
+
+    // The seeded code is live, so a lookup that reached the database would say
+    // so. Being refused before that read is what makes the limit a real bound.
+    expect((await lookupFrom(address)).status).toBe(404);
+    expect((await readCode())?.state).toBeNull();
+  });
+
+  it("leaves another client's allowance alone", async () => {
+    for (let i = 0; i < LOOKUPS_PER_PERIOD; i += 1) await lookupFrom("198.51.100.7", "ZZZZZ-ZZZZZ");
+
+    const other = await lookupFrom("198.51.100.8");
+    expect(other.status).toBe(200);
+    expect(await other.text()).toContain("Continue with Google");
+  });
+
+  it("counts starting a handshake too, since that also says whether a code is live", async () => {
+    const address = "198.51.100.9";
+    for (let i = 0; i < LOOKUPS_PER_PERIOD; i += 1) await lookupFrom(address, "ZZZZZ-ZZZZZ");
+
+    const refused = await send(
+      "/approve/start/google",
+      {
+        method: "POST",
+        headers: { "cf-connecting-ip": address },
+        body: new URLSearchParams({ user_code: USER_CODE }),
+      },
+      { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
+    );
+
+    expect(refused.status).toBe(404);
+    // No handshake was written, so nothing can be completed against it.
+    expect((await readCode())?.state).toBeNull();
   });
 });
 

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -58,10 +58,14 @@ async function send(path: string, init: RequestInit = {}, over: Partial<Env> = {
 const LOOKUPS_PER_PERIOD = 20;
 
 /** A lookup from one address on a deployment that declares the limiter. */
-function lookupFrom(address: string, userCode = USER_CODE): Promise<Response> {
+function lookupFrom(
+  address: string,
+  userCode = USER_CODE,
+  headers: Record<string, string> = {},
+): Promise<Response> {
   return send(
     `/approve?user_code=${userCode}`,
-    { headers: { "cf-connecting-ip": address } },
+    { headers: { "cf-connecting-ip": address, ...headers } },
     { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
   );
 }
@@ -382,6 +386,73 @@ describe("guessing a user code", () => {
 
     expect(refused.status).toBe(404);
     // No handshake was written, so nothing can be completed against it.
+    expect((await readCode())?.state).toBeNull();
+  });
+});
+
+/**
+ * A `GET` needs no preflight, so a hostile page can make any visitor's browser
+ * fetch this route from their address with an `<img>` or an iframe. If those
+ * were counted, twenty of them would spend that visitor's allowance and their
+ * own approval would come back as an expired code
+ * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928455536).
+ */
+describe("a lookup a page made rather than a person", () => {
+  it("refuses a subresource fetch and charges its client nothing", async () => {
+    const address = "198.51.100.20";
+
+    for (let i = 0; i < LOOKUPS_PER_PERIOD + 4; i += 1) {
+      const refused = await lookupFrom(address, USER_CODE, {
+        "sec-fetch-dest": i % 2 === 0 ? "image" : "iframe",
+        "sec-fetch-site": "cross-site",
+      });
+      // The code is live, so a request that got as far as the lookup would say
+      // so. It is refused before that, and told nothing a miss would not tell.
+      expect(refused.status).toBe(404);
+    }
+
+    // The visitor's own approval still works, which is what proves the bucket
+    // was never charged on their behalf.
+    const mine = await lookupFrom(address);
+    expect(mine.status).toBe(200);
+    expect(await mine.text()).toContain("Continue with Google");
+  });
+
+  it("lets a person opening the link through, and counts that", async () => {
+    const address = "198.51.100.21";
+
+    const opened = await lookupFrom(address, USER_CODE, {
+      "sec-fetch-dest": "document",
+      "sec-fetch-mode": "navigate",
+    });
+    expect(opened.status).toBe(200);
+
+    // Charged: the rest of the allowance is what is left after that one.
+    for (let i = 0; i < LOOKUPS_PER_PERIOD - 1; i += 1) await lookupFrom(address, "ZZZZZ-ZZZZZ");
+    expect((await lookupFrom(address)).status).toBe(404);
+  });
+
+  it("lets a client that sends no fetch metadata through, and counts it", async () => {
+    const address = "198.51.100.22";
+
+    expect((await lookupFrom(address)).status).toBe(200);
+
+    for (let i = 0; i < LOOKUPS_PER_PERIOD - 1; i += 1) await lookupFrom(address, "ZZZZZ-ZZZZZ");
+    expect((await lookupFrom(address)).status).toBe(404);
+  });
+
+  it("refuses a handshake a page tried to start, and writes nothing", async () => {
+    const refused = await send(
+      "/approve/start/google",
+      {
+        method: "POST",
+        headers: { "cf-connecting-ip": "198.51.100.23", "sec-fetch-dest": "iframe" },
+        body: new URLSearchParams({ user_code: USER_CODE }),
+      },
+      { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
+    );
+
+    expect(refused.status).toBe(404);
     expect((await readCode())?.state).toBeNull();
   });
 });

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -241,9 +241,52 @@ describe("GET /approve", () => {
     expect((await send("/approve?user_code=NOSUCHCODE")).status).toBe(404);
   });
 
-  it("asks for the whole link when the code is missing or malformed", async () => {
-    expect((await send("/approve")).status).toBe(400);
-    expect((await send("/approve?user_code=not%20a%20code")).status).toBe(400);
+  /**
+   * The mint returns a bare `verification_uri` for someone reading the address
+   * off a terminal and typing it into a phone, so that address has to lead to
+   * somewhere the code can be entered rather than to a page telling them to go
+   * back for the whole link.
+   */
+  it("offers a form to type the code into when the url carries none", async () => {
+    const response = await send("/approve");
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<form method="get" action="/approve">');
+    expect(html).toContain('name="user_code"');
+    // A GET, because submitting it only navigates. The two presses that change
+    // what a code is worth stay POSTs.
+    expect(html).not.toContain('<form method="post" action="/approve">');
+  });
+
+  it("reaches the provider page when that form is submitted with a waiting code", async () => {
+    const response = await send(`/approve?user_code=${USER_CODE.toLowerCase()}`);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Continue with Google");
+  });
+
+  it("asks again rather than dead-ending when the code is malformed", async () => {
+    const response = await send("/approve?user_code=not%20a%20code");
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).toContain('<form method="get" action="/approve">');
+    expect(html).toContain("does not look like a code");
+  });
+
+  it("treats a blank submission as no code at all", async () => {
+    const response = await send("/approve?user_code=%20");
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<form method="get" action="/approve">');
+  });
+
+  it("still says a well-formed code is gone rather than offering the form again", async () => {
+    const response = await send("/approve?user_code=NOSUCHCODE");
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).not.toContain('<form method="get"');
   });
 
   it("says so plainly on a deployment with no provider configured", async () => {
@@ -262,6 +305,8 @@ describe("GET /approve", () => {
     // nothing that reaches the page can carry markup in the first place.
     const html = await (await send("/approve?user_code=%3Cimg%20src%3Dx%3E")).text();
     expect(html).not.toContain("<img src=x>");
+    // Nor escaped: what was submitted is not put back in the field at all.
+    expect(html).not.toContain("&lt;img");
   });
 });
 

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -700,13 +700,13 @@ describe("POST /approve/confirm", () => {
     expect((await readCode())?.approved_at).toBe(approvedAt);
   });
 
-  it("refuses a token from a page whose handshake has since been restarted", async () => {
+  it("refuses to restart after rendering confirmation and keeps that page usable", async () => {
     await begin();
-    const stale = confirmToken(await (await callback()).text());
-    await begin("github");
+    const confirmation = confirmToken(await (await callback()).text());
 
-    expect((await post("/approve/confirm", { confirm_token: stale })).status).toBe(400);
-    expect((await readCode())?.approved_at).toBeNull();
+    expect((await begin("github")).status).toBe(404);
+    expect((await post("/approve/confirm", { confirm_token: confirmation })).status).toBe(200);
+    expect((await readCode())?.approved_at).toBeGreaterThanOrEqual(NOW);
   });
 
   it("refuses a press for a code that expired while the page was open", async () => {

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -766,6 +766,10 @@ describe("readDeviceLabel()", () => {
     expect(readDeviceLabel("Claude[31m Code\nrm -rf")).toBe("Claude [31m Code rm -rf");
   });
 
+  it("strips bidi controls without stripping ordinary right-to-left text", () => {
+    expect(readDeviceLabel("Trusted\u202Etxt.exe\u202C جهاز")).toBe("Trustedtxt.exe جهاز");
+  });
+
   it("cuts a label that would not fit on the approval page", () => {
     expect(readDeviceLabel("x".repeat(200))).toHaveLength(80);
   });
@@ -819,8 +823,9 @@ describe("the whole flow, from an empty terminal to a token", () => {
     const confirmPage = await approval(`/approve/callback/google?state=${state}&code=auth-code`);
     const html = await confirmPage.text();
     // The machine's own name for itself is what tells the person whether the
-    // terminal waiting on this code is theirs.
-    expect(html).toContain("Claude Code on loganmac");
+    // terminal waiting on this code is theirs. `bdi` keeps natural RTL labels
+    // from changing the direction of the surrounding warning.
+    expect(html).toContain("<b><bdi>Claude Code on loganmac</bdi></b>");
     expect(html).toContain("Deny");
 
     const confirmToken = /name="confirm_token" value="([^"]+)"/.exec(html)?.[1] ?? "";

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -12,7 +12,13 @@ import { handleDevice, readDeviceLabel } from "../src/device.js";
 import type { Env } from "../src/config.js";
 import { collectDeviceToken, confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
 import { sha256Hex } from "../src/hash.js";
-import { newApiToken, TOKEN_ID_PREFIX, TOKEN_PREFIX, USER_CODE_ALPHABET } from "../src/ids.js";
+import {
+  newApiToken,
+  TOKEN_ID_PREFIX,
+  TOKEN_PREFIX,
+  USER_CODE_ALPHABET,
+  USER_CODE_LENGTH,
+} from "../src/ids.js";
 import worker from "../src/index.js";
 
 /**
@@ -55,6 +61,7 @@ const configured = (over: Partial<Env> = {}): Env =>
     OAUTH_GITHUB_CLIENT_ID: "github-client",
     OAUTH_GITHUB_CLIENT_SECRET: "github-secret",
     DEVICE_CODE_LIMITER: undefined,
+    APPROVAL_LOOKUP_LIMITER: undefined,
     ...over,
   }) as Env;
 
@@ -198,9 +205,11 @@ describe("POST /device/code", () => {
     const { user_code } = await mint();
 
     expect(user_code).toMatch(
-      new RegExp(`^[${USER_CODE_ALPHABET}]{4}-[${USER_CODE_ALPHABET}]{4}$`),
+      new RegExp(`^[${USER_CODE_ALPHABET}]{5}-[${USER_CODE_ALPHABET}]{5}$`),
     );
     expect(normalizeUserCode(user_code)).toBe(user_code);
+    // Ten characters of a twenty-letter alphabet, which is 2^43.2.
+    expect(user_code.replace("-", "")).toHaveLength(USER_CODE_LENGTH);
   });
 
   it("stores the device code only as a hash, and the label beside it", async () => {
@@ -297,6 +306,31 @@ describe("POST /device/code", () => {
     expect(refused.status).toBe(429);
     expect(await errorOf(refused)).toBe("quota_exceeded");
     expect(refused.headers.get("retry-after")).toBe("60");
+  });
+
+  /**
+   * The published binding reference documents no ceiling on key length and the
+   * runtime checks only that a key is a string, but a review raised a possible
+   * 32-byte cap, and a key over one would fail every hosted mint
+   * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928334734).
+   */
+  it("hands the limiter a key well inside any length a binding could cap", async () => {
+    const keys: string[] = [];
+    const watching: RateLimit = {
+      limit: async ({ key }) => {
+        keys.push(key);
+        return { success: true };
+      },
+    };
+
+    const url = new URL(`${ORIGIN}/device/code`);
+    await handleDevice(request("/device/code", undefined, { "cf-connecting-ip": "203.0.113.30" }), url, configured(), {
+      now: () => NOW,
+      limiter: watching,
+    });
+
+    expect(keys).toHaveLength(1);
+    expect(new TextEncoder().encode(keys[0]).byteLength).toBeLessThanOrEqual(32);
   });
 
   it("counts each client address separately", async () => {

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -11,7 +11,8 @@ import {
 import { handleDevice, readDeviceLabel } from "../src/device.js";
 import type { Env } from "../src/config.js";
 import { collectDeviceToken, confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
-import { TOKEN_ID_PREFIX, TOKEN_PREFIX, USER_CODE_ALPHABET } from "../src/ids.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, TOKEN_ID_PREFIX, TOKEN_PREFIX, USER_CODE_ALPHABET } from "../src/ids.js";
 import worker from "../src/index.js";
 
 /**
@@ -130,6 +131,13 @@ async function mint(body?: unknown, now = NOW): Promise<Minted> {
 
 const errorOf = async (response: Response): Promise<string> =>
   (await response.json<{ error: { code: string } }>()).error.code;
+
+const revokedAt = async (id: string): Promise<number | null> =>
+  (
+    await env.DB.prepare("SELECT revoked_at FROM tokens WHERE id = ?")
+      .bind(id)
+      .first<{ revoked_at: number | null }>()
+  )?.revoked_at ?? null;
 
 async function codeRow(userCode: string) {
   return await env.DB.prepare(
@@ -464,7 +472,7 @@ describe("POST /device/token", () => {
       ),
     ]);
 
-    expect([first.status, second.status].sort()).toEqual(["gone", "issued"]);
+    expect([first, second].filter((outcome) => outcome !== null)).toHaveLength(1);
     const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
     expect(n).toBe(1);
     expect(await codeRow(minted.user_code)).toBeNull();
@@ -538,60 +546,148 @@ describe("claiming a polling interval", () => {
   });
 });
 
-describe("the ceiling on tokens an account may hold", () => {
+describe("the rolling window of tokens an account holds", () => {
   const ACCOUNT = "oa_crowded_account";
 
-  /** Fill the account to one below the ceiling, cheaply. */
-  async function fillTokens(count: number): Promise<void> {
+  /** One seeded token, with the use history the eviction order reads. */
+  async function seedToken(id: string, lastUsed: number | null, value?: string): Promise<void> {
+    await env.DB.prepare(
+      `INSERT INTO tokens (id, token_hash, account_id, label, created_at, last_used_at)
+       VALUES (?, ?, ?, NULL, ?, ?)`,
+    )
+      .bind(id, value === undefined ? `hash-${id}` : await sha256Hex(value), ACCOUNT, NOW, lastUsed)
+      .run();
+  }
+
+  /** Pad the account out to the window, all used more recently than the victim. */
+  async function padTo(count: number, from: number): Promise<void> {
     await env.DB.batch(
-      Array.from({ length: count }, (_, i) =>
+      Array.from({ length: count - from }, (_, i) =>
         env.DB.prepare(
-          `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
-           VALUES (?, ?, ?, ?, ?)`,
-        ).bind(`tok_seed${String(i).padStart(11, "0")}`, `hash-${i}`, ACCOUNT, null, NOW + i),
+          `INSERT INTO tokens (id, token_hash, account_id, label, created_at, last_used_at)
+           VALUES (?, ?, ?, NULL, ?, ?)`,
+        ).bind(
+          `tok_pad${String(i + from).padStart(13, "0")}`,
+          `hash-pad-${i + from}`,
+          ACCOUNT,
+          NOW,
+          NOW + i + from,
+        ),
       ),
     );
   }
 
-  it("refuses the collection past the ceiling and leaves the code collectable", async () => {
-    await fillTokens(MAX_TOKENS_PER_ACCOUNT);
+  const liveTokens = async (): Promise<number> =>
+    (await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM tokens WHERE account_id = ? AND revoked_at IS NULL",
+    )
+      .bind(ACCOUNT)
+      .first<{ n: number }>())!.n;
+
+  /** Mint, approve and collect on this account, returning the new token. */
+  async function signIn(): Promise<Issued> {
     const minted = await mint();
     await approve(minted.user_code, ACCOUNT);
+    const response = await device("/device/token", { device_code: minted.device_code });
+    expect(response.status).toBe(200);
+    return await response.json<Issued>();
+  }
 
-    const refused = await device("/device/token", { device_code: minted.device_code });
-
-    expect(refused.status).toBe(429);
-    expect(await errorOf(refused)).toBe("quota_exceeded");
-    // Not spent: revoking one token and polling again finishes this same sign-in.
-    expect(await codeRow(minted.user_code)).not.toBeNull();
-    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
-    expect(n).toBe(MAX_TOKENS_PER_ACCOUNT);
-  });
-
-  it("collects on the next poll once room is made", async () => {
-    await fillTokens(MAX_TOKENS_PER_ACCOUNT);
-    const minted = await mint();
-    await approve(minted.user_code, ACCOUNT);
-    await device("/device/token", { device_code: minted.device_code });
-
-    await env.DB.prepare("UPDATE tokens SET revoked_at = ? WHERE id = ?")
-      .bind(NOW, "tok_seed00000000000")
-      .run();
-
-    const collected = await device(
-      "/device/token",
-      { device_code: minted.device_code },
-      NOW + DEVICE_POLL_INTERVAL_SECONDS * 1000,
+  const asks = async (credential: string): Promise<number> => {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}/api/v1/docs`, { headers: { authorization: `Bearer ${credential}` } }),
+      configured(),
+      ctx,
     );
-    expect(collected.status).toBe(200);
+    await waitOnExecutionContext(ctx);
+    return response.status;
+  };
+
+  /**
+   * Refusing at the ceiling would strand an owner who no longer holds any of
+   * the hundred values: revoking needs one of them, so neither revoking nor
+   * collecting would ever work again
+   * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928231361).
+   */
+  it("evicts the least recently used token and refuses it on its next request", async () => {
+    const victim = newApiToken();
+    await seedToken("tok_victim000000000", NOW - 5_000, victim);
+    await seedToken("tok_keeper000000000", NOW - 4_000);
+    await padTo(MAX_TOKENS_PER_ACCOUNT, 2);
+
+    const issued = await signIn();
+
+    expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
+    expect(await revokedAt("tok_victim000000000")).toBe(NOW);
+    expect(await revokedAt("tok_keeper000000000")).toBeNull();
+    expect(await asks(victim)).toBe(401);
+    expect(await asks(issued.access_token)).toBe(200);
   });
 
-  it("returns every token an account can hold, so none is invisible to revoke", async () => {
-    await fillTokens(MAX_TOKENS_PER_ACCOUNT - 1);
+  it("drops a token that was never used before one that was used long ago", async () => {
+    await seedToken("tok_neverused000000", null);
+    await seedToken("tok_ancient00000000", 1);
+    await padTo(MAX_TOKENS_PER_ACCOUNT, 2);
+
+    await signIn();
+
+    expect(await revokedAt("tok_neverused000000")).toBe(NOW);
+    expect(await revokedAt("tok_ancient00000000")).toBeNull();
+  });
+
+  it("evicts nothing while the account is under the window", async () => {
+    await seedToken("tok_lonely000000000", null);
+
+    await signIn();
+
+    expect(await revokedAt("tok_lonely000000000")).toBeNull();
+    expect(await liveTokens()).toBe(2);
+  });
+
+  it("evicts nothing for a poll at a code nobody has approved", async () => {
+    await seedToken("tok_untouched000000", null);
+    await padTo(MAX_TOKENS_PER_ACCOUNT, 1);
+    const minted = await mint();
+
+    expect(await errorOf(await device("/device/token", { device_code: minted.device_code }))).toBe(
+      "authorization_pending",
+    );
+
+    expect(await revokedAt("tok_untouched000000")).toBeNull();
+    expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
+  });
+
+  it("issues one token when two collections race at the window", async () => {
+    await seedToken("tok_victim000000000", NOW - 5_000);
+    await padTo(MAX_TOKENS_PER_ACCOUNT, 1);
     const minted = await mint();
     await approve(minted.user_code, ACCOUNT);
-    const issued = await (await device("/device/token", { device_code: minted.device_code }))
-      .json<Issued>();
+    const hash = (await codeRow(minted.user_code))!.device_code_hash!;
+
+    const [first, second] = await Promise.all([
+      collectDeviceToken(
+        env.DB,
+        hash,
+        { id: "tok_race000000000a", token_hash: "hash-a", created_at: NOW },
+        MAX_TOKENS_PER_ACCOUNT,
+      ),
+      collectDeviceToken(
+        env.DB,
+        hash,
+        { id: "tok_race000000000b", token_hash: "hash-b", created_at: NOW },
+        MAX_TOKENS_PER_ACCOUNT,
+      ),
+    ]);
+
+    expect([first, second].filter((outcome) => outcome !== null)).toHaveLength(1);
+    expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
+    expect(await codeRow(minted.user_code)).toBeNull();
+  });
+
+  it("returns every token an account holds, so none is invisible to revoke", async () => {
+    await padTo(MAX_TOKENS_PER_ACCOUNT - 1, 0);
+    const issued = await signIn();
 
     const ctx = createExecutionContext();
     const listed = await worker.fetch(
@@ -606,8 +702,7 @@ describe("the ceiling on tokens an account may hold", () => {
     const body = await listed.json<{ tokens: { tokenId: string }[] }>();
     expect(body.tokens).toHaveLength(MAX_TOKENS_PER_ACCOUNT);
     expect(body.tokens.map((row) => row.tokenId)).toContain(issued.token_id);
-    // The oldest is still listed, which is what makes it revocable.
-    expect(body.tokens.map((row) => row.tokenId)).toContain("tok_seed00000000000");
+    expect(body.tokens.map((row) => row.tokenId)).toContain("tok_pad0000000000000");
   });
 });
 

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -62,6 +62,7 @@ const configured = (over: Partial<Env> = {}): Env =>
     DEVICE_CODE_LIMITER: undefined,
     APPROVAL_LOOKUP_LIMITER: undefined,
     DEVICE_POLL_LIMITER: undefined,
+    DEVICE_POLL_CLIENT_LIMITER: undefined,
     ...over,
   }) as Env;
 
@@ -402,6 +403,31 @@ describe("POST /device/token", () => {
         ),
       ),
     ).toBe("slow_down");
+  });
+
+  it("bounds random code misses in one client bucket before the per-code limit", async () => {
+    const keys: string[] = [];
+    const aggregate: RateLimit = {
+      limit: async ({ key }) => {
+        keys.push(key);
+        return { success: keys.length === 1 };
+      },
+    };
+    const deployment = configured({ DEVICE_POLL_CLIENT_LIMITER: aggregate });
+    const headers = { "cf-connecting-ip": "198.51.100.72" };
+
+    expect(
+      await errorOf(
+        await device("/device/token", { device_code: "random-a" }, NOW, headers, deployment),
+      ),
+    ).toBe("expired_token");
+    expect(
+      await errorOf(
+        await device("/device/token", { device_code: "random-b" }, NOW, headers, deployment),
+      ),
+    ).toBe("slow_down");
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toBe(keys[1]);
   });
 
   it("uses the hosted poll binding declared in wrangler.jsonc", async () => {

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -404,6 +404,18 @@ describe("POST /device/token", () => {
     ).toBe("slow_down");
   });
 
+  it("uses the hosted poll binding declared in wrangler.jsonc", async () => {
+    const { device_code } = await mint();
+    const deployment = configured({ DEVICE_POLL_LIMITER: env.DEVICE_POLL_LIMITER });
+
+    expect(
+      await errorOf(await device("/device/token", { device_code }, NOW, {}, deployment)),
+    ).toBe("authorization_pending");
+    expect(
+      await errorOf(await device("/device/token", { device_code }, NOW, {}, deployment)),
+    ).toBe("slow_down");
+  });
+
   it("answers an unknown device code exactly as it answers an expired one", async () => {
     const { device_code } = await mint();
     const unknown = "zzzz".repeat(13);

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -1,0 +1,489 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { handleApproval, normalizeUserCode } from "../src/approval/handler.js";
+import type { OAuthClient, ProviderId } from "../src/approval/providers.js";
+import {
+  DEVICE_CODE_TTL_MS,
+  DEVICE_POLL_INTERVAL_SECONDS,
+  MAX_DEVICE_MINTS_PER_WINDOW,
+} from "../src/config.js";
+import { handleDevice, readDeviceLabel } from "../src/device.js";
+import type { Env } from "../src/config.js";
+import { confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
+import { TOKEN_ID_PREFIX, TOKEN_PREFIX, USER_CODE_ALPHABET } from "../src/ids.js";
+import worker from "../src/index.js";
+
+/**
+ * Local routing has no configured hosts, so the surfaces resolve by path
+ * prefix. Nothing here is about which production domain carries them.
+ */
+const ORIGIN = "https://openartifacts.workers.dev";
+
+/**
+ * A fixed instant for everything driven through `handleDevice` directly, which
+ * is how the cases about expiry and polling intervals control the clock. Cases
+ * that go through `worker.fetch` have no seam for one and use real time.
+ */
+const NOW = 1_800_000_000_000;
+
+const configured = (over: Partial<Env> = {}): Env =>
+  ({
+    ...env,
+    SERVING_HOST: "",
+    API_HOST: "",
+    LEGACY_SERVING_HOST: "",
+    RETIRED_API_HOST: "",
+    OAUTH_GOOGLE_CLIENT_ID: "google-client",
+    OAUTH_GOOGLE_CLIENT_SECRET: "google-secret",
+    OAUTH_GITHUB_CLIENT_ID: "github-client",
+    OAUTH_GITHUB_CLIENT_SECRET: "github-secret",
+    ...over,
+  }) as Env;
+
+function request(path: string, body?: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(`${ORIGIN}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+/** Straight at the handler, where the clock is injectable. */
+function device(path: string, body?: unknown, now = NOW, headers: Record<string, string> = {}) {
+  const url = new URL(`${ORIGIN}${path}`);
+  return handleDevice(request(path, body, headers), url, configured(), { now: () => now });
+}
+
+/** Through the router, which is what proves the surface is reachable at all. */
+async function routed(path: string, body?: unknown): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request(path, body), configured(), ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+interface Minted {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface Issued {
+  access_token: string;
+  token_type: string;
+  token_id: string;
+  label: string | null;
+}
+
+async function mint(body?: unknown, now = NOW): Promise<Minted> {
+  const response = await device("/device/code", body, now);
+  expect(response.status).toBe(200);
+  return await response.json<Minted>();
+}
+
+const errorOf = async (response: Response): Promise<string> =>
+  (await response.json<{ error: { code: string } }>()).error.code;
+
+async function codeRow(userCode: string) {
+  return await env.DB.prepare(
+    `SELECT device_code_hash, label, approved_at, denied_at, last_polled_at, expires_at
+       FROM device_codes WHERE user_code = ?`,
+  )
+    .bind(userCode)
+    .first<{
+      device_code_hash: string | null;
+      label: string | null;
+      approved_at: number | null;
+      denied_at: number | null;
+      last_polled_at: number | null;
+      expires_at: number;
+    }>();
+}
+
+/**
+ * Approve a minted code the way the page does, through the two writes the
+ * approval page performs. Driving the browser flow as well is one case below;
+ * everything else only needs the code approved.
+ */
+async function approve(userCode: string, accountId = "oa_device_account"): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE device_codes SET state = ?, verifier = ? WHERE user_code = ?",
+  )
+    .bind(`state-${userCode}`, "verifier", userCode)
+    .run();
+  await env.DB.prepare("INSERT OR IGNORE INTO accounts (id, email, created_at) VALUES (?, ?, ?)")
+    .bind(accountId, `${accountId}@example.test`, NOW)
+    .run();
+
+  const held = await holdProvenIdentity(
+    env.DB,
+    `state-${userCode}`,
+    accountId,
+    `confirm-${userCode}`,
+    NOW,
+  );
+  expect(held).toBe(true);
+  expect(await confirmDeviceApproval(env.DB, `confirm-${userCode}`, NOW)).toBe(userCode);
+}
+
+describe("POST /device/code", () => {
+  it("mints both codes, the two verification urls, the interval and the expiry", async () => {
+    const minted = await mint({ label: "Claude Code on loganmac" });
+
+    expect(minted.device_code).toMatch(/^[0-9a-z]{52}$/);
+    expect(minted.verification_uri).toBe(`${ORIGIN}/approve`);
+    expect(minted.verification_uri_complete).toBe(
+      `${ORIGIN}/approve?user_code=${minted.user_code}`,
+    );
+    expect(minted.expires_in).toBe(DEVICE_CODE_TTL_MS / 1000);
+    expect(minted.interval).toBe(DEVICE_POLL_INTERVAL_SECONDS);
+  });
+
+  it("draws a user code the approval page accepts, from the alphabet with no vowels or digits", async () => {
+    const { user_code } = await mint();
+
+    expect(user_code).toMatch(
+      new RegExp(`^[${USER_CODE_ALPHABET}]{4}-[${USER_CODE_ALPHABET}]{4}$`),
+    );
+    expect(normalizeUserCode(user_code)).toBe(user_code);
+  });
+
+  it("stores the device code only as a hash, and the label beside it", async () => {
+    const minted = await mint({ label: "Codex on ci-runner-3" });
+
+    const row = await codeRow(minted.user_code);
+    expect(row?.device_code_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(row?.device_code_hash).not.toBe(minted.device_code);
+    expect(row?.label).toBe("Codex on ci-runner-3");
+    expect(row?.expires_at).toBe(NOW + DEVICE_CODE_TTL_MS);
+  });
+
+  it("accepts a request with no body at all, since a label is optional", async () => {
+    const response = await device("/device/code");
+    expect(response.status).toBe(200);
+    expect((await codeRow((await response.json<Minted>()).user_code))?.label).toBeNull();
+  });
+
+  it("refuses a label that is not a string, and junk that is not JSON", async () => {
+    expect(await errorOf(await device("/device/code", { label: 7 }))).toBe("bad_request");
+
+    const url = new URL(`${ORIGIN}/device/code`);
+    const junk = new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    });
+    const response = await handleDevice(junk, url, configured(), { now: () => NOW });
+    expect(await errorOf(response)).toBe("bad_request");
+  });
+
+  it("sweeps codes that have expired, so their user codes can be drawn again", async () => {
+    await env.DB.prepare(
+      "INSERT INTO device_codes (user_code, expires_at, created_at) VALUES (?, ?, ?)",
+    )
+      .bind("SWEEP-OLD", NOW - 1, NOW - DEVICE_CODE_TTL_MS)
+      .run();
+
+    await mint();
+
+    expect(await codeRow("SWEEP-OLD")).toBeNull();
+  });
+
+  it("leaves a code that has not expired alone", async () => {
+    const first = await mint();
+    await mint();
+
+    expect(await codeRow(first.user_code)).not.toBeNull();
+  });
+
+  it("refuses a client that has spent its window's worth of codes", async () => {
+    for (let i = 0; i < MAX_DEVICE_MINTS_PER_WINDOW; i += 1) {
+      expect((await device("/device/code")).status).toBe(200);
+    }
+
+    const refused = await device("/device/code");
+    expect(refused.status).toBe(429);
+    expect(await errorOf(refused)).toBe("quota_exceeded");
+    expect(refused.headers.get("retry-after")).toMatch(/^[0-9]+$/);
+  });
+
+  it("counts each client address separately", async () => {
+    for (let i = 0; i < MAX_DEVICE_MINTS_PER_WINDOW; i += 1) {
+      await device("/device/code", undefined, NOW, { "cf-connecting-ip": "203.0.113.7" });
+    }
+
+    expect(
+      (await device("/device/code", undefined, NOW, { "cf-connecting-ip": "203.0.113.8" })).status,
+    ).toBe(200);
+    expect(
+      (await device("/device/code", undefined, NOW, { "cf-connecting-ip": "203.0.113.7" })).status,
+    ).toBe(429);
+  });
+
+  it("is reachable through the router and answers 404 on any other device path or method", async () => {
+    expect((await routed("/device/code")).status).toBe(200);
+    expect((await routed("/device/nowhere")).status).toBe(404);
+
+    const ctx = createExecutionContext();
+    const get = await worker.fetch(
+      new Request(`${ORIGIN}/device/code`),
+      configured(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(get.status).toBe(404);
+  });
+});
+
+describe("POST /device/token", () => {
+  it("says the approval is pending while nobody has approved", async () => {
+    const { device_code } = await mint();
+
+    expect(await errorOf(await device("/device/token", { device_code }))).toBe(
+      "authorization_pending",
+    );
+  });
+
+  it("says slow down when the terminal polls faster than the interval it was given", async () => {
+    const { device_code } = await mint();
+    await device("/device/token", { device_code }, NOW);
+
+    expect(await errorOf(await device("/device/token", { device_code }, NOW + 1_000))).toBe(
+      "slow_down",
+    );
+    expect(
+      await errorOf(
+        await device(
+          "/device/token",
+          { device_code },
+          NOW + DEVICE_POLL_INTERVAL_SECONDS * 1000,
+        ),
+      ),
+    ).toBe("authorization_pending");
+  });
+
+  it("answers an unknown device code exactly as it answers an expired one", async () => {
+    const { device_code } = await mint();
+    const unknown = "zzzz".repeat(13);
+
+    expect(await errorOf(await device("/device/token", { device_code: unknown }))).toBe(
+      "expired_token",
+    );
+    expect(
+      await errorOf(await device("/device/token", { device_code }, NOW + DEVICE_CODE_TTL_MS)),
+    ).toBe("expired_token");
+  });
+
+  it("refuses a body with no device code", async () => {
+    expect(await errorOf(await device("/device/token", {}))).toBe("bad_request");
+    expect(await errorOf(await device("/device/token", { device_code: 42 }))).toBe("bad_request");
+  });
+
+  it("issues a token once the code is approved, and reports the label back", async () => {
+    const minted = await mint({ label: "Claude Code on loganmac" });
+    await approve(minted.user_code);
+
+    const response = await device("/device/token", { device_code: minted.device_code });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+
+    const issued = await response.json<Issued>();
+    expect(issued.access_token.startsWith(TOKEN_PREFIX)).toBe(true);
+    expect(issued.token_type).toBe("Bearer");
+    expect(issued.token_id.startsWith(TOKEN_ID_PREFIX)).toBe(true);
+    expect(issued.label).toBe("Claude Code on loganmac");
+  });
+
+  it("stores only the token's hash, against the account that approved it", async () => {
+    const minted = await mint();
+    await approve(minted.user_code, "oa_holder");
+
+    const issued = await (await device("/device/token", { device_code: minted.device_code }))
+      .json<Issued>();
+
+    const row = await env.DB.prepare(
+      "SELECT token_hash, account_id, label, last_used_at, revoked_at FROM tokens WHERE id = ?",
+    )
+      .bind(issued.token_id)
+      .first<{
+        token_hash: string;
+        account_id: string;
+        label: string | null;
+        last_used_at: number | null;
+        revoked_at: number | null;
+      }>();
+
+    expect(row?.account_id).toBe("oa_holder");
+    expect(row?.token_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(row?.token_hash).not.toContain(issued.access_token);
+    expect(row?.last_used_at).toBeNull();
+    expect(row?.revoked_at).toBeNull();
+  });
+
+  it("consumes the code, so replaying a collected device code gets nothing", async () => {
+    const minted = await mint();
+    await approve(minted.user_code);
+    await device("/device/token", { device_code: minted.device_code });
+
+    expect(await codeRow(minted.user_code)).toBeNull();
+    expect(await errorOf(await device("/device/token", { device_code: minted.device_code }))).toBe(
+      "expired_token",
+    );
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
+    expect(n).toBe(1);
+  });
+
+  it("issues one token when two polls collect the same approval at once", async () => {
+    const minted = await mint();
+    await approve(minted.user_code);
+
+    const [first, second] = await Promise.all([
+      device("/device/token", { device_code: minted.device_code }),
+      device("/device/token", { device_code: minted.device_code }),
+    ]);
+
+    const statuses = [first.status, second.status].sort();
+    expect(statuses).toEqual([200, 400]);
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
+    expect(n).toBe(1);
+  });
+});
+
+describe("denying an approval", () => {
+  it("tells the waiting terminal it was refused, and issues nothing", async () => {
+    const minted = await mint({ label: "Somebody else's laptop" });
+    await env.DB.prepare("UPDATE device_codes SET denied_at = ? WHERE user_code = ?")
+      .bind(NOW, minted.user_code)
+      .run();
+
+    expect(await errorOf(await device("/device/token", { device_code: minted.device_code }))).toBe(
+      "access_denied",
+    );
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
+    expect(n).toBe(0);
+  });
+});
+
+describe("readDeviceLabel()", () => {
+  it("keeps a plain label, and treats a missing one as none", () => {
+    expect(readDeviceLabel("Codex on loganmac")).toBe("Codex on loganmac");
+    expect(readDeviceLabel(undefined)).toBeNull();
+    expect(readDeviceLabel(null)).toBeNull();
+    expect(readDeviceLabel("   ")).toBeNull();
+  });
+
+  it("strips control characters, so a terminal cannot draw over the page it is named on", () => {
+    expect(readDeviceLabel("Claude[31m Code\nrm -rf")).toBe("Claude [31m Code rm -rf");
+  });
+
+  it("cuts a label that would not fit on the approval page", () => {
+    expect(readDeviceLabel("x".repeat(200))).toHaveLength(80);
+  });
+
+  it("rejects a label that is not a string", () => {
+    expect(readDeviceLabel(7)).toBeUndefined();
+    expect(readDeviceLabel({ label: "no" })).toBeUndefined();
+  });
+});
+
+describe("the whole flow, from an empty terminal to a token", () => {
+  /** The callback reaches Google in production, so its client is replaced. */
+  const oauth: OAuthClient = {
+    authorizationUrl(provider: ProviderId, redirectUri: string, state: string) {
+      return new URL(`https://provider.test/${provider}?state=${state}&r=${redirectUri}`);
+    },
+    async verifiedIdentity() {
+      return { subject: "sub-flow", email: "flow@example.test" };
+    },
+  };
+
+  const approval = (path: string, init: RequestInit = {}) =>
+    handleApproval(
+      new Request(`${ORIGIN}${path}`, init),
+      new URL(`${ORIGIN}${path}`),
+      configured(),
+      { now: () => NOW, oauth },
+    );
+
+  const form = (path: string, fields: Record<string, string>) =>
+    approval(path, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(fields),
+    });
+
+  it("mints, approves in the browser, and hands the terminal a token that publishes", async () => {
+    const minted = await mint({ label: "Claude Code on loganmac" });
+
+    const chooser = await approval(`/approve?user_code=${minted.user_code}`);
+    expect(chooser.status).toBe(200);
+    expect(await chooser.text()).toContain(minted.user_code);
+
+    expect((await form("/approve/start/google", { user_code: minted.user_code })).status).toBe(303);
+
+    const state = (
+      await env.DB.prepare("SELECT state FROM device_codes WHERE user_code = ?")
+        .bind(minted.user_code)
+        .first<{ state: string }>()
+    )?.state;
+    const confirmPage = await approval(`/approve/callback/google?state=${state}&code=auth-code`);
+    const html = await confirmPage.text();
+    // The machine's own name for itself is what tells the person whether the
+    // terminal waiting on this code is theirs.
+    expect(html).toContain("Claude Code on loganmac");
+    expect(html).toContain("Deny");
+
+    const confirmToken = /name="confirm_token" value="([^"]+)"/.exec(html)?.[1] ?? "";
+    expect((await form("/approve/confirm", { confirm_token: confirmToken })).status).toBe(200);
+
+    const issued = await (await device("/device/token", { device_code: minted.device_code }))
+      .json<Issued>();
+
+    const ctx = createExecutionContext();
+    const published = await worker.fetch(
+      new Request(`${ORIGIN}/api/v1/docs`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${issued.access_token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          title: "From the terminal",
+          html: "<!doctype html><html><body><p>hi</p></body></html>",
+        }),
+      }),
+      configured(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(published.status).toBe(201);
+  });
+
+  it("lets the person deny instead, which kills the code the terminal is waiting on", async () => {
+    const minted = await mint({ label: "A terminal that is not mine" });
+    await form("/approve/start/google", { user_code: minted.user_code });
+    const state = (
+      await env.DB.prepare("SELECT state FROM device_codes WHERE user_code = ?")
+        .bind(minted.user_code)
+        .first<{ state: string }>()
+    )?.state;
+    const html = await (
+      await approval(`/approve/callback/google?state=${state}&code=auth-code`)
+    ).text();
+    const confirmToken = /name="confirm_token" value="([^"]+)"/.exec(html)?.[1] ?? "";
+
+    const denied = await form("/approve/deny", { confirm_token: confirmToken });
+    expect(denied.status).toBe(200);
+    expect(await denied.text()).toContain("Denied");
+
+    expect(await errorOf(await device("/device/token", { device_code: minted.device_code }))).toBe(
+      "access_denied",
+    );
+    // The same press cannot then approve it: the confirm token is spent either way.
+    expect((await form("/approve/confirm", { confirm_token: confirmToken })).status).toBe(400);
+    expect((await codeRow(minted.user_code))?.approved_at).toBeNull();
+  });
+});

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -2,11 +2,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { describe, expect, it } from "vitest";
 import { handleApproval, normalizeUserCode } from "../src/approval/handler.js";
 import type { OAuthClient, ProviderId } from "../src/approval/providers.js";
-import {
-  DEVICE_CODE_TTL_MS,
-  DEVICE_POLL_INTERVAL_SECONDS,
-  MAX_DEVICE_MINTS_PER_WINDOW,
-} from "../src/config.js";
+import { DEVICE_CODE_TTL_MS, DEVICE_POLL_INTERVAL_SECONDS } from "../src/config.js";
 import { handleDevice, readDeviceLabel } from "../src/device.js";
 import type { Env } from "../src/config.js";
 import { confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
@@ -26,6 +22,21 @@ const ORIGIN = "https://openartifacts.workers.dev";
  */
 const NOW = 1_800_000_000_000;
 
+/**
+ * The limit declared on the binding in wrangler.jsonc. Not readable from the
+ * binding itself, which reports a verdict and no numbers, so a change there has
+ * to be made here too.
+ */
+const MINTS_PER_PERIOD = 5;
+
+/**
+ * A deployment with no limiter declared, which is the supported self-hosted
+ * shape and the one almost every case here wants: the limiter's state lives in
+ * the runtime rather than in storage, so it does *not* reset between tests, and
+ * a suite that minted through it would start refusing itself. The cases that
+ * are about the limit reach for `env.DEVICE_CODE_LIMITER` explicitly, each with
+ * an address of its own.
+ */
 const configured = (over: Partial<Env> = {}): Env =>
   ({
     ...env,
@@ -37,8 +48,12 @@ const configured = (over: Partial<Env> = {}): Env =>
     OAUTH_GOOGLE_CLIENT_SECRET: "google-secret",
     OAUTH_GITHUB_CLIENT_ID: "github-client",
     OAUTH_GITHUB_CLIENT_SECRET: "github-secret",
+    DEVICE_CODE_LIMITER: undefined,
     ...over,
   }) as Env;
+
+/** The same deployment with the limiter the hosted one declares. */
+const limited = (): Env => configured({ DEVICE_CODE_LIMITER: env.DEVICE_CODE_LIMITER });
 
 function request(path: string, body?: unknown, headers: Record<string, string> = {}): Request {
   return new Request(`${ORIGIN}${path}`, {
@@ -49,10 +64,20 @@ function request(path: string, body?: unknown, headers: Record<string, string> =
 }
 
 /** Straight at the handler, where the clock is injectable. */
-function device(path: string, body?: unknown, now = NOW, headers: Record<string, string> = {}) {
+function device(
+  path: string,
+  body?: unknown,
+  now = NOW,
+  headers: Record<string, string> = {},
+  over: Env = configured(),
+) {
   const url = new URL(`${ORIGIN}${path}`);
-  return handleDevice(request(path, body, headers), url, configured(), { now: () => now });
+  return handleDevice(request(path, body, headers), url, over, { now: () => now });
 }
+
+/** A mint from one address through a deployment that declares the limiter. */
+const mintFrom = (address: string) =>
+  device("/device/code", undefined, NOW, { "cf-connecting-ip": address }, limited());
 
 /** Through the router, which is what proves the surface is reachable at all. */
 async function routed(path: string, body?: unknown): Promise<Response> {
@@ -199,28 +224,49 @@ describe("POST /device/code", () => {
     expect(await codeRow(first.user_code)).not.toBeNull();
   });
 
-  it("refuses a client that has spent its window's worth of codes", async () => {
-    for (let i = 0; i < MAX_DEVICE_MINTS_PER_WINDOW; i += 1) {
-      expect((await device("/device/code")).status).toBe(200);
+  it("refuses a client that has spent its period's worth of codes", async () => {
+    for (let i = 0; i < MINTS_PER_PERIOD; i += 1) {
+      expect((await mintFrom("203.0.113.7")).status).toBe(200);
     }
 
-    const refused = await device("/device/code");
+    const refused = await mintFrom("203.0.113.7");
     expect(refused.status).toBe(429);
     expect(await errorOf(refused)).toBe("quota_exceeded");
-    expect(refused.headers.get("retry-after")).toMatch(/^[0-9]+$/);
+    expect(refused.headers.get("retry-after")).toBe("60");
   });
 
   it("counts each client address separately", async () => {
-    for (let i = 0; i < MAX_DEVICE_MINTS_PER_WINDOW; i += 1) {
-      await device("/device/code", undefined, NOW, { "cf-connecting-ip": "203.0.113.7" });
-    }
+    for (let i = 0; i < MINTS_PER_PERIOD; i += 1) await mintFrom("203.0.113.9");
 
-    expect(
-      (await device("/device/code", undefined, NOW, { "cf-connecting-ip": "203.0.113.8" })).status,
-    ).toBe(200);
-    expect(
-      (await device("/device/code", undefined, NOW, { "cf-connecting-ip": "203.0.113.7" })).status,
-    ).toBe(429);
+    expect((await mintFrom("203.0.113.10")).status).toBe(200);
+    expect((await mintFrom("203.0.113.9")).status).toBe(429);
+  });
+
+  /**
+   * A self-hoster who declares no limiter gets no limit, deliberately. Failing
+   * closed instead would mean a Worker that signs nobody in until an operator
+   * has read a configuration reference.
+   */
+  it("mints freely on a deployment that declares no limiter", async () => {
+    expect(configured().DEVICE_CODE_LIMITER).toBeUndefined();
+
+    for (let i = 0; i < MINTS_PER_PERIOD + 2; i += 1) {
+      expect((await device("/device/code")).status).toBe(200);
+    }
+  });
+
+  it("writes nothing when the limiter refuses, so abuse costs no storage", async () => {
+    for (let i = 0; i < MINTS_PER_PERIOD; i += 1) await mintFrom("203.0.113.11");
+    const { n: before } = (await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM device_codes",
+    ).first<{ n: number }>())!;
+
+    expect((await mintFrom("203.0.113.11")).status).toBe(429);
+
+    const { n: after } = (await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM device_codes",
+    ).first<{ n: number }>())!;
+    expect(after).toBe(before);
   });
 
   it("is reachable through the router and answers 404 on any other device path or method", async () => {

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -812,8 +812,9 @@ describe("readDeviceLabel()", () => {
     expect(readDeviceLabel("   ")).toBeNull();
   });
 
-  it("strips control characters, so a terminal cannot draw over the page it is named on", () => {
+  it("strips C0 and C1 controls, so a terminal cannot draw over the page it is named on", () => {
     expect(readDeviceLabel("Claude[31m Code\nrm -rf")).toBe("Claude [31m Code rm -rf");
+    expect(readDeviceLabel("Claude\u009b31m Code")).toBe("Claude 31m Code");
   });
 
   it("strips bidi controls without stripping ordinary right-to-left text", () => {

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -6,10 +6,11 @@ import {
   DEVICE_CODE_TTL_MS,
   DEVICE_POLL_INTERVAL_SECONDS,
   MAX_TOKENS_PER_ACCOUNT,
+  MIN_DEVICE_POLL_GAP_MS,
 } from "../src/config.js";
 import { handleDevice, readDeviceLabel } from "../src/device.js";
 import type { Env } from "../src/config.js";
-import { confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
+import { collectDeviceToken, confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
 import { TOKEN_ID_PREFIX, TOKEN_PREFIX, USER_CODE_ALPHABET } from "../src/ids.js";
 import worker from "../src/index.js";
 
@@ -437,19 +438,103 @@ describe("POST /device/token", () => {
     expect(n).toBe(1);
   });
 
-  it("issues one token when two polls collect the same approval at once", async () => {
+  /**
+   * Below the handler, because the interval claim now stops two polls reaching
+   * the collection at once through it. The write still has to be safe on its
+   * own: the interval bounds a well-behaved client, it is not what makes
+   * issuing exclusive.
+   */
+  it("issues one token when two collections race for the same approval", async () => {
     const minted = await mint();
     await approve(minted.user_code);
+    const hash = (await codeRow(minted.user_code))!.device_code_hash!;
 
     const [first, second] = await Promise.all([
-      device("/device/token", { device_code: minted.device_code }),
-      device("/device/token", { device_code: minted.device_code }),
+      collectDeviceToken(
+        env.DB,
+        hash,
+        { id: "tok_race000000000a", token_hash: "hash-a", created_at: NOW },
+        MAX_TOKENS_PER_ACCOUNT,
+      ),
+      collectDeviceToken(
+        env.DB,
+        hash,
+        { id: "tok_race000000000b", token_hash: "hash-b", created_at: NOW },
+        MAX_TOKENS_PER_ACCOUNT,
+      ),
     ]);
 
-    const statuses = [first.status, second.status].sort();
-    expect(statuses).toEqual([200, 400]);
+    expect([first.status, second.status].sort()).toEqual(["gone", "issued"]);
     const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
     expect(n).toBe(1);
+    expect(await codeRow(minted.user_code)).toBeNull();
+  });
+});
+
+describe("claiming a polling interval", () => {
+  const lastPolled = async (userCode: string): Promise<number | null> =>
+    (await codeRow(userCode))?.last_polled_at ?? null;
+
+  /**
+   * Overlapping polls all read the same `last_polled_at`, so a check followed
+   * by a write would let every one of them through and every one of them write
+   * — turning the interval that exists to bound this endpoint's writes into the
+   * thing that makes them unbounded
+   * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928181821).
+   */
+  it("serves one poll of a concurrent burst and tells the rest to slow down", async () => {
+    const minted = await mint();
+
+    const burst = await Promise.all(
+      Array.from({ length: 6 }, () => device("/device/token", { device_code: minted.device_code })),
+    );
+
+    const codes = await Promise.all(burst.map(errorOf));
+    expect(codes.filter((code) => code !== "slow_down")).toEqual(["authorization_pending"]);
+    expect(await lastPolled(minted.user_code)).toBe(NOW);
+  });
+
+  it("writes nothing at all for a burst that arrives inside the interval", async () => {
+    const minted = await mint();
+    await device("/device/token", { device_code: minted.device_code }, NOW);
+
+    const burst = await Promise.all(
+      Array.from({ length: 6 }, (_, i) =>
+        device("/device/token", { device_code: minted.device_code }, NOW + 100 + i),
+      ),
+    );
+
+    expect(await Promise.all(burst.map(errorOf))).toEqual(Array(6).fill("slow_down"));
+    // Still the first poll's instant, so not one of the six wrote.
+    expect(await lastPolled(minted.user_code)).toBe(NOW);
+  });
+
+  it("claims again once the interval has elapsed", async () => {
+    const minted = await mint();
+    await device("/device/token", { device_code: minted.device_code }, NOW);
+
+    const later = NOW + MIN_DEVICE_POLL_GAP_MS;
+    expect(await errorOf(await device("/device/token", { device_code: minted.device_code }, later)))
+      .toBe("authorization_pending");
+    expect(await lastPolled(minted.user_code)).toBe(later);
+  });
+
+  it("never writes for a code that has expired or been refused", async () => {
+    const expired = await mint();
+    const denied = await mint();
+    await env.DB.prepare("UPDATE device_codes SET denied_at = ? WHERE user_code = ?")
+      .bind(NOW, denied.user_code)
+      .run();
+
+    const past = NOW + DEVICE_CODE_TTL_MS;
+    expect(await errorOf(await device("/device/token", { device_code: expired.device_code }, past)))
+      .toBe("expired_token");
+    expect(await errorOf(await device("/device/token", { device_code: denied.device_code }))).toBe(
+      "access_denied",
+    );
+
+    expect(await lastPolled(expired.user_code)).toBeNull();
+    expect(await lastPolled(denied.user_code)).toBeNull();
   });
 });
 

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -2,7 +2,11 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { describe, expect, it } from "vitest";
 import { handleApproval, normalizeUserCode } from "../src/approval/handler.js";
 import type { OAuthClient, ProviderId } from "../src/approval/providers.js";
-import { DEVICE_CODE_TTL_MS, DEVICE_POLL_INTERVAL_SECONDS } from "../src/config.js";
+import {
+  DEVICE_CODE_TTL_MS,
+  DEVICE_POLL_INTERVAL_SECONDS,
+  MAX_TOKENS_PER_ACCOUNT,
+} from "../src/config.js";
 import { handleDevice, readDeviceLabel } from "../src/device.js";
 import type { Env } from "../src/config.js";
 import { confirmDeviceApproval, holdProvenIdentity } from "../src/db.js";
@@ -78,6 +82,20 @@ function device(
 /** A mint from one address through a deployment that declares the limiter. */
 const mintFrom = (address: string) =>
   device("/device/code", undefined, NOW, { "cf-connecting-ip": address }, limited());
+
+/**
+ * A mint whose content type and body are whatever the caller says, which is how
+ * a request a browser would send cross-site without a preflight is reproduced.
+ */
+function crossSiteMint(contentType: string, body: string, address: string): Promise<Response> {
+  const url = new URL(`${ORIGIN}/device/code`);
+  const raw = new Request(url, {
+    method: "POST",
+    headers: { "content-type": contentType, "cf-connecting-ip": address },
+    body,
+  });
+  return handleDevice(raw, url, limited(), { now: () => NOW });
+}
 
 /** Through the router, which is what proves the surface is reachable at all. */
 async function routed(path: string, body?: unknown): Promise<Response> {
@@ -190,6 +208,43 @@ describe("POST /device/code", () => {
     const response = await device("/device/code");
     expect(response.status).toBe(200);
     expect((await codeRow((await response.json<Minted>()).user_code))?.label).toBeNull();
+  });
+
+  /**
+   * A page anybody visits can fire a form-encoded or text/plain POST at an
+   * unauthenticated endpoint without a preflight. If the limiter were charged
+   * before the request was validated, that page would spend a visitor's next
+   * sign-in for them (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3927574066).
+   */
+  it("refuses a request a browser could send cross-site without spending its bucket", async () => {
+    const address = "203.0.113.20";
+
+    for (let i = 0; i < MINTS_PER_PERIOD + 3; i += 1) {
+      const refused = await crossSiteMint(
+        i % 2 === 0 ? "application/x-www-form-urlencoded" : "text/plain;charset=UTF-8",
+        i % 2 === 0 ? "label=drive-by" : '{"label":"drive-by"}',
+        address,
+      );
+      expect(refused.status).toBe(400);
+      expect(await errorOf(refused)).toBe("bad_request");
+    }
+
+    // The bucket is untouched, so the visitor's own sign-in still works.
+    expect((await mintFrom(address)).status).toBe(200);
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM device_codes").first<{
+      n: number;
+    }>())!;
+    expect(n).toBe(1);
+  });
+
+  it("refuses a malformed JSON body before charging the bucket too", async () => {
+    const address = "203.0.113.21";
+
+    for (let i = 0; i < MINTS_PER_PERIOD + 1; i += 1) {
+      expect((await crossSiteMint("application/json", "not json", address)).status).toBe(400);
+    }
+
+    expect((await mintFrom(address)).status).toBe(200);
   });
 
   it("refuses a label that is not a string, and junk that is not JSON", async () => {
@@ -395,6 +450,79 @@ describe("POST /device/token", () => {
     expect(statuses).toEqual([200, 400]);
     const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
     expect(n).toBe(1);
+  });
+});
+
+describe("the ceiling on tokens an account may hold", () => {
+  const ACCOUNT = "oa_crowded_account";
+
+  /** Fill the account to one below the ceiling, cheaply. */
+  async function fillTokens(count: number): Promise<void> {
+    await env.DB.batch(
+      Array.from({ length: count }, (_, i) =>
+        env.DB.prepare(
+          `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).bind(`tok_seed${String(i).padStart(11, "0")}`, `hash-${i}`, ACCOUNT, null, NOW + i),
+      ),
+    );
+  }
+
+  it("refuses the collection past the ceiling and leaves the code collectable", async () => {
+    await fillTokens(MAX_TOKENS_PER_ACCOUNT);
+    const minted = await mint();
+    await approve(minted.user_code, ACCOUNT);
+
+    const refused = await device("/device/token", { device_code: minted.device_code });
+
+    expect(refused.status).toBe(429);
+    expect(await errorOf(refused)).toBe("quota_exceeded");
+    // Not spent: revoking one token and polling again finishes this same sign-in.
+    expect(await codeRow(minted.user_code)).not.toBeNull();
+    const { n } = (await env.DB.prepare("SELECT COUNT(*) AS n FROM tokens").first<{ n: number }>())!;
+    expect(n).toBe(MAX_TOKENS_PER_ACCOUNT);
+  });
+
+  it("collects on the next poll once room is made", async () => {
+    await fillTokens(MAX_TOKENS_PER_ACCOUNT);
+    const minted = await mint();
+    await approve(minted.user_code, ACCOUNT);
+    await device("/device/token", { device_code: minted.device_code });
+
+    await env.DB.prepare("UPDATE tokens SET revoked_at = ? WHERE id = ?")
+      .bind(NOW, "tok_seed00000000000")
+      .run();
+
+    const collected = await device(
+      "/device/token",
+      { device_code: minted.device_code },
+      NOW + DEVICE_POLL_INTERVAL_SECONDS * 1000,
+    );
+    expect(collected.status).toBe(200);
+  });
+
+  it("returns every token an account can hold, so none is invisible to revoke", async () => {
+    await fillTokens(MAX_TOKENS_PER_ACCOUNT - 1);
+    const minted = await mint();
+    await approve(minted.user_code, ACCOUNT);
+    const issued = await (await device("/device/token", { device_code: minted.device_code }))
+      .json<Issued>();
+
+    const ctx = createExecutionContext();
+    const listed = await worker.fetch(
+      new Request(`${ORIGIN}/api/v1/tokens`, {
+        headers: { authorization: `Bearer ${issued.access_token}` },
+      }),
+      configured(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const body = await listed.json<{ tokens: { tokenId: string }[] }>();
+    expect(body.tokens).toHaveLength(MAX_TOKENS_PER_ACCOUNT);
+    expect(body.tokens.map((row) => row.tokenId)).toContain(issued.token_id);
+    // The oldest is still listed, which is what makes it revocable.
+    expect(body.tokens.map((row) => row.tokenId)).toContain("tok_seed00000000000");
   });
 });
 

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -6,7 +6,6 @@ import {
   DEVICE_CODE_TTL_MS,
   DEVICE_POLL_INTERVAL_SECONDS,
   MAX_TOKENS_PER_ACCOUNT,
-  MIN_DEVICE_POLL_GAP_MS,
 } from "../src/config.js";
 import { handleDevice, readDeviceLabel } from "../src/device.js";
 import type { Env } from "../src/config.js";
@@ -62,6 +61,7 @@ const configured = (over: Partial<Env> = {}): Env =>
     OAUTH_GITHUB_CLIENT_SECRET: "github-secret",
     DEVICE_CODE_LIMITER: undefined,
     APPROVAL_LOOKUP_LIMITER: undefined,
+    DEVICE_POLL_LIMITER: undefined,
     ...over,
   }) as Env;
 
@@ -139,16 +139,13 @@ async function mint(body?: unknown, now = NOW): Promise<Minted> {
 const errorOf = async (response: Response): Promise<string> =>
   (await response.json<{ error: { code: string } }>()).error.code;
 
-const revokedAt = async (id: string): Promise<number | null> =>
-  (
-    await env.DB.prepare("SELECT revoked_at FROM tokens WHERE id = ?")
-      .bind(id)
-      .first<{ revoked_at: number | null }>()
-  )?.revoked_at ?? null;
+const tokenExists = async (id: string): Promise<boolean> =>
+  (await env.DB.prepare("SELECT id FROM tokens WHERE id = ?").bind(id).first<{ id: string }>()) !==
+  null;
 
 async function codeRow(userCode: string) {
   return await env.DB.prepare(
-    `SELECT device_code_hash, label, approved_at, denied_at, last_polled_at, expires_at
+    `SELECT device_code_hash, label, approved_at, denied_at, expires_at
        FROM device_codes WHERE user_code = ?`,
   )
     .bind(userCode)
@@ -157,7 +154,6 @@ async function codeRow(userCode: string) {
       label: string | null;
       approved_at: number | null;
       denied_at: number | null;
-      last_polled_at: number | null;
       expires_at: number;
     }>();
 }
@@ -326,7 +322,7 @@ describe("POST /device/code", () => {
     const url = new URL(`${ORIGIN}/device/code`);
     await handleDevice(request("/device/code", undefined, { "cf-connecting-ip": "203.0.113.30" }), url, configured(), {
       now: () => NOW,
-      limiter: watching,
+      mintLimiter: watching,
     });
 
     expect(keys).toHaveLength(1);
@@ -391,22 +387,21 @@ describe("POST /device/token", () => {
     );
   });
 
-  it("says slow down when the terminal polls faster than the interval it was given", async () => {
+  it("says slow down when the polling limiter refuses the request", async () => {
     const { device_code } = await mint();
-    await device("/device/token", { device_code }, NOW);
+    const refusing: RateLimit = { limit: async () => ({ success: false }) };
 
-    expect(await errorOf(await device("/device/token", { device_code }, NOW + 1_000))).toBe(
-      "slow_down",
-    );
     expect(
       await errorOf(
         await device(
           "/device/token",
           { device_code },
-          NOW + DEVICE_POLL_INTERVAL_SECONDS * 1000,
+          NOW,
+          {},
+          configured({ DEVICE_POLL_LIMITER: refusing }),
         ),
       ),
-    ).toBe("authorization_pending");
+    ).toBe("slow_down");
   });
 
   it("answers an unknown device code exactly as it answers an expired one", async () => {
@@ -449,7 +444,7 @@ describe("POST /device/token", () => {
       .json<Issued>();
 
     const row = await env.DB.prepare(
-      "SELECT token_hash, account_id, label, last_used_at, revoked_at FROM tokens WHERE id = ?",
+      "SELECT token_hash, account_id, label, last_used_at FROM tokens WHERE id = ?",
     )
       .bind(issued.token_id)
       .first<{
@@ -457,14 +452,12 @@ describe("POST /device/token", () => {
         account_id: string;
         label: string | null;
         last_used_at: number | null;
-        revoked_at: number | null;
       }>();
 
     expect(row?.account_id).toBe("oa_holder");
     expect(row?.token_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(row?.token_hash).not.toContain(issued.access_token);
     expect(row?.last_used_at).toBeNull();
-    expect(row?.revoked_at).toBeNull();
   });
 
   it("consumes the code, so replaying a collected device code gets nothing", async () => {
@@ -481,10 +474,8 @@ describe("POST /device/token", () => {
   });
 
   /**
-   * Below the handler, because the interval claim now stops two polls reaching
-   * the collection at once through it. The write still has to be safe on its
-   * own: the interval bounds a well-behaved client, it is not what makes
-   * issuing exclusive.
+   * Below the handler because the write has to be safe independently of the
+   * best-effort polling limiter.
    */
   it("issues one token when two collections race for the same approval", async () => {
     const minted = await mint();
@@ -513,70 +504,66 @@ describe("POST /device/token", () => {
   });
 });
 
-describe("claiming a polling interval", () => {
-  const lastPolled = async (userCode: string): Promise<number | null> =>
-    (await codeRow(userCode))?.last_polled_at ?? null;
-
-  /**
-   * Overlapping polls all read the same `last_polled_at`, so a check followed
-   * by a write would let every one of them through and every one of them write
-   * — turning the interval that exists to bound this endpoint's writes into the
-   * thing that makes them unbounded
-   * (https://github.com/Brevilabs/OpenArtifacts/pull/62#discussion_r3928181821).
-   */
+describe("limiting polls without database writes", () => {
   it("serves one poll of a concurrent burst and tells the rest to slow down", async () => {
     const minted = await mint();
+    let first = true;
+    const limiter: RateLimit = {
+      limit: async () => {
+        const success = first;
+        first = false;
+        return { success };
+      },
+    };
+    const deployment = configured({ DEVICE_POLL_LIMITER: limiter });
 
     const burst = await Promise.all(
-      Array.from({ length: 6 }, () => device("/device/token", { device_code: minted.device_code })),
+      Array.from({ length: 6 }, () =>
+        device("/device/token", { device_code: minted.device_code }, NOW, {}, deployment),
+      ),
     );
 
     const codes = await Promise.all(burst.map(errorOf));
     expect(codes.filter((code) => code !== "slow_down")).toEqual(["authorization_pending"]);
-    expect(await lastPolled(minted.user_code)).toBe(NOW);
   });
 
-  it("writes nothing at all for a burst that arrives inside the interval", async () => {
+  it("leaves the device row unchanged however many pending polls are served", async () => {
     const minted = await mint();
-    await device("/device/token", { device_code: minted.device_code }, NOW);
+    const before = await codeRow(minted.user_code);
+    const allowing: RateLimit = { limit: async () => ({ success: true }) };
+    const deployment = configured({ DEVICE_POLL_LIMITER: allowing });
 
     const burst = await Promise.all(
       Array.from({ length: 6 }, (_, i) =>
-        device("/device/token", { device_code: minted.device_code }, NOW + 100 + i),
+        device("/device/token", { device_code: minted.device_code }, NOW + i, {}, deployment),
       ),
     );
 
-    expect(await Promise.all(burst.map(errorOf))).toEqual(Array(6).fill("slow_down"));
-    // Still the first poll's instant, so not one of the six wrote.
-    expect(await lastPolled(minted.user_code)).toBe(NOW);
+    expect(await Promise.all(burst.map(errorOf))).toEqual(Array(6).fill("authorization_pending"));
+    expect(await codeRow(minted.user_code)).toEqual(before);
   });
 
-  it("claims again once the interval has elapsed", async () => {
+  it("keys the limiter by a hash rather than the raw device code", async () => {
     const minted = await mint();
-    await device("/device/token", { device_code: minted.device_code }, NOW);
+    const keys: string[] = [];
+    const watching: RateLimit = {
+      limit: async ({ key }) => {
+        keys.push(key);
+        return { success: true };
+      },
+    };
 
-    const later = NOW + MIN_DEVICE_POLL_GAP_MS;
-    expect(await errorOf(await device("/device/token", { device_code: minted.device_code }, later)))
-      .toBe("authorization_pending");
-    expect(await lastPolled(minted.user_code)).toBe(later);
-  });
-
-  it("never writes for a code that has expired or been refused", async () => {
-    const expired = await mint();
-    const denied = await mint();
-    await env.DB.prepare("UPDATE device_codes SET denied_at = ? WHERE user_code = ?")
-      .bind(NOW, denied.user_code)
-      .run();
-
-    const past = NOW + DEVICE_CODE_TTL_MS;
-    expect(await errorOf(await device("/device/token", { device_code: expired.device_code }, past)))
-      .toBe("expired_token");
-    expect(await errorOf(await device("/device/token", { device_code: denied.device_code }))).toBe(
-      "access_denied",
+    await device(
+      "/device/token",
+      { device_code: minted.device_code },
+      NOW,
+      {},
+      configured({ DEVICE_POLL_LIMITER: watching }),
     );
 
-    expect(await lastPolled(expired.user_code)).toBeNull();
-    expect(await lastPolled(denied.user_code)).toBeNull();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).not.toContain(minted.device_code);
+    expect(keys[0]).toMatch(/^[0-9a-f]{32}$/);
   });
 });
 
@@ -613,7 +600,7 @@ describe("the rolling window of tokens an account holds", () => {
 
   const liveTokens = async (): Promise<number> =>
     (await env.DB.prepare(
-      "SELECT COUNT(*) AS n FROM tokens WHERE account_id = ? AND revoked_at IS NULL",
+      "SELECT COUNT(*) AS n FROM tokens WHERE account_id = ?",
     )
       .bind(ACCOUNT)
       .first<{ n: number }>())!.n;
@@ -653,8 +640,8 @@ describe("the rolling window of tokens an account holds", () => {
     const issued = await signIn();
 
     expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
-    expect(await revokedAt("tok_victim000000000")).toBe(NOW);
-    expect(await revokedAt("tok_keeper000000000")).toBeNull();
+    expect(await tokenExists("tok_victim000000000")).toBe(false);
+    expect(await tokenExists("tok_keeper000000000")).toBe(true);
     expect(await asks(victim)).toBe(401);
     expect(await asks(issued.access_token)).toBe(200);
   });
@@ -666,8 +653,8 @@ describe("the rolling window of tokens an account holds", () => {
 
     await signIn();
 
-    expect(await revokedAt("tok_neverused000000")).toBe(NOW);
-    expect(await revokedAt("tok_ancient00000000")).toBeNull();
+    expect(await tokenExists("tok_neverused000000")).toBe(false);
+    expect(await tokenExists("tok_ancient00000000")).toBe(true);
   });
 
   it("evicts nothing while the account is under the window", async () => {
@@ -675,7 +662,7 @@ describe("the rolling window of tokens an account holds", () => {
 
     await signIn();
 
-    expect(await revokedAt("tok_lonely000000000")).toBeNull();
+    expect(await tokenExists("tok_lonely000000000")).toBe(true);
     expect(await liveTokens()).toBe(2);
   });
 
@@ -688,7 +675,7 @@ describe("the rolling window of tokens an account holds", () => {
       "authorization_pending",
     );
 
-    expect(await revokedAt("tok_untouched000000")).toBeNull();
+    expect(await tokenExists("tok_untouched000000")).toBe(true);
     expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
   });
 

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -691,6 +691,30 @@ describe("the rolling window of tokens an account holds", () => {
     expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
   });
 
+  it("evicts and issues nothing when an approved code expires before collection", async () => {
+    await seedToken("tok_untouched000000", null);
+    await padTo(MAX_TOKENS_PER_ACCOUNT, 1);
+    const minted = await mint();
+    await approve(minted.user_code, ACCOUNT);
+    const hash = (await codeRow(minted.user_code))!.device_code_hash!;
+
+    const issued = await collectDeviceToken(
+      env.DB,
+      hash,
+      {
+        id: "tok_expired00000000",
+        token_hash: "hash-expired-collection",
+        created_at: NOW + DEVICE_CODE_TTL_MS,
+      },
+      MAX_TOKENS_PER_ACCOUNT,
+    );
+
+    expect(issued).toBeNull();
+    expect(await tokenExists("tok_untouched000000")).toBe(true);
+    expect(await tokenExists("tok_expired00000000")).toBe(false);
+    expect(await liveTokens()).toBe(MAX_TOKENS_PER_ACCOUNT);
+  });
+
   it("issues one token when two collections race at the window", async () => {
     await seedToken("tok_victim000000000", NOW - 5_000);
     await padTo(MAX_TOKENS_PER_ACCOUNT, 1);

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -36,13 +36,13 @@ const local = (over: Partial<Env> = {}): Env =>
  */
 async function issueToken(
   accountId: string,
-  over: { label?: string | null; createdAt?: number; revokedAt?: number | null } = {},
+  over: { label?: string | null; createdAt?: number } = {},
 ): Promise<{ token: string; id: string }> {
   const token = newApiToken();
   const id = newTokenId();
   await env.DB.prepare(
-    `INSERT INTO tokens (id, token_hash, account_id, label, created_at, revoked_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO tokens (id, token_hash, account_id, label, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
   )
     .bind(
       id,
@@ -50,7 +50,6 @@ async function issueToken(
       accountId,
       over.label ?? null,
       over.createdAt ?? NOW,
-      over.revokedAt ?? null,
     )
     .run();
   return { token, id };
@@ -280,9 +279,10 @@ describe("GET /api/v1/tokens", () => {
     expect(listed.find((row) => row.tokenId === id)?.lastUsedAt).toBeGreaterThan(0);
   });
 
-  it("hides revoked tokens and every other account's", async () => {
+  it("omits deleted tokens and every other account's", async () => {
     const mine = await issueToken(ACCOUNT_A);
-    await issueToken(ACCOUNT_A, { revokedAt: NOW });
+    const removed = await issueToken(ACCOUNT_A);
+    await env.DB.prepare("DELETE FROM tokens WHERE id = ?").bind(removed.id).run();
     await issueToken(ACCOUNT_B);
 
     const listed = await tokensOf(await send("GET", "/api/v1/tokens", mine.token));
@@ -336,7 +336,8 @@ describe("DELETE /api/v1/tokens/{tokenId}", () => {
   it("answers 404 for another account's token, a revoked one, and a malformed id alike", async () => {
     const mine = await issueToken(ACCOUNT_A);
     const theirs = await issueToken(ACCOUNT_B);
-    const already = await issueToken(ACCOUNT_A, { revokedAt: NOW });
+    const already = await issueToken(ACCOUNT_A);
+    expect((await send("DELETE", `/api/v1/tokens/${already.id}`, mine.token)).status).toBe(200);
 
     for (const id of [theirs.id, already.id, newTokenId(), "not-a-token-id"]) {
       const response = await send("DELETE", `/api/v1/tokens/${id}`, mine.token);

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -1,0 +1,365 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ACCOUNT_TOKEN_PLAN, resolvePublisher } from "../src/auth.js";
+import { TOKEN_LAST_USED_RESOLUTION_MS } from "../src/config.js";
+import type { Env } from "../src/config.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId } from "../src/ids.js";
+import worker from "../src/index.js";
+
+/** Local routing has no configured hosts, so the surfaces resolve by path prefix. */
+const ORIGIN = "https://openartifacts.workers.dev";
+
+const NOW = 1_800_000_000_000;
+
+const ACCOUNT_A = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const ACCOUNT_B = "oa_bbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+/** A license key, to prove both credentials reach the same routes unchanged. */
+const LICENSE_KEY = "cplus_live_a1b2c3d4e5f60718";
+const LICENSE_ACCOUNT = "e2b7a0c4-1f3d-4a6b-9c8e-2d5f7a1b3c9d";
+
+const local = (over: Partial<Env> = {}): Env =>
+  ({
+    ...env,
+    SERVING_HOST: "",
+    API_HOST: "",
+    LEGACY_SERVING_HOST: "",
+    RETIRED_API_HOST: "",
+    ...over,
+  }) as Env;
+
+/**
+ * Put a token on an account without going through the device flow. These cases
+ * are about what a token does once it exists; `test/device.test.ts` covers how
+ * one comes to exist.
+ */
+async function issueToken(
+  accountId: string,
+  over: { label?: string | null; createdAt?: number; revokedAt?: number | null } = {},
+): Promise<{ token: string; id: string }> {
+  const token = newApiToken();
+  const id = newTokenId();
+  await env.DB.prepare(
+    `INSERT INTO tokens (id, token_hash, account_id, label, created_at, revoked_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      id,
+      await sha256Hex(token),
+      accountId,
+      over.label ?? null,
+      over.createdAt ?? NOW,
+      over.revokedAt ?? null,
+    )
+    .run();
+  return { token, id };
+}
+
+/** A warm license-validation row, so no case here reaches a license server. */
+async function seedLicense(): Promise<void> {
+  await env.DB.prepare(
+    `INSERT OR REPLACE INTO publishers (key_hash, plan, validated_at, owner)
+     VALUES (?, 'believer', ?, ?)`,
+  )
+    .bind(await sha256Hex(LICENSE_KEY), Date.now(), LICENSE_ACCOUNT)
+    .run();
+}
+
+const BODILESS = new Set([204, 205, 304]);
+
+async function send(
+  method: string,
+  path: string,
+  credential: string | null,
+  body?: unknown,
+): Promise<Response> {
+  const headers = new Headers();
+  if (credential !== null) headers.set("authorization", `Bearer ${credential}`);
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    headers.set("content-type", "application/json");
+    init.body = JSON.stringify(body);
+  }
+
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`${ORIGIN}${path}`, init), local(), ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+const page = (body: string) => `<!doctype html><html><body><p>${body}</p></body></html>`;
+
+interface PushResponse {
+  docId: string;
+  url: string;
+  version: number;
+}
+
+async function publish(credential: string, title: string): Promise<PushResponse> {
+  const response = await send("POST", "/api/v1/docs", credential, { title, html: page(title) });
+  expect(response.status).toBe(201);
+  return await response.json<PushResponse>();
+}
+
+interface ListedToken {
+  tokenId: string;
+  label: string | null;
+  createdAt: number;
+  lastUsedAt: number | null;
+}
+
+const tokensOf = async (response: Response): Promise<ListedToken[]> =>
+  (await response.json<{ tokens: ListedToken[] }>()).tokens;
+
+const errorOf = async (response: Response): Promise<string> =>
+  (await response.json<{ error: { code: string } }>()).error.code;
+
+beforeEach(async () => {
+  await seedLicense();
+});
+
+describe("Authorization: Bearer <token>", () => {
+  it("publishes, lists, updates and unshares exactly as a license key does", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+
+    const created = await publish(token, "From a token");
+    expect(created.url).toContain(`/d/${created.docId}`);
+
+    const updated = await send("PUT", `/api/v1/docs/${created.docId}`, token, {
+      html: page("second"),
+    });
+    expect(updated.status).toBe(200);
+    expect((await updated.json<PushResponse>()).version).toBe(2);
+
+    const listed = await send("GET", "/api/v1/docs", token);
+    expect(listed.status).toBe(200);
+    expect(await listed.json<{ docs: { docId: string }[] }>()).toMatchObject({
+      docs: [{ docId: created.docId }],
+    });
+
+    expect((await send("DELETE", `/api/v1/docs/${created.docId}`, token)).status).toBe(204);
+  });
+
+  it("files documents under the account rather than the token, so a second token sees them", async () => {
+    const first = await issueToken(ACCOUNT_A);
+    const second = await issueToken(ACCOUNT_A);
+
+    const created = await publish(first.token, "Shared shelf");
+
+    const listed = await tokensSeeDoc(second.token);
+    expect(listed).toContain(created.docId);
+  });
+
+  it("refuses a token this deployment never issued, with the frozen code", async () => {
+    const response = await send("GET", "/api/v1/docs", newApiToken());
+
+    expect(response.status).toBe(401);
+    expect(await errorOf(response)).toBe("unauthorized");
+    expect(response.headers.get("www-authenticate")).toBe("Bearer");
+  });
+
+  it("never sends a token to the license server", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+    let calls = 0;
+
+    const resolved = await resolvePublisher(
+      token,
+      local({ LICENSE_API_URL: "https://license.test", LICENSE_API_KEY: "ours" }),
+      {
+        fetch: async () => {
+          calls += 1;
+          return Response.json({});
+        },
+      },
+    );
+
+    expect(calls).toBe(0);
+    expect(resolved).toEqual({
+      ok: true,
+      publisher: { owner: ACCOUNT_A, plan: ACCOUNT_TOKEN_PLAN },
+    });
+  });
+
+  it("lets a brand-new account publish, which a plan that may not would not", async () => {
+    const { token } = await issueToken(ACCOUNT_B);
+
+    const created = await publish(token, "First ever");
+    expect((await send("PUT", `/api/v1/docs/${created.docId}`, token, { html: page("v2") })).status)
+      .toBe(200);
+  });
+
+  it("answers 404 for another account's document, never 403", async () => {
+    const mine = await issueToken(ACCOUNT_A);
+    const theirs = await issueToken(ACCOUNT_B);
+    const created = await publish(mine.token, "Mine");
+
+    for (const attempt of [
+      await send("PUT", `/api/v1/docs/${created.docId}`, theirs.token, { html: page("x") }),
+      await send("DELETE", `/api/v1/docs/${created.docId}`, theirs.token),
+    ]) {
+      expect(attempt.status).toBe(404);
+      expect(await errorOf(attempt)).toBe("not_found");
+    }
+    expect(await tokensSeeDoc(theirs.token)).not.toContain(created.docId);
+  });
+
+  it("keeps a license key's documents away from a token account, and the other way round", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+    const licensed = await publish(LICENSE_KEY, "Copilot doc");
+    const fromToken = await publish(token, "Token doc");
+
+    expect(await tokensSeeDoc(token)).toEqual([fromToken.docId]);
+    expect(await tokensSeeDoc(LICENSE_KEY)).toEqual([licensed.docId]);
+    expect((await send("DELETE", `/api/v1/docs/${licensed.docId}`, token)).status).toBe(404);
+  });
+});
+
+async function tokensSeeDoc(credential: string): Promise<string[]> {
+  const listed = await send("GET", "/api/v1/docs", credential);
+  const body = await listed.json<{ docs: { docId: string }[] }>();
+  return body.docs.map((doc) => doc.docId);
+}
+
+describe("recording when a token was last used", () => {
+  const lastUsed = async (id: string): Promise<number | null> =>
+    (
+      await env.DB.prepare("SELECT last_used_at FROM tokens WHERE id = ?")
+        .bind(id)
+        .first<{ last_used_at: number | null }>()
+    )?.last_used_at ?? null;
+
+  it("records the first use immediately", async () => {
+    const { token, id } = await issueToken(ACCOUNT_A);
+
+    await resolvePublisher(token, local(), { now: () => NOW });
+
+    expect(await lastUsed(id)).toBe(NOW);
+  });
+
+  it("leaves it alone for the rest of the hour, so a read is not a write", async () => {
+    const { token, id } = await issueToken(ACCOUNT_A);
+    await resolvePublisher(token, local(), { now: () => NOW });
+
+    await resolvePublisher(token, local(), { now: () => NOW + 60_000 });
+
+    expect(await lastUsed(id)).toBe(NOW);
+  });
+
+  it("moves it forward once the recorded use is older than the resolution", async () => {
+    const { token, id } = await issueToken(ACCOUNT_A);
+    await resolvePublisher(token, local(), { now: () => NOW });
+
+    const later = NOW + TOKEN_LAST_USED_RESOLUTION_MS + 1;
+    await resolvePublisher(token, local(), { now: () => later });
+
+    expect(await lastUsed(id)).toBe(later);
+  });
+});
+
+describe("GET /api/v1/tokens", () => {
+  it("lists this account's live tokens, newest first, and never a value", async () => {
+    const older = await issueToken(ACCOUNT_A, { label: "Codex on ci", createdAt: NOW - 1000 });
+    const newer = await issueToken(ACCOUNT_A, { label: null, createdAt: NOW });
+
+    const listed = await tokensOf(await send("GET", "/api/v1/tokens", older.token));
+
+    expect(listed.map((row) => row.tokenId)).toEqual([newer.id, older.id]);
+    expect(listed[1]).toMatchObject({ label: "Codex on ci", createdAt: NOW - 1000 });
+    expect(listed[0]?.label).toBeNull();
+    expect(JSON.stringify(listed)).not.toContain(older.token);
+    expect(JSON.stringify(listed)).not.toContain(newer.token);
+  });
+
+  it("reports the use it recorded, once there is one", async () => {
+    const { token, id } = await issueToken(ACCOUNT_A);
+    await send("GET", "/api/v1/docs", token);
+
+    const listed = await tokensOf(await send("GET", "/api/v1/tokens", token));
+
+    expect(listed.find((row) => row.tokenId === id)?.lastUsedAt).toBeGreaterThan(0);
+  });
+
+  it("hides revoked tokens and every other account's", async () => {
+    const mine = await issueToken(ACCOUNT_A);
+    await issueToken(ACCOUNT_A, { revokedAt: NOW });
+    await issueToken(ACCOUNT_B);
+
+    const listed = await tokensOf(await send("GET", "/api/v1/tokens", mine.token));
+
+    expect(listed.map((row) => row.tokenId)).toEqual([mine.id]);
+  });
+
+  it("gives a license key an empty list rather than a refusal", async () => {
+    await issueToken(ACCOUNT_A);
+
+    const response = await send("GET", "/api/v1/tokens", LICENSE_KEY);
+
+    expect(response.status).toBe(200);
+    expect(await tokensOf(response)).toEqual([]);
+  });
+});
+
+describe("DELETE /api/v1/tokens/{tokenId}", () => {
+  it("revokes the token and says how many the account has left", async () => {
+    const keeping = await issueToken(ACCOUNT_A);
+    const going = await issueToken(ACCOUNT_A);
+
+    const response = await send("DELETE", `/api/v1/tokens/${going.id}`, keeping.token);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ tokenId: going.id, remaining: 1 });
+  });
+
+  it("stops the revoked token on its very next request", async () => {
+    const keeping = await issueToken(ACCOUNT_A);
+    const going = await issueToken(ACCOUNT_A);
+    expect((await send("GET", "/api/v1/docs", going.token)).status).toBe(200);
+
+    await send("DELETE", `/api/v1/tokens/${going.id}`, keeping.token);
+
+    const after = await send("GET", "/api/v1/docs", going.token);
+    expect(after.status).toBe(401);
+    expect(await errorOf(after)).toBe("unauthorized");
+  });
+
+  it("allows revoking the only token, and says nothing is left", async () => {
+    const only = await issueToken(ACCOUNT_A);
+
+    const response = await send("DELETE", `/api/v1/tokens/${only.id}`, only.token);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ tokenId: only.id, remaining: 0 });
+    expect((await send("GET", "/api/v1/tokens", only.token)).status).toBe(401);
+  });
+
+  it("answers 404 for another account's token, a revoked one, and a malformed id alike", async () => {
+    const mine = await issueToken(ACCOUNT_A);
+    const theirs = await issueToken(ACCOUNT_B);
+    const already = await issueToken(ACCOUNT_A, { revokedAt: NOW });
+
+    for (const id of [theirs.id, already.id, newTokenId(), "not-a-token-id"]) {
+      const response = await send("DELETE", `/api/v1/tokens/${id}`, mine.token);
+      expect(response.status).toBe(404);
+      expect(await errorOf(response)).toBe("not_found");
+    }
+    // Refusing another account's revoke must not have revoked it either.
+    expect((await send("GET", "/api/v1/docs", theirs.token)).status).toBe(200);
+  });
+
+  it("has no route for any other method or shape", async () => {
+    const { token, id } = await issueToken(ACCOUNT_A);
+
+    expect((await send("DELETE", "/api/v1/tokens", token)).status).toBe(404);
+    expect((await send("POST", "/api/v1/tokens", token)).status).toBe(404);
+    expect((await send("GET", `/api/v1/tokens/${id}`, token)).status).toBe(404);
+    expect((await send("DELETE", `/api/v1/tokens/${id}/extra`, token)).status).toBe(404);
+  });
+
+  it("needs a credential, like every other route under /api/v1", async () => {
+    const { id } = await issueToken(ACCOUNT_A);
+
+    expect((await send("GET", "/api/v1/tokens", null)).status).toBe(401);
+    expect((await send("DELETE", `/api/v1/tokens/${id}`, null)).status).toBe(401);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,6 +23,25 @@
     { "pattern": "api.symposium.md", "custom_domain": true }
   ],
 
+  // The limiter on POST /device/code, which is unauthenticated by necessity —
+  // the caller has no credential yet, which is the entire reason it is asking.
+  //
+  // The binding rather than a D1 counter, because a counter in a row costs a
+  // write per attempt including every refused one, so the limiter itself would
+  // be the thing that exhausts a self-hoster's daily write budget under exactly
+  // the abuse it exists to stop. docs/cost-at-scale.md says counters go here or
+  // in a Durable Object, never in D1 rows. A refused request here costs
+  // nothing.
+  //
+  // `namespace_id` is unique per account, not per Worker: an operator running
+  // more than one Worker has to give each limiter its own. `period` accepts
+  // only 10 or 60. `DEVICE_MINT_PERIOD_SECONDS` in src/config.ts must match the
+  // period, since the Retry-After header is the only place the number is
+  // needed in code.
+  "ratelimits": [
+    { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } }
+  ],
+
   // R2 is the system of record: every served byte lives here.
   "r2_buckets": [{ "binding": "DOCS", "bucket_name": "symposium-docs" }],
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,6 +50,15 @@
       "name": "APPROVAL_LOOKUP_LIMITER",
       "namespace_id": "1002",
       "simple": { "limit": 20, "period": 60 }
+    },
+    // Polling is keyed by the hash of the secret device code, not by address:
+    // one machine cannot make another wait behind the same NAT. Keeping this in
+    // a binding also makes every pending poll a D1 read instead of a timestamp
+    // write. The advertised DEVICE_POLL_INTERVAL_SECONDS must match the period.
+    {
+      "name": "DEVICE_POLL_LIMITER",
+      "namespace_id": "1003",
+      "simple": { "limit": 1, "period": 10 }
     }
   ],
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -59,6 +59,15 @@
       "name": "DEVICE_POLL_LIMITER",
       "namespace_id": "1003",
       "simple": { "limit": 1, "period": 10 }
+    },
+    // A separate address bucket runs before the D1 lookup. Per-code buckets
+    // alone can be bypassed with a fresh random code on every request. Twenty
+    // polls per ten seconds leaves ample room for shared networks while
+    // bounding misses from one caller.
+    {
+      "name": "DEVICE_POLL_CLIENT_LIMITER",
+      "namespace_id": "1004",
+      "simple": { "limit": 20, "period": 10 }
     }
   ],
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,7 +39,18 @@
   // period, since the Retry-After header is the only place the number is
   // needed in code.
   "ratelimits": [
-    { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } }
+    { "name": "DEVICE_CODE_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },
+    // The approval page's own limit, on looking a user code up and on starting
+    // a handshake against one. Separate from the mint's because it protects a
+    // different thing — guessing a user code, rather than the write budget —
+    // and because one ordinary sign-in spends three of a shared bucket.
+    // Twenty a minute is meaningless against the code's own entropy and still
+    // generous for somebody retyping a code off a phone.
+    {
+      "name": "APPROVAL_LOOKUP_LIMITER",
+      "namespace_id": "1002",
+      "simple": { "limit": 20, "period": 60 }
+    }
   ],
 
   // R2 is the system of record: every served byte lives here.


### PR DESCRIPTION
Fixes #57

## Why

The API accepts only Brevilabs license keys today. An agent acting for someone without one has no credential, and asking the person to paste a secret into chat would copy that secret into transcripts and logs.

The server needs a browser-assisted way to issue its own token, plus an API-only way to list and revoke those tokens. The terminal client that consumes this contract is separate work in #59.

## What

A client can now request a device code, show the returned approval URL, and poll for an opaque token. The person signs in through the existing approval page, sees which machine is asking, and explicitly approves or denies it.

| State | API result |
| --- | --- |
| Nobody has approved yet | `authorization_pending` |
| The hosted client exceeds either polling limit | `slow_down` |
| The person denies the request | `access_denied` |
| The code expires, is unknown, or was already collected | `expired_token` |
| The person approves | One `oat_...` token is returned and the code is consumed |

OpenArtifacts tokens work on every existing `/api/v1/*` route without entering the Brevilabs license-key path. Documents belong to the account, not to one token, so all tokens for an account see the same shelf and quotas.

`GET /api/v1/tokens` returns every token an account currently holds, without values. `DELETE /api/v1/tokens/{tokenId}` revokes one immediately. An account holds at most 100 tokens; collecting the next one removes the least recently used token so lost machines cannot create a permanent lockout.

The hosted deployment has separate limits for device-code minting and approval-code lookup, plus aggregate per-client and interval per-code poll limits. The aggregate limit runs before D1; the interval limit is keyed by the device-code hash, and pending polls are read-only in D1. Revocation removes token rows, so dead credentials do not accumulate forever. Token issue and code consumption remain transactional and do not depend on the rate limiter being exact.

## Non goal

- No npm package, CLI, agent skill, local token storage, or `OPENARTIFACTS_TOKEN`; #59 owns the client.
- No browser dashboard or persistent browser session.
- No per-plan limits, `402`, or admin API; that is #60.
- No document-scoped tokens.
- No change to license-key validation or caching.

## Screenshot

A rendered before/after screenshot is blocked because no Google or GitHub OAuth application is configured for the callback, so the confirmation page cannot be reached in the deployed product yet. The deterministic approval tests exercise the rendered HTML and escaping.

| Before | After |
| --- | --- |
| The page says “that terminal” and offers only “Approve this device.” | The page names the requesting machine and offers both “Approve this device” and “Deny.” |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Device, approval, auth, token-management, migration, and concurrency branches have deterministic workerd tests |
| A defect would fail CI or be obvious on first use | ✅ | The route and state-machine tests run in CI, including the configured rate limiter bindings |
| A revert fully restores prior state, including persisted data | ❌ | Migration `0004` adds device columns and a token table; reverting code leaves that additive schema behind |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | This adds a bearer credential, two unauthenticated JSON endpoints, approval inputs, and token revocation |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The public HTTP contract gains device and token endpoints plus four polling errors |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Approval, denial, polling, collection, LRU replacement, and concurrent collection form a new state machine |
| No hot-path behavior lacks deterministic coverage | ✅ | Authentication, read-only pending polling, collection races, token replacement, and immediate revocation are covered |
| No new dependency | ✅ | Dependency manifests are unchanged; rate limiting uses Worker bindings |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The only human surface is the existing approval page, and each result is shown immediately |

Review: inspect `mint` and `poll` in `src/device.ts`; `collectDeviceToken`, `findLiveToken`, and `revokeAccountToken` in `src/db.ts`; `resolveAccountToken` in `src/auth.ts`; and `begin`, `prove`, `confirm`, and `deny` in `src/approval/handler.ts`. Then run Verification steps 2 through 6, including malformed input, denial, replay, and concurrent collection.

## Verification

1. Apply migration `0004` to a local D1 database and configure a Google or GitHub OAuth callback at `http://127.0.0.1:8787/approve/callback/{provider}`.
2. Run the typecheck and test suite. Confirm the malformed-body, limiter, denial, replay, cross-account, and concurrent-collection cases pass.
3. Start the Worker locally. `POST /device/code` with JSON and a machine label; confirm the response contains two codes, both approval URLs, a 15-minute expiry, and a 10-second interval.
4. Poll once before approval, then immediately again. Confirm `authorization_pending` followed by `slow_down`. Submit a non-JSON body and confirm `bad_request`.
5. Open the complete approval URL. Confirm the machine label is escaped and visible. Exercise Deny once and Approve on a fresh code. Confirm denial returns `access_denied`; after approval and the next interval, collection returns one token; replay returns `expired_token`.
6. Use the token to publish and list a document, list tokens, and revoke the token. Confirm the next authenticated request is `401 unauthorized`, and a different account receives `404 not_found` for the first account's document and token ID.

## Note

Migration `0004` adds three nullable columns to `device_codes` and creates `tokens`. Production has `0003` applied and must receive `0004` before this Worker version deploys.

`wrangler.jsonc` declares `DEVICE_CODE_LIMITER` on namespace `1001`, `APPROVAL_LOOKUP_LIMITER` on `1002`, `DEVICE_POLL_LIMITER` on `1003`, and `DEVICE_POLL_CLIENT_LIMITER` on `1004`. Namespace IDs are account-global, so verify these four are unused by other Brevilabs Workers before deployment. WAF rules on `POST /device/code`, `POST /device/token`, and `/approve` remain the edge layer because a request refused inside the Worker has already been billed.

Production approval still needs the Google and GitHub OAuth applications requested by #56. Until they are configured, clients can mint and poll but nobody can complete approval.

