### PR TITLE
Add the OpenArtifacts agent CLI and skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ comments do not exist yet.
 - **Bound abuse.** The current limits are 10 MB per document, 100 pushes per UTC
   day, and 500 live documents per owner.
 
+## Use from an agent
+
+Install the CLI and shared skill into detected Claude Code, Codex, OpenCode,
+and pi installations:
+
+```bash
+npx @brevilabs/openartifacts install
+```
+
+The first publish opens a browser approval and stores the resulting token
+without printing it. Later publishes of the same local file update its existing
+document. Set `OPENARTIFACTS_API_HOST` for a self-hosted deployment, or provide
+an opaque credential through `OPENARTIFACTS_TOKEN` in a non-interactive session.
+
 ## Vision
 
 OpenArtifacts is an agent-first medium for publishing and reading webpages and

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install the CLI and shared skill into detected Claude Code, Codex, OpenCode,
 and pi installations:
 
 ```bash
-npx @brevilabs/openartifacts install
+npx openartifacts install
 ```
 
 The first publish opens a browser approval and stores the resulting token

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "openartifacts",
       "version": "0.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "arctic": "^3.7.0"
       },
@@ -21,6 +24,10 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@brevilabs/openartifacts": {
+      "resolved": "packages/openartifacts",
+      "link": true
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -2684,6 +2691,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+      "integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260426.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260426.0.tgz",
@@ -3847,6 +3866,20 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "packages/openartifacts": {
+      "name": "@brevilabs/openartifacts",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^18.0.11"
+      },
+      "bin": {
+        "openartifacts": "bin/openartifacts.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@brevilabs/openartifacts": {
-      "resolved": "packages/openartifacts",
-      "link": true
-    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
@@ -2750,6 +2746,10 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/openartifacts": {
+      "resolved": "packages/openartifacts",
+      "link": true
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -3869,8 +3869,7 @@
       }
     },
     "packages/openartifacts": {
-      "name": "@brevilabs/openartifacts",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "marked": "^18.0.11"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "dev": "wrangler dev --var SERVING_HOST: --var API_HOST: --var LEGACY_SERVING_HOST: --var RETIRED_API_HOST: --local-upstream 127.0.0.1:8787",
     "deploy": "wrangler deploy",
-    "typecheck": "tsc --noEmit && npm run typecheck -w @brevilabs/openartifacts",
-    "test": "vitest run && npm test -w @brevilabs/openartifacts",
+    "typecheck": "tsc --noEmit && npm run typecheck -w packages/openartifacts",
+    "test": "vitest run && npm test -w packages/openartifacts",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "description": "Push a local md/html file, get a public HTML page on the internet",
   "type": "module",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "dev": "wrangler dev --var SERVING_HOST: --var API_HOST: --var LEGACY_SERVING_HOST: --var RETIRED_API_HOST: --local-upstream 127.0.0.1:8787",
     "deploy": "wrangler deploy",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "typecheck": "tsc --noEmit && npm run typecheck -w @brevilabs/openartifacts",
+    "test": "vitest run && npm test -w @brevilabs/openartifacts",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/packages/openartifacts/LICENSE
+++ b/packages/openartifacts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brevilabs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -3,7 +3,7 @@
 Install the CLI and the shared OpenArtifacts skill into detected Claude Code, Codex, OpenCode, and pi installations:
 
 ```bash
-npx @brevilabs/openartifacts install
+npx openartifacts install
 ```
 
 The `openartifacts` binary can then publish Markdown or HTML, update the same document on repeat publishes, list and fetch documents, unshare them, and list or revoke machine tokens. The first authenticated command opens the browser device flow and stores the resulting token with owner-only permissions.

--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -1,0 +1,11 @@
+# OpenArtifacts CLI
+
+Install the CLI and the shared OpenArtifacts skill into detected Claude Code, Codex, OpenCode, and pi installations:
+
+```bash
+npx @brevilabs/openartifacts install
+```
+
+The `openartifacts` binary can then publish Markdown or HTML, update the same document on repeat publishes, list and fetch documents, unshare them, and list or revoke machine tokens. The first authenticated command opens the browser device flow and stores the resulting token with owner-only permissions.
+
+Set `OPENARTIFACTS_TOKEN` to supply a credential without browser sign-in. Set `OPENARTIFACTS_API_HOST` to target a self-hosted deployment.

--- a/packages/openartifacts/bin/openartifacts.js
+++ b/packages/openartifacts/bin/openartifacts.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { main, presentError } from "../src/cli.js";
+
+try {
+  await main(process.argv.slice(2));
+} catch (error) {
+  presentError(error);
+  process.exitCode = 1;
+}

--- a/packages/openartifacts/package.json
+++ b/packages/openartifacts/package.json
@@ -1,9 +1,21 @@
 {
-  "name": "@brevilabs/openartifacts",
-  "version": "0.1.0",
+  "name": "openartifacts",
+  "version": "0.2.0",
   "description": "Install the OpenArtifacts agent skill and publish files from the terminal",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Brevilabs/OpenArtifacts.git",
+    "directory": "packages/openartifacts"
+  },
+  "bugs": {
+    "url": "https://github.com/Brevilabs/OpenArtifacts/issues"
+  },
+  "homepage": "https://github.com/Brevilabs/OpenArtifacts#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "openartifacts": "./bin/openartifacts.js"
   },

--- a/packages/openartifacts/package.json
+++ b/packages/openartifacts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@brevilabs/openartifacts",
+  "version": "0.1.0",
+  "description": "Install the OpenArtifacts agent skill and publish files from the terminal",
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "openartifacts": "./bin/openartifacts.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "skill",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node --test test/cli.node.js",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "marked": "^18.0.11"
+  }
+}

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: openartifacts
+description: Publish, update, list, fetch, or unshare public OpenArtifacts documents and manage this machine's OpenArtifacts access.
+---
+
+# OpenArtifacts
+
+Use the `openartifacts` CLI for every operation. Do not read OpenArtifacts config files, look for credentials, or print `OPENARTIFACTS_TOKEN`.
+
+- Publish Markdown or HTML: `openartifacts publish <file>`
+- List documents: `openartifacts list`
+- Fetch current HTML: `openartifacts get <docId>`
+- Withdraw a document: `openartifacts unshare <docId>`
+- List machine tokens: `openartifacts tokens`
+- Revoke one: `openartifacts revoke <tokenId>`
+- Sign in again after an `unauthorized` response: `openartifacts login`
+
+The first authenticated command may wait for approval. Relay both sign-in URLs and the user code printed by the CLI, then keep waiting; never ask the user to copy a token. Return the public URL printed by `publish`.
+
+Publishing the same local file again updates its existing document. If an update returns `not_found`, stop and report it; do not create a replacement. If publishing returns `limit_reached`, show its limit and upgrade link when present, and retry only after the user confirms the limit was changed.

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -17,4 +17,10 @@ Use the `openartifacts` CLI for every operation. Do not read OpenArtifacts confi
 
 The first authenticated command may wait for approval. Relay both sign-in URLs and the user code printed by the CLI, then keep waiting; never ask the user to copy a token. Return the public URL printed by `publish`.
 
-Publishing the same local file again updates its existing document. If an update returns `not_found`, stop and report it; do not create a replacement. If publishing returns `limit_reached`, show its limit and upgrade link when present, and retry only after the user confirms the limit was changed.
+Publishing the same local file again updates its existing document. If an update returns `not_found`, stop and report it; do not create a replacement.
+
+Markdown files use ordinary Markdown rendering. Obsidian wikilinks, embeds, and callouts are not expanded and will appear as literal text.
+
+If the user explicitly wants a new link after an update returns `not_found`, ask for confirmation, run `openartifacts unshare <oldDocId>` to forget the stale local mapping, then publish the file again. Never take that recovery path automatically.
+
+If publishing returns `quota_exceeded`, show the error and advise the user to wait for the current quota window or remove an unused document, as appropriate. Do not blindly retry. If publishing returns `limit_reached`, show its limit and upgrade link when present, and retry only after the user confirms the limit was changed.

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -175,11 +175,21 @@ async function credential(host, directory) {
   return stored.hosts?.[host]?.token ?? login(host, directory);
 }
 
