### PR TITLE
Restore npm discovery keywords

### DIFF
--- a/packages/openartifacts/package.json
+++ b/packages/openartifacts/package.json
@@ -3,12 +3,13 @@
   "version": "0.2.0",
   "description": "Install the OpenArtifacts agent skill and publish files from the terminal",
   "keywords": [
+    "agent-skills",
+    "publishing",
     "cli",
-    "upload",
-    "share",
     "artifacts",
     "markdown",
-    "mermaid"
+    "html",
+    "file-sharing"
   ],
   "type": "module",
   "license": "MIT",

--- a/packages/openartifacts/package.json
+++ b/packages/openartifacts/package.json
@@ -2,6 +2,14 @@
   "name": "openartifacts",
   "version": "0.2.0",
   "description": "Install the OpenArtifacts agent skill and publish files from the terminal",
+  "keywords": [
+    "cli",
+    "upload",
+    "share",
+    "artifacts",
+    "markdown",
+    "mermaid"
+  ],
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Why

The npm page for v0.2.0 shows `Keywords: none` because the workspace package manifest omitted the discovery keywords included in earlier releases. This makes the package harder to find through npm search and leaves the new package listing incomplete.

## What

Future package releases advertise seven focused terms: `agent-skills`, `publishing`, `cli`, `artifacts`, `markdown`, `html`, and `file-sharing`.

## Non goal

This PR does not republish v0.2.0 or change CLI behavior.

## Screenshot

![Before: npm v0.2.0 shows no keywords](https://github.com/user-attachments/assets/ebfc4dda-6481-4692-abe2-2dc77cf3a7c3)

An after screenshot is not available because npm renders package metadata only after a new version is published. The packed manifest provides the reviewable before-release result.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | This changes npm discovery metadata only, and the packed manifest exposes the result before release |
| A defect would fail CI or be obvious on first use | ✅ | Packing the workspace package immediately shows the complete keyword list |
| A revert fully restores prior state, including persisted data | ✅ | This PR does not publish a package or migrate data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Package discovery metadata does not touch these surfaces |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The CLI and package contents are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime code changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The result is confined to the npm package listing and packed manifest |

Review: run Verification and confirm the packed `package.json` contains exactly the seven listed keywords.

## Verification

1. Create a temporary output directory: `mkdir -p /tmp/openartifacts-keyword-check`.
2. Pack the workspace package: `npm pack ./packages/openartifacts --json --pack-destination /tmp/openartifacts-keyword-check`.
3. Run `tar -xOf /tmp/openartifacts-keyword-check/openartifacts-0.2.0.tgz package/package.json` and confirm `keywords` contains `agent-skills`, `publishing`, `cli`, `artifacts`, `markdown`, `html`, and `file-sharing`.