-/** @param {string} npm */
+/** @param {NodeJS.Platform} os */
+export function npmProcess(os = platform()) {
+  return os === "win32"
+    ? { command: "npm.cmd", shell: true }
+    : { command: "npm", shell: false };
+}
+
+/** @param {{command: string, shell: boolean}} npm */
 async function npmGlobalRoot(npm) {
   return new Promise((resolvePromise, reject) => {
     let output = "";
-    const child = spawn(npm, ["root", "--global"], { stdio: ["ignore", "pipe", "inherit"] });
+    const child = spawn(npm.command, ["root", "--global"], {
+      shell: npm.shell,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk) => { output += chunk; });
     child.on("error", reject);
@@ -191,9 +201,12 @@ async function npmGlobalRoot(npm) {
 
 async function install() {
   const manifest = JSON.parse(await readFile(join(PACKAGE_ROOT, "package.json"), "utf8"));
-  const npm = platform() === "win32" ? "npm.cmd" : "npm";
+  const npm = npmProcess();
   await new Promise((resolvePromise, reject) => {
-    const child = spawn(npm, ["install", "--global", `${manifest.name}@latest`], { stdio: "inherit" });
+    const child = spawn(npm.command, ["install", "--global", `${manifest.name}@latest`], {
+      shell: npm.shell,
+      stdio: "inherit",
+    });
     child.on("error", reject);
     child.on("exit", (code) => code === 0
       ? resolvePromise(undefined)
@@ -288,7 +301,9 @@ export async function main(args) {
     await client.unshare(value);
     const statePath = join(directory, "state.json");
     const state = await readJson(statePath, /** @type {PublishState} */ ({ files: {} }));
-    for (const [file, entry] of Object.entries(state.files)) if (entry.docId === value) delete state.files[file];
+    for (const [fileKey, entry] of Object.entries(state.files)) {
+      if (fileKey.startsWith(`${host}\n`) && entry.docId === value) delete state.files[fileKey];
+    }
     await writePrivateJson(statePath, state);
     console.log(`Unshared ${value}.`);
   } else if (command === "tokens") {

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -332,7 +332,7 @@ export function presentError(error) {
     console.error(error.message);
     if (error.status === 401) console.error("Run `openartifacts login` to sign in again.");
     if (error.code === "quota_exceeded") {
-      console.error("Wait for the current quota window to reset, or remove an unused document if the live-document ceiling was reached.");
+      console.error("Wait for the current quota window to reset before retrying.");
     }
     if (error.code === "limit_reached") {
       if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -119,40 +119,50 @@ function openBrowser(url) {
 /** @param {number} milliseconds */
 const sleep = (milliseconds) => new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
 
+/**
+ * Poll a device code until it yields a token or expires.
+ * @param {ReturnType<typeof createClient>} client
+ * @param {{device_code: string, interval: number, expires_in: number}} minted
+ * @param {{wait?: (milliseconds: number) => Promise<unknown>, now?: () => number}} [options]
+ */
+export async function collectToken(client, minted, { wait = sleep, now = Date.now } = {}) {
+  let delay = minted.interval * 1000;
+  const expiresAt = now() + minted.expires_in * 1000;
+  while (now() < expiresAt) {
+    try {
+      return await client.deviceToken(minted.device_code);
+    } catch (error) {
+      if (!(error instanceof APIError)) throw error;
+      if (error.code === "authorization_pending") await wait(delay);
+      else if (error.code === "slow_down") {
+        delay += 5000;
+        await wait(delay);
+      } else throw error;
+    }
+  }
+  throw new Error("The approval code expired. Run the command again to start a new sign-in.");
+}
+
 /** Sign in, store the credential owner-only, and return it without printing it. */
 /** @param {string} host @param {string} directory @returns {Promise<string>} */
 async function login(host, directory) {
   const anonymous = createClient({ host });
   const minted = await anonymous.deviceCode(`OpenArtifacts CLI on ${hostname()}`);
-  console.log(`Approve OpenArtifacts: ${minted.verification_uri_complete}`);
-  console.log(`Or open ${minted.verification_uri} and enter ${minted.user_code}.`);
+  console.error(`Approve OpenArtifacts: ${minted.verification_uri_complete}`);
+  console.error(`Or open ${minted.verification_uri} and enter ${minted.user_code}.`);
   openBrowser(minted.verification_uri_complete);
 
-  let delay = minted.interval * 1000;
-  const expiresAt = Date.now() + minted.expires_in * 1000;
-  while (Date.now() < expiresAt) {
-    try {
-      const issued = await anonymous.deviceToken(minted.device_code);
-      const credentialsPath = join(directory, "credentials.json");
-      const credentials = await readJson(
-        credentialsPath,
-        /** @type {Credentials} */ ({ hosts: {} }),
-      );
-      credentials.hosts ??= {};
-      credentials.hosts[host] = { token: issued.access_token, tokenId: issued.token_id };
-      await writePrivateJson(credentialsPath, credentials);
-      console.log(`Signed in (${issued.token_id}).`);
-      return issued.access_token;
-    } catch (error) {
-      if (!(error instanceof APIError)) throw error;
-      if (error.code === "authorization_pending") await sleep(delay);
-      else if (error.code === "slow_down") {
-        delay += 5000;
-        await sleep(delay);
-      } else throw error;
-    }
-  }
-  throw new Error("The approval code expired. Run the command again to start a new sign-in.");
+  const issued = await collectToken(anonymous, minted);
+  const credentialsPath = join(directory, "credentials.json");
+  const credentials = await readJson(
+    credentialsPath,
+    /** @type {Credentials} */ ({ hosts: {} }),
+  );
+  credentials.hosts ??= {};
+  credentials.hosts[host] = { token: issued.access_token, tokenId: issued.token_id };
+  await writePrivateJson(credentialsPath, credentials);
+  console.error(`Signed in (${issued.token_id}).`);
+  return issued.access_token;
 }
 
 /** @param {string} host @param {string} directory */
@@ -171,7 +181,9 @@ async function install() {
   await new Promise((resolvePromise, reject) => {
     const child = spawn(npm, ["install", "--global", `${manifest.name}@${manifest.version}`], { stdio: "inherit" });
     child.on("error", reject);
-    child.on("exit", (code) => code === 0 ? resolvePromise(undefined) : reject(new Error(`npm install exited with ${code}.`)));
+    child.on("exit", (code) => code === 0
+      ? resolvePromise(undefined)
+      : reject(new Error(`Global CLI install failed (npm exit ${code}). Fix the npm error above; for EACCES, use a Node version manager or a user-writable npm prefix, then rerun.`)));
   });
   console.log(`CLI: installed ${manifest.name}@${manifest.version}`);
   const agents = await detectAgents();
@@ -217,17 +229,36 @@ export async function main(args) {
     await login(host, directory);
     return;
   }
+
+  /** @type {{file: string, body: {title: string, html: string}} | undefined} */
+  let preparedPublish;
+  if (command === "publish") {
+    const file = await realpath(resolve(value));
+    preparedPublish = {
+      file,
+      body: { title: basename(file, extname(file)), html: await renderFile(file) },
+    };
+  }
+
   const token = await credential(host, directory);
   const client = createClient({ host, token });
 
   if (command === "publish") {
-    const file = await realpath(resolve(value));
+    if (!preparedPublish) throw new Error("Publish input was not prepared.");
+    const { file, body } = preparedPublish;
     const fileKey = `${host}\n${file}`;
     const statePath = join(directory, "state.json");
     const state = await readJson(statePath, /** @type {PublishState} */ ({ files: {} }));
     const previous = state.files[fileKey];
-    const body = { title: basename(file, extname(file)), html: await renderFile(file) };
-    const published = previous ? await client.updateDoc(previous.docId, body) : await client.createDoc(body);
+    let published;
+    try {
+      published = previous ? await client.updateDoc(previous.docId, body) : await client.createDoc(body);
+    } catch (error) {
+      if (previous && error instanceof APIError && error.status === 404) {
+        error.message += ` To intentionally replace it, run \`openartifacts unshare ${previous.docId}\`, then publish again.`;
+      }
+      throw error;
+    }
     state.files[fileKey] = { docId: published.docId, url: published.url };
     await writePrivateJson(statePath, state);
     console.log(published.url);
@@ -269,6 +300,9 @@ export function presentError(error) {
   if (error instanceof APIError) {
     console.error(error.message);
     if (error.status === 401) console.error("Run `openartifacts login` to sign in again.");
+    if (error.code === "quota_exceeded") {
+      console.error("Wait for the current quota window to reset, or remove an unused document if the live-document ceiling was reached.");
+    }
     if (error.code === "limit_reached") {
       if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);
       if (error.detail.upgrade_url) console.error(`Upgrade: ${error.detail.upgrade_url}`);

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -175,19 +175,35 @@ async function credential(host, directory) {
   return stored.hosts?.[host]?.token ?? login(host, directory);
 }
 
+/** @param {string} npm */
+async function npmGlobalRoot(npm) {
+  return new Promise((resolvePromise, reject) => {
+    let output = "";
+    const child = spawn(npm, ["root", "--global"], { stdio: ["ignore", "pipe", "inherit"] });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.on("error", reject);
+    child.on("exit", (code) => code === 0
+      ? resolvePromise(output.trim())
+      : reject(new Error(`Could not locate the global npm package directory (npm exit ${code}).`)));
+  });
+}
+
 async function install() {
   const manifest = JSON.parse(await readFile(join(PACKAGE_ROOT, "package.json"), "utf8"));
   const npm = platform() === "win32" ? "npm.cmd" : "npm";
   await new Promise((resolvePromise, reject) => {
-    const child = spawn(npm, ["install", "--global", `${manifest.name}@${manifest.version}`], { stdio: "inherit" });
+    const child = spawn(npm, ["install", "--global", `${manifest.name}@latest`], { stdio: "inherit" });
     child.on("error", reject);
     child.on("exit", (code) => code === 0
       ? resolvePromise(undefined)
       : reject(new Error(`Global CLI install failed (npm exit ${code}). Fix the npm error above; for EACCES, use a Node version manager or a user-writable npm prefix, then rerun.`)));
   });
-  console.log(`CLI: installed ${manifest.name}@${manifest.version}`);
+  const installedRoot = join(await npmGlobalRoot(npm), ...manifest.name.split("/"));
+  const installedManifest = JSON.parse(await readFile(join(installedRoot, "package.json"), "utf8"));
+  console.log(`CLI: installed ${installedManifest.name}@${installedManifest.version}`);
   const agents = await detectAgents();
-  await installSkills(agents);
+  await installSkills(agents, join(installedRoot, "skill", "openartifacts", "SKILL.md"));
   for (const agent of agents) {
     console.log(`${agent.name}: ${agent.detected ? `installed ${agent.target}` : "not detected"}`);
   }

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -1,0 +1,279 @@
+import { access, chmod, copyFile, mkdir, readFile, realpath, rename, stat, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { homedir, hostname, platform } from "node:os";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { marked } from "marked";
+import { APIError, createClient } from "./client.js";
+
+const DEFAULT_HOST = "https://api.openartifacts.ai";
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SKILL_SOURCE = join(PACKAGE_ROOT, "skill", "openartifacts", "SKILL.md");
+/** @typedef {{name: string, detected: boolean, target: string}} DetectedAgent */
+/** @typedef {{files: Record<string, {docId: string, url: string}>}} PublishState */
+/** @typedef {{hosts: Record<string, {token: string, tokenId?: string}>}} Credentials */
+
+/** @param {NodeJS.Platform} os @param {string} home @param {NodeJS.ProcessEnv} env */
+export function configDir(os = platform(), home = homedir(), env = process.env) {
+  if (env.OPENARTIFACTS_CONFIG_DIR) return resolve(env.OPENARTIFACTS_CONFIG_DIR);
+  if (os === "darwin") return join(home, "Library", "Application Support", "openartifacts");
+  if (os === "win32") return join(env.APPDATA ?? join(home, "AppData", "Roaming"), "openartifacts");
+  return join(env.XDG_CONFIG_HOME ?? join(home, ".config"), "openartifacts");
+}
+
+/** @param {string} command @param {NodeJS.ProcessEnv} env */
+async function hasCommand(command, env) {
+  const suffixes = platform() === "win32" ? (env.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
+  for (const dir of (env.PATH ?? "").split(platform() === "win32" ? ";" : ":")) {
+    for (const suffix of suffixes) {
+      try {
+        await access(join(dir, `${command}${suffix.toLowerCase()}`), constants.X_OK);
+        return true;
+      } catch {}
+    }
+  }
+  return false;
+}
+
+/** Detect supported agents by their executable or existing user config root.
+ * @returns {Promise<DetectedAgent[]>}
+ */
+export async function detectAgents(home = homedir(), env = process.env) {
+  const agents = [
+    { name: "Claude Code", command: "claude", root: env.CLAUDE_CONFIG_DIR ?? join(home, ".claude"), hinted: !!env.CLAUDE_CONFIG_DIR },
+    { name: "Codex", command: "codex", root: env.CODEX_HOME ?? join(home, ".codex"), hinted: !!env.CODEX_HOME },
+    { name: "OpenCode", command: "opencode", root: join(env.XDG_CONFIG_HOME ?? join(home, ".config"), "opencode"), hinted: false },
+    { name: "pi", command: "pi", root: env.PI_CODING_AGENT_DIR ?? join(home, ".pi", "agent"), hinted: !!env.PI_CODING_AGENT_DIR },
+  ];
+  /** @type {DetectedAgent[]} */
+  const found = [];
+  for (const agent of agents) {
+    let configured = false;
+    try {
+      configured = (await stat(agent.root)).isDirectory();
+    } catch {}
+    found.push({
+      name: agent.name,
+      detected: agent.hinted || configured || (await hasCommand(agent.command, env)),
+      target: join(agent.root, "skills", "openartifacts", "SKILL.md"),
+    });
+  }
+  return found;
+}
+
+/** Copy the package's one shared skill into every detected agent.
+ * @param {DetectedAgent[]} agents @param {string} [source]
+ */
+export async function installSkills(agents, source = SKILL_SOURCE) {
+  for (const agent of agents) {
+    if (!agent.detected) continue;
+    await mkdir(dirname(agent.target), { recursive: true });
+    await copyFile(source, agent.target);
+  }
+}
+
+/** @param {string} file */
+export async function renderFile(file) {
+  const extension = extname(file).toLowerCase();
+  if (![".md", ".markdown", ".html", ".htm"].includes(extension)) {
+    throw new Error("Publish a Markdown (.md, .markdown) or HTML (.html, .htm) file.");
+  }
+  const source = await readFile(file, "utf8");
+  if ([".html", ".htm"].includes(extension)) return source;
+  const title = basename(file, extname(file));
+  const escaped = title.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escaped}</title><style>body{max-width:48rem;margin:3rem auto;padding:0 1rem;font:18px/1.6 system-ui;color:#222}img{max-width:100%}pre{overflow:auto;padding:1rem;background:#f5f5f5}code{font-family:ui-monospace,monospace}</style></head><body>${marked.parse(source)}</body></html>`;
+}
+
+/** @template T @param {string} path @param {T} fallback @returns {Promise<T>} */
+async function readJson(path, fallback) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return fallback;
+    throw error;
+  }
+}
+
+/** @param {string} path @param {unknown} value */
+async function writePrivateJson(path, value) {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporary, path);
+  await chmod(path, 0o600);
+}
+
+/** @param {string} url */
+function openBrowser(url) {
+  const command = platform() === "darwin" ? "open" : platform() === "win32" ? "cmd" : "xdg-open";
+  const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    child.on("error", () => {});
+    child.unref();
+  } catch {}
+}
+
+/** @param {number} milliseconds */
+const sleep = (milliseconds) => new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+
+/** Sign in, store the credential owner-only, and return it without printing it. */
+/** @param {string} host @param {string} directory @returns {Promise<string>} */
+async function login(host, directory) {
+  const anonymous = createClient({ host });
+  const minted = await anonymous.deviceCode(`OpenArtifacts CLI on ${hostname()}`);
+  console.log(`Approve OpenArtifacts: ${minted.verification_uri_complete}`);
+  console.log(`Or open ${minted.verification_uri} and enter ${minted.user_code}.`);
+  openBrowser(minted.verification_uri_complete);
+
+  let delay = minted.interval * 1000;
+  const expiresAt = Date.now() + minted.expires_in * 1000;
+  while (Date.now() < expiresAt) {
+    try {
+      const issued = await anonymous.deviceToken(minted.device_code);
+      const credentialsPath = join(directory, "credentials.json");
+      const credentials = await readJson(
+        credentialsPath,
+        /** @type {Credentials} */ ({ hosts: {} }),
+      );
+      credentials.hosts ??= {};
+      credentials.hosts[host] = { token: issued.access_token, tokenId: issued.token_id };
+      await writePrivateJson(credentialsPath, credentials);
+      console.log(`Signed in (${issued.token_id}).`);
+      return issued.access_token;
+    } catch (error) {
+      if (!(error instanceof APIError)) throw error;
+      if (error.code === "authorization_pending") await sleep(delay);
+      else if (error.code === "slow_down") {
+        delay += 5000;
+        await sleep(delay);
+      } else throw error;
+    }
+  }
+  throw new Error("The approval code expired. Run the command again to start a new sign-in.");
+}
+
+/** @param {string} host @param {string} directory */
+async function credential(host, directory) {
+  if (process.env.OPENARTIFACTS_TOKEN) return process.env.OPENARTIFACTS_TOKEN;
+  const stored = await readJson(
+    join(directory, "credentials.json"),
+    /** @type {Credentials} */ ({ hosts: {} }),
+  );
+  return stored.hosts?.[host]?.token ?? login(host, directory);
+}
+
+async function install() {
+  const manifest = JSON.parse(await readFile(join(PACKAGE_ROOT, "package.json"), "utf8"));
+  const npm = platform() === "win32" ? "npm.cmd" : "npm";
+  await new Promise((resolvePromise, reject) => {
+    const child = spawn(npm, ["install", "--global", `${manifest.name}@${manifest.version}`], { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code) => code === 0 ? resolvePromise(undefined) : reject(new Error(`npm install exited with ${code}.`)));
+  });
+  console.log(`CLI: installed ${manifest.name}@${manifest.version}`);
+  const agents = await detectAgents();
+  await installSkills(agents);
+  for (const agent of agents) {
+    console.log(`${agent.name}: ${agent.detected ? `installed ${agent.target}` : "not detected"}`);
+  }
+}
+
+const HELP = `Usage: openartifacts <command> [argument]
+
+Commands:
+  install            Install or upgrade the CLI and detected agent skills
+  login              Approve this machine and store its token
+  publish <file>     Publish Markdown or HTML; repeat to update the same document
+  list               List published documents
+  get <docId>        Print a document's current HTML
+  unshare <docId>    Withdraw a public document
+  tokens             List this account's machine tokens
+  revoke <tokenId>   Revoke a machine token`;
+
+/** CLI entry point. */
+/** @param {string[]} args */
+export async function main(args) {
+  const [command, argument, ...extra] = args;
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    console.log(HELP);
+    return;
+  }
+  if (!["install", "login", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
+    throw new Error(HELP);
+  }
+  const needsArgument = ["publish", "get", "unshare", "revoke"].includes(command);
+  if (extra.length || (needsArgument && !argument) || (!needsArgument && argument)) {
+    throw new Error(HELP);
+  }
+  const value = argument ?? "";
+  if (command === "install") return install();
+
+  const host = (process.env.OPENARTIFACTS_API_HOST ?? DEFAULT_HOST).replace(/\/$/, "");
+  const directory = configDir();
+  if (command === "login") {
+    await login(host, directory);
+    return;
+  }
+  const token = await credential(host, directory);
+  const client = createClient({ host, token });
+
+  if (command === "publish") {
+    const file = await realpath(resolve(value));
+    const fileKey = `${host}\n${file}`;
+    const statePath = join(directory, "state.json");
+    const state = await readJson(statePath, /** @type {PublishState} */ ({ files: {} }));
+    const previous = state.files[fileKey];
+    const body = { title: basename(file, extname(file)), html: await renderFile(file) };
+    const published = previous ? await client.updateDoc(previous.docId, body) : await client.createDoc(body);
+    state.files[fileKey] = { docId: published.docId, url: published.url };
+    await writePrivateJson(statePath, state);
+    console.log(published.url);
+  } else if (command === "list") {
+    console.log(JSON.stringify(await client.listDocs(), null, 2));
+  } else if (command === "get") {
+    const doc = (await client.listDocs()).find((item) => item.docId === value);
+    if (!doc) throw new Error(`No document with id ${value} is in this account.`);
+    process.stdout.write(await client.readDocument(doc.url));
+  } else if (command === "unshare") {
+    await client.unshare(value);
+    const statePath = join(directory, "state.json");
+    const state = await readJson(statePath, /** @type {PublishState} */ ({ files: {} }));
+    for (const [file, entry] of Object.entries(state.files)) if (entry.docId === value) delete state.files[file];
+    await writePrivateJson(statePath, state);
+    console.log(`Unshared ${value}.`);
+  } else if (command === "tokens") {
+    console.log(JSON.stringify((await client.listTokens()).tokens, null, 2));
+  } else if (command === "revoke") {
+    const result = await client.revoke(value);
+    const credentialsPath = join(directory, "credentials.json");
+    const credentials = await readJson(
+      credentialsPath,
+      /** @type {Credentials} */ ({ hosts: {} }),
+    );
+    if (credentials.hosts?.[host]?.tokenId === value) {
+      delete credentials.hosts[host];
+      await writePrivateJson(credentialsPath, credentials);
+    }
+    console.log(result ? JSON.stringify(result) : `Token ${value} is already absent.`);
+  } else {
+    throw new Error(HELP);
+  }
+}
+
+/** Print API errors without ever exposing a credential. */
+/** @param {unknown} error */
+export function presentError(error) {
+  if (error instanceof APIError) {
+    console.error(error.message);
+    if (error.status === 401) console.error("Run `openartifacts login` to sign in again.");
+    if (error.code === "limit_reached") {
+      if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);
+      if (error.detail.upgrade_url) console.error(`Upgrade: ${error.detail.upgrade_url}`);
+    }
+  } else {
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/packages/openartifacts/src/client.js
+++ b/packages/openartifacts/src/client.js
@@ -1,0 +1,84 @@
+/** An error returned by the OpenArtifacts JSON API. */
+export class APIError extends Error {
+  /** @param {number} status @param {Record<string, any>} body */
+  constructor(status, body) {
+    const detail = body.error ?? {};
+    super(detail.message ?? `OpenArtifacts returned HTTP ${status}.`);
+    this.name = "APIError";
+    this.status = status;
+    this.code = detail.code;
+    this.detail = detail;
+  }
+}
+
+/**
+ * The fetch-only OpenArtifacts client. Keeping it free of Node APIs lets the
+ * same calls be tested directly against the local Worker.
+ * @param {{host: string, token?: string, fetcher?: typeof fetch}} options
+ */
+export function createClient({ host, token, fetcher = fetch }) {
+  const base = host.replace(/\/$/, "");
+
+  /** @param {string} path @param {RequestInit} [init] @param {number[]} [allowed] @param {boolean} [authenticated] */
+  async function request(path, init = {}, allowed = [], authenticated = true) {
+    const headers = new Headers(init.headers);
+    if (token && authenticated) headers.set("authorization", `Bearer ${token}`);
+    if (init.body !== undefined) headers.set("content-type", "application/json");
+    const response = await fetcher(path.startsWith("http") ? path : `${base}${path}`, {
+      ...init,
+      headers,
+    });
+    if (!response.ok && allowed.includes(response.status)) return null;
+    if (!response.ok) {
+      let body = {};
+      try {
+        body = await response.json();
+      } catch {}
+      throw new APIError(response.status, body);
+    }
+    if (response.status === 204) return null;
+    const type = response.headers.get("content-type") ?? "";
+    return type.includes("application/json") ? response.json() : response.text();
+  }
+
+  return {
+    /** @param {string} label */
+    deviceCode: (label) =>
+      request("/device/code", { method: "POST", body: JSON.stringify({ label }) }),
+    /** @param {string} deviceCode */
+    deviceToken: (deviceCode) =>
+      request("/device/token", {
+        method: "POST",
+        body: JSON.stringify({ device_code: deviceCode }),
+      }),
+    /** @param {{title?: string, html: string}} body */
+    createDoc: (body) =>
+      request("/api/v1/docs", { method: "POST", body: JSON.stringify(body) }),
+    /** @param {string} docId @param {{title?: string, html: string}} body */
+    updateDoc: (docId, body) =>
+      request(`/api/v1/docs/${encodeURIComponent(docId)}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    listDocs: async () => {
+      const docs = [];
+      let cursor;
+      do {
+        const query = cursor ? `?limit=100&cursor=${encodeURIComponent(cursor)}` : "?limit=100";
+        const page = await request(`/api/v1/docs${query}`);
+        docs.push(...page.docs);
+        cursor = page.cursor;
+      } while (cursor);
+      return docs;
+    },
+    /** @param {string} url */
+    readDocument: (url) => request(url, {}, [], false),
+    /** @param {string} docId */
+    unshare: (docId) =>
+      request(`/api/v1/docs/${encodeURIComponent(docId)}`, { method: "DELETE" }, [404]),
+    listTokens: () => request("/api/v1/tokens"),
+    /** @param {string} tokenId */
+    revoke: (tokenId) =>
+      request(`/api/v1/tokens/${encodeURIComponent(tokenId)}`, { method: "DELETE" }, [404]),
+  };
+}

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -5,7 +5,7 @@ import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { collectToken, configDir, detectAgents, installSkills, main, presentError, renderFile } from "../src/cli.js";
+import { collectToken, configDir, detectAgents, installSkills, main, npmProcess, presentError, renderFile } from "../src/cli.js";
 import { APIError } from "../src/client.js";
 
 test("uses each platform's user config directory", () => {
@@ -13,6 +13,11 @@ test("uses each platform's user config directory", () => {
   assert.equal(configDir("linux", "/home/me", {}), "/home/me/.config/openartifacts");
   assert.equal(configDir("linux", "/home/me", { XDG_CONFIG_HOME: "/xdg" }), "/xdg/openartifacts");
   assert.equal(configDir("win32", "C:\\Users\\me", { APPDATA: "C:\\AppData" }), "C:\\AppData/openartifacts");
+});
+
+test("runs npm.cmd through the Windows command processor", () => {
+  assert.deepEqual(npmProcess("win32"), { command: "npm.cmd", shell: true });
+  assert.deepEqual(npmProcess("linux"), { command: "npm", shell: false });
 });
 
 test("rejects an unknown command before authentication", async () => {
@@ -257,6 +262,10 @@ test("repeat publish updates per API host", async () => {
     await main(["publish", markdown]);
     process.env.OPENARTIFACTS_API_HOST = second.host;
     await main(["publish", markdown]);
+    process.env.OPENARTIFACTS_API_HOST = first.host;
+    await main(["unshare", "9f2k4mvq7t0xbz3n"]);
+    process.env.OPENARTIFACTS_API_HOST = second.host;
+    await main(["publish", markdown]);
   } finally {
     console.log = previous.log;
     for (const [name, value] of [
@@ -267,8 +276,8 @@ test("repeat publish updates per API host", async () => {
     first.server.close();
     second.server.close();
   }
-  assert.deepEqual(first.methods, ["POST", "PUT"]);
-  assert.deepEqual(second.methods, ["POST"]);
+  assert.deepEqual(first.methods, ["POST", "PUT", "DELETE"]);
+  assert.deepEqual(second.methods, ["POST", "PUT"]);
 });
 
 test("a stale publish mapping requires explicit replacement", async () => {

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -5,7 +5,8 @@ import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { configDir, detectAgents, installSkills, main, renderFile } from "../src/cli.js";
+import { collectToken, configDir, detectAgents, installSkills, main, presentError, renderFile } from "../src/cli.js";
+import { APIError } from "../src/client.js";
 
 test("uses each platform's user config directory", () => {
   assert.equal(configDir("darwin", "/home/me", {}), "/home/me/Library/Application Support/openartifacts");
@@ -64,11 +65,119 @@ test("keeps HTML verbatim and renders plain Markdown locally", async () => {
   await assert.rejects(renderFile(join(directory, "notes.txt")), /Markdown.*or HTML/);
 });
 
+test("validates a publish file before authentication", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "openartifacts-invalid-"));
+  const text = join(directory, "notes.txt");
+  await writeFile(text, "not publishable");
+  const previous = {
+    config: process.env.OPENARTIFACTS_CONFIG_DIR,
+    host: process.env.OPENARTIFACTS_API_HOST,
+    token: process.env.OPENARTIFACTS_TOKEN,
+  };
+  process.env.OPENARTIFACTS_CONFIG_DIR = join(directory, "config");
+  process.env.OPENARTIFACTS_API_HOST = "http://127.0.0.1:1";
+  delete process.env.OPENARTIFACTS_TOKEN;
+  try {
+    await assert.rejects(main(["publish", text]), /Markdown.*or HTML/);
+  } finally {
+    for (const [name, value] of [
+      ["OPENARTIFACTS_CONFIG_DIR", previous.config],
+      ["OPENARTIFACTS_API_HOST", previous.host],
+      ["OPENARTIFACTS_TOKEN", previous.token],
+    ]) value === undefined ? delete process.env[name] : process.env[name] = value;
+  }
+});
+
+test("device polling handles pending, slow down, denial, and expiry", async () => {
+  const minted = { device_code: "device", interval: 1, expires_in: 60 };
+  const pendingWaits = [];
+  let pendingCalls = 0;
+  const pendingResult = await collectToken(
+    {
+      deviceToken: async () => {
+        pendingCalls += 1;
+        if (pendingCalls === 1) throw new APIError(400, { error: { code: "authorization_pending" } });
+        return { access_token: "opaque", token_id: "token" };
+      },
+    },
+    minted,
+    { wait: async (milliseconds) => pendingWaits.push(milliseconds) },
+  );
+  assert.equal(pendingResult.access_token, "opaque");
+  assert.deepEqual(pendingWaits, [1000]);
+
+  const slowWaits = [];
+  let slowCalls = 0;
+  await collectToken(
+    {
+      deviceToken: async () => {
+        slowCalls += 1;
+        if (slowCalls === 1) throw new APIError(400, { error: { code: "slow_down" } });
+        return { access_token: "opaque", token_id: "token" };
+      },
+    },
+    minted,
+    { wait: async (milliseconds) => slowWaits.push(milliseconds) },
+  );
+  assert.deepEqual(slowWaits, [6000]);
+
+  await assert.rejects(
+    collectToken(
+      { deviceToken: async () => { throw new APIError(400, { error: { code: "access_denied" } }); } },
+      minted,
+    ),
+    (error) => error instanceof APIError && error.code === "access_denied",
+  );
+
+  const times = [0, 0, 1000];
+  await assert.rejects(
+    collectToken(
+      { deviceToken: async () => { throw new APIError(400, { error: { code: "authorization_pending" } }); } },
+      { ...minted, expires_in: 1 },
+      { wait: async () => {}, now: () => times.shift() ?? 1000 },
+    ),
+    /approval code expired/,
+  );
+});
+
+test("prints guidance for current quota and future plan limits", () => {
+  const lines = [];
+  const previous = console.error;
+  console.error = (...parts) => lines.push(parts.join(" "));
+  try {
+    presentError(new APIError(429, { error: { code: "quota_exceeded", message: "Quota reached." } }));
+    presentError(new APIError(402, {
+      error: {
+        code: "limit_reached",
+        message: "Plan limit reached.",
+        limit: "10 documents",
+        upgrade_url: "https://example.test/upgrade",
+      },
+    }));
+  } finally {
+    console.error = previous;
+  }
+  assert(lines.some((line) => line.includes("quota window")));
+  assert(lines.includes("Limit: 10 documents"));
+  assert(lines.includes("Upgrade: https://example.test/upgrade"));
+});
+
 async function publishingServer() {
   const methods = [];
+  const control = { staleUpdates: false, missingDeletes: false };
   const server = createServer((request, response) => {
     methods.push(request.method);
     response.setHeader("content-type", "application/json");
+    if (request.method === "PUT" && control.staleUpdates) {
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: { code: "not_found", message: "Document not found." } }));
+      return;
+    }
+    if (request.method === "DELETE" && control.missingDeletes) {
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: { code: "not_found", message: "Document not found." } }));
+      return;
+    }
     response.end(JSON.stringify({
       docId: "9f2k4mvq7t0xbz3n",
       url: `http://${request.headers.host}/d/9f2k4mvq7t0xbz3n`,
@@ -79,7 +188,7 @@ async function publishingServer() {
   await once(server, "listening");
   const address = server.address();
   assert(address && typeof address !== "string");
-  return { server, methods, host: `http://127.0.0.1:${address.port}` };
+  return { server, methods, control, host: `http://127.0.0.1:${address.port}` };
 }
 
 test("repeat publish updates per API host", async () => {
@@ -115,4 +224,42 @@ test("repeat publish updates per API host", async () => {
   }
   assert.deepEqual(first.methods, ["POST", "PUT"]);
   assert.deepEqual(second.methods, ["POST"]);
+});
+
+test("a stale publish mapping requires explicit replacement", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "openartifacts-stale-"));
+  const markdown = join(directory, "notes.md");
+  await writeFile(markdown, "# One");
+  const remote = await publishingServer();
+  const previous = {
+    config: process.env.OPENARTIFACTS_CONFIG_DIR,
+    host: process.env.OPENARTIFACTS_API_HOST,
+    token: process.env.OPENARTIFACTS_TOKEN,
+    log: console.log,
+  };
+  process.env.OPENARTIFACTS_CONFIG_DIR = join(directory, "config");
+  process.env.OPENARTIFACTS_API_HOST = remote.host;
+  process.env.OPENARTIFACTS_TOKEN = "opaque-test-token";
+  console.log = () => {};
+  try {
+    await main(["publish", markdown]);
+    remote.control.staleUpdates = true;
+    await assert.rejects(
+      main(["publish", markdown]),
+      /openartifacts unshare 9f2k4mvq7t0xbz3n/,
+    );
+    remote.control.missingDeletes = true;
+    await main(["unshare", "9f2k4mvq7t0xbz3n"]);
+    remote.control.staleUpdates = false;
+    await main(["publish", markdown]);
+  } finally {
+    console.log = previous.log;
+    for (const [name, value] of [
+      ["OPENARTIFACTS_CONFIG_DIR", previous.config],
+      ["OPENARTIFACTS_API_HOST", previous.host],
+      ["OPENARTIFACTS_TOKEN", previous.token],
+    ]) value === undefined ? delete process.env[name] : process.env[name] = value;
+    remote.server.close();
+  }
+  assert.deepEqual(remote.methods, ["POST", "PUT", "DELETE", "POST"]);
 });

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -63,12 +63,12 @@ test("installer fetches latest and copies its newly installed skill", async () =
   const directory = await mkdtemp(join(tmpdir(), "openartifacts-install-"));
   const bin = join(directory, "bin");
   const globalRoot = join(directory, "global", "node_modules");
-  const installedRoot = join(globalRoot, "@brevilabs", "openartifacts");
+  const installedRoot = join(globalRoot, "openartifacts");
   const calls = join(directory, "npm-calls.jsonl");
   await mkdir(bin, { recursive: true });
   await mkdir(join(installedRoot, "skill", "openartifacts"), { recursive: true });
   await writeFile(join(installedRoot, "package.json"), JSON.stringify({
-    name: "@brevilabs/openartifacts",
+    name: "openartifacts",
     version: "0.2.0",
   }));
   await writeFile(join(installedRoot, "skill", "openartifacts", "SKILL.md"), "latest skill\n");
@@ -96,7 +96,7 @@ test("installer fetches latest and copies its newly installed skill", async () =
 
   const npmCalls = (await readFile(calls, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
   assert.deepEqual(npmCalls, [
-    ["install", "--global", "@brevilabs/openartifacts@latest"],
+    ["install", "--global", "openartifacts@latest"],
     ["root", "--global"],
   ]);
   for (const root of ["claude", "codex", "pi"]) {

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { configDir, detectAgents, installSkills, main, renderFile } from "../src/cli.js";
+
+test("uses each platform's user config directory", () => {
+  assert.equal(configDir("darwin", "/home/me", {}), "/home/me/Library/Application Support/openartifacts");
+  assert.equal(configDir("linux", "/home/me", {}), "/home/me/.config/openartifacts");
+  assert.equal(configDir("linux", "/home/me", { XDG_CONFIG_HOME: "/xdg" }), "/xdg/openartifacts");
+  assert.equal(configDir("win32", "C:\\Users\\me", { APPDATA: "C:\\AppData" }), "C:\\AppData/openartifacts");
+});
+
+test("rejects an unknown command before authentication", async () => {
+  await assert.rejects(main(["unknown"]), /Usage: openartifacts/);
+});
+
+test("detects configured agents and installs the same skill into each", async () => {
+  const home = await mkdtemp(join(tmpdir(), "openartifacts-agents-"));
+  await mkdir(join(home, ".claude"));
+  await mkdir(join(home, ".codex"));
+  const source = join(home, "SKILL.md");
+  await writeFile(source, "shared skill\n");
+  const agents = await detectAgents(home, { PATH: "" });
+  assert.deepEqual(agents.filter((agent) => agent.detected).map((agent) => agent.name), ["Claude Code", "Codex"]);
+  await installSkills(agents, source);
+  for (const agent of agents.filter((item) => item.detected)) {
+    assert.equal(await readFile(agent.target, "utf8"), "shared skill\n");
+  }
+  await writeFile(source, "upgraded skill\n");
+  await installSkills(agents, source);
+  for (const agent of agents.filter((item) => item.detected)) {
+    assert.equal(await readFile(agent.target, "utf8"), "upgraded skill\n");
+  }
+});
+
+test("honours agent-specific config roots", async () => {
+  const home = await mkdtemp(join(tmpdir(), "openartifacts-roots-"));
+  const agents = await detectAgents(home, {
+    PATH: "",
+    CLAUDE_CONFIG_DIR: join(home, "claude-home"),
+    CODEX_HOME: join(home, "codex-home"),
+    PI_CODING_AGENT_DIR: join(home, "pi-home"),
+    XDG_CONFIG_HOME: join(home, "xdg"),
+  });
+  const targets = Object.fromEntries(agents.map((agent) => [agent.name, agent.target]));
+  assert.equal(targets["Claude Code"], join(home, "claude-home", "skills", "openartifacts", "SKILL.md"));
+  assert.equal(targets.Codex, join(home, "codex-home", "skills", "openartifacts", "SKILL.md"));
+  assert.equal(targets.OpenCode, join(home, "xdg", "opencode", "skills", "openartifacts", "SKILL.md"));
+  assert.equal(targets.pi, join(home, "pi-home", "skills", "openartifacts", "SKILL.md"));
+});
+
+test("keeps HTML verbatim and renders plain Markdown locally", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "openartifacts-render-"));
+  const html = join(directory, "page.html");
+  const markdown = join(directory, "notes.md");
+  await writeFile(html, "<!doctype html><p>kept</p>");
+  await writeFile(markdown, "# Heading\n\nHello **world**.");
+  assert.equal(await renderFile(html), "<!doctype html><p>kept</p>");
+  assert.match(await renderFile(markdown), /<h1>Heading<\/h1>[\s\S]*<strong>world<\/strong>/);
+  await assert.rejects(renderFile(join(directory, "notes.txt")), /Markdown.*or HTML/);
+});
+
+async function publishingServer() {
+  const methods = [];
+  const server = createServer((request, response) => {
+    methods.push(request.method);
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({
+      docId: "9f2k4mvq7t0xbz3n",
+      url: `http://${request.headers.host}/d/9f2k4mvq7t0xbz3n`,
+      version: methods.length,
+    }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert(address && typeof address !== "string");
+  return { server, methods, host: `http://127.0.0.1:${address.port}` };
+}
+
+test("repeat publish updates per API host", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "openartifacts-state-"));
+  const markdown = join(directory, "notes.md");
+  await writeFile(markdown, "# One");
+  const first = await publishingServer();
+  const second = await publishingServer();
+  const previous = {
+    config: process.env.OPENARTIFACTS_CONFIG_DIR,
+    host: process.env.OPENARTIFACTS_API_HOST,
+    token: process.env.OPENARTIFACTS_TOKEN,
+    log: console.log,
+  };
+  process.env.OPENARTIFACTS_CONFIG_DIR = join(directory, "config");
+  process.env.OPENARTIFACTS_TOKEN = "opaque-test-token";
+  console.log = () => {};
+  try {
+    process.env.OPENARTIFACTS_API_HOST = first.host;
+    await main(["publish", markdown]);
+    await main(["publish", markdown]);
+    process.env.OPENARTIFACTS_API_HOST = second.host;
+    await main(["publish", markdown]);
+  } finally {
+    console.log = previous.log;
+    for (const [name, value] of [
+      ["OPENARTIFACTS_CONFIG_DIR", previous.config],
+      ["OPENARTIFACTS_API_HOST", previous.host],
+      ["OPENARTIFACTS_TOKEN", previous.token],
+    ]) value === undefined ? delete process.env[name] : process.env[name] = value;
+    first.server.close();
+    second.server.close();
+  }
+  assert.deepEqual(first.methods, ["POST", "PUT"]);
+  assert.deepEqual(second.methods, ["POST"]);
+});

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { once } from "node:events";
 import { tmpdir } from "node:os";
@@ -52,6 +52,51 @@ test("honours agent-specific config roots", async () => {
   assert.equal(targets.Codex, join(home, "codex-home", "skills", "openartifacts", "SKILL.md"));
   assert.equal(targets.OpenCode, join(home, "xdg", "opencode", "skills", "openartifacts", "SKILL.md"));
   assert.equal(targets.pi, join(home, "pi-home", "skills", "openartifacts", "SKILL.md"));
+});
+
+test("installer fetches latest and copies its newly installed skill", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "openartifacts-install-"));
+  const bin = join(directory, "bin");
+  const globalRoot = join(directory, "global", "node_modules");
+  const installedRoot = join(globalRoot, "@brevilabs", "openartifacts");
+  const calls = join(directory, "npm-calls.jsonl");
+  await mkdir(bin, { recursive: true });
+  await mkdir(join(installedRoot, "skill", "openartifacts"), { recursive: true });
+  await writeFile(join(installedRoot, "package.json"), JSON.stringify({
+    name: "@brevilabs/openartifacts",
+    version: "0.2.0",
+  }));
+  await writeFile(join(installedRoot, "skill", "openartifacts", "SKILL.md"), "latest skill\n");
+  const fakeNpm = join(bin, "npm");
+  await writeFile(fakeNpm, `#!${process.execPath}\nimport { appendFileSync } from "node:fs";\nconst args = process.argv.slice(2);\nappendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");\nif (args[0] === "root") console.log(${JSON.stringify(globalRoot)});\n`);
+  await chmod(fakeNpm, 0o755);
+
+  const variables = ["PATH", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME"];
+  const previous = Object.fromEntries(variables.map((name) => [name, process.env[name]]));
+  process.env.PATH = bin;
+  process.env.CLAUDE_CONFIG_DIR = join(directory, "claude");
+  process.env.CODEX_HOME = join(directory, "codex");
+  process.env.PI_CODING_AGENT_DIR = join(directory, "pi");
+  process.env.XDG_CONFIG_HOME = join(directory, "xdg");
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await main(["install"]);
+  } finally {
+    console.log = originalLog;
+    for (const [name, value] of Object.entries(previous)) {
+      value === undefined ? delete process.env[name] : process.env[name] = value;
+    }
+  }
+
+  const npmCalls = (await readFile(calls, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+  assert.deepEqual(npmCalls, [
+    ["install", "--global", "@brevilabs/openartifacts@latest"],
+    ["root", "--global"],
+  ]);
+  for (const root of ["claude", "codex", "pi"]) {
+    assert.equal(await readFile(join(directory, root, "skills", "openartifacts", "SKILL.md"), "utf8"), "latest skill\n");
+  }
 });
 
 test("keeps HTML verbatim and renders plain Markdown locally", async () => {

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -73,7 +73,7 @@ test("installer fetches latest and copies its newly installed skill", async () =
   }));
   await writeFile(join(installedRoot, "skill", "openartifacts", "SKILL.md"), "latest skill\n");
   const fakeNpm = join(bin, "npm");
-  await writeFile(fakeNpm, `#!${process.execPath}\nimport { appendFileSync } from "node:fs";\nconst args = process.argv.slice(2);\nappendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");\nif (args[0] === "root") console.log(${JSON.stringify(globalRoot)});\n`);
+  await writeFile(fakeNpm, `#!${process.execPath}\nconst { appendFileSync } = require("node:fs");\nconst args = process.argv.slice(2);\nappendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");\nif (args[0] === "root") console.log(${JSON.stringify(globalRoot)});\n`);
   await chmod(fakeNpm, 0o755);
 
   const variables = ["PATH", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME"];

--- a/packages/openartifacts/tsconfig.json
+++ b/packages/openartifacts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["bin/**/*.js", "src/**/*.js"]
+}

--- a/test/cli-client.test.ts
+++ b/test/cli-client.test.ts
@@ -1,0 +1,67 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { createClient, APIError } from "../packages/openartifacts/src/client.js";
+import type { Env } from "../src/config.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId } from "../src/ids.js";
+import worker from "../src/index.js";
+
+const ORIGIN = "https://openartifacts.workers.dev";
+const local = (): Env => ({
+  ...env,
+  SERVING_HOST: "",
+  API_HOST: "",
+  LEGACY_SERVING_HOST: "",
+  RETIRED_API_HOST: "",
+  DEVICE_CODE_LIMITER: undefined,
+  DEVICE_POLL_LIMITER: undefined,
+  DEVICE_POLL_CLIENT_LIMITER: undefined,
+}) as Env;
+
+async function issueToken(): Promise<{ token: string; id: string }> {
+  const token = newApiToken();
+  const id = newTokenId();
+  await env.DB.prepare(
+    "INSERT INTO tokens (id, token_hash, account_id, label, created_at) VALUES (?, ?, ?, ?, ?)",
+  ).bind(id, await sha256Hex(token), "oa_cli_test_account000000000", "CLI test", Date.now()).run();
+  return { token, id };
+}
+
+const localFetch: typeof fetch = async (input, init) => {
+  const context = createExecutionContext();
+  const response = await worker.fetch(new Request(input, init), local(), context);
+  await waitOnExecutionContext(context);
+  return response;
+};
+
+describe("the CLI client against the local Worker", () => {
+  it("covers login, publish, update, list, get, unshare, tokens and revoke", async () => {
+    const anonymous = createClient({ host: ORIGIN, fetcher: localFetch });
+    const code = await anonymous.deviceCode("CLI test");
+    expect(code.verification_uri_complete).toContain(code.user_code);
+    await expect(anonymous.deviceToken(code.device_code)).rejects.toMatchObject({
+      code: "authorization_pending",
+    } satisfies Partial<APIError>);
+
+    const issued = await issueToken();
+    let documentAuthorization: string | null | undefined;
+    const observedFetch: typeof fetch = async (input, init) => {
+      const request = new Request(input, init);
+      if (new URL(request.url).pathname.startsWith("/d/")) {
+        documentAuthorization = request.headers.get("authorization");
+      }
+      return localFetch(request);
+    };
+    const client = createClient({ host: ORIGIN, token: issued.token, fetcher: observedFetch });
+    const created = await client.createDoc({ title: "CLI", html: "<!doctype html><p>one</p>" });
+    const updated = await client.updateDoc(created.docId, { title: "CLI", html: "<!doctype html><p>two</p>" });
+    expect(updated).toMatchObject({ docId: created.docId, version: 2, url: created.url });
+    expect(await client.listDocs()).toContainEqual(expect.objectContaining({ docId: created.docId }));
+    expect(await client.readDocument(created.url)).toContain("<p>two</p>");
+    expect(documentAuthorization).toBeNull();
+    expect(await client.listTokens()).toMatchObject({ tokens: [expect.objectContaining({ tokenId: issued.id })] });
+    await client.unshare(created.docId);
+    await expect(client.readDocument(created.url)).rejects.toMatchObject({ status: 410 });
+    expect(await client.revoke(issued.id)).toEqual({ tokenId: issued.id, remaining: 0 });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "ESNext",
@@ -13,5 +15,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "vitest.config.ts",
+    "packages/openartifacts/src/client.js"
+  ]
 }


### PR DESCRIPTION
Relates to #59

## Why

OpenArtifacts currently has no installable client outside Obsidian Copilot. A Claude Code, Codex, OpenCode, or pi user has to read the HTTP contract and build their own script before an agent can publish anything.

## What

| Situation | Result |
| --- | --- |
| The user runs `npx openartifacts install` | `openartifacts@0.2.0` installs one CLI and copies the same OpenArtifacts skill into every detected supported agent |
| The first authenticated command runs | The CLI writes approval status to stderr, opens the device-approval URL, and stores the returned token without printing it |
| Markdown or HTML is published | The file is validated before sign-in, Markdown is rendered locally, and stdout contains the API's returned public URL |
| The same local file is published again | The existing document is updated instead of creating a second link |
| A saved document is no longer accessible | The update stays terminal and reports the explicit unshare-then-republish recovery instead of silently replacing the link |
| A self-hosted deployment is used | The API host and opaque credential come from environment variables, and saved state stays scoped to that host |

The CLI also lists, fetches, and unshares documents, and lists or revokes machine tokens. Its public-document fetch never sends the publisher credential to the serving origin.

## Non goal

- No change to the Copilot plugin's bundled skill.
- No agent-specific behavior beyond placing the same skill in each supported agent.
- No server-side Markdown rendering or HTTP API change.
- No token minting beyond the existing device flow.

## Screenshot

Not applicable. This PR adds a terminal client and agent instruction file; it does not add or change a rendered product surface.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Node tests cover placement, upgrades, rendering, validation-before-auth, device polling, quota guidance, and repeat-publish state; Worker tests exercise every request path |
| A defect would fail CI or be obvious on first use | ✅ | The root CI commands run both the Worker integration test and the package tests |
| A revert fully restores prior state, including persisted data | ❌ | Commands write an installed skill, credentials, and publish state to the user's config directory |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The CLI receives, stores, and sends opaque bearer credentials and accepts local files |
| No public API, plugin API, message, or on-disk contract changes | ❌ | This introduces a public CLI plus credential and publish-state files |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Terminal sign-in polls the existing device flow until approval, denial, or expiry |
| No hot-path behavior lacks deterministic coverage | ✅ | Worker tests cover all request paths, and Node tests cover pending, slow-down, denial, and expiry during login |
| No new dependency | ❌ | `marked` is the package's single runtime dependency for local Markdown rendering |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Installer and command failures are reported directly in the invoking terminal |

Review: inspect `createClient` in `packages/openartifacts/src/client.js` and `login`, `writePrivateJson`, `install`, and `main` in `packages/openartifacts/src/cli.js` line by line, then run Verification steps 2-4 including the unsupported-file and repeat-publish cases.

## Verification

1. Run `npm ci`, `npm run typecheck`, and `npm test`.
2. Run `npm pack --dry-run -w packages/openartifacts`; confirm the tarball contains only the CLI, shared skill, README, and license.
3. Follow `docs/development.md` to seed a local publisher and start the Worker. Publish one Markdown file twice with `OPENARTIFACTS_API_HOST=http://127.0.0.1:8787`, `OPENARTIFACTS_TOKEN=<local key>`, and `node packages/openartifacts/bin/openartifacts.js publish <file>`; observe the same URL both times and version 2 in `list`.
4. Run `get`, `tokens`, and `unshare` against that local Worker, then try to publish a `.txt` file with no stored credential; observe current HTML, an empty token list for the local license key, a withdrawn document, and a local input error without a sign-in request respectively.

## Note

Published as `openartifacts@0.2.0` after merge. The public registry and exact `npx openartifacts install` path were verified against isolated agent and global-install directories.

Concurrent first publishes of the same file from separate processes are not serialized; sequential repeat publishes are. `get` paginates the account list because the frozen API has no document-metadata endpoint and the client must use the returned serving URL.
