### PR TITLE
Limit free accounts to three published documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The D1 command prints a `database_id`. Update `wrangler.jsonc` for your account:
 3. Set `database_name` and `database_id` to your D1 values.
 4. Replace `routes` with exactly two `custom_domain` entries: your document
    host and your API host.
-5. Keep only `SERVING_HOST` and `API_HOST` under `vars`, using those same hosts.
+5. Keep `SERVING_HOST` and `API_HOST` under `vars`, using those same hosts, plus `ACCOUNT_MAX_DOCS` if you set a custom document ceiling.
 6. Keep `workers_dev` set to `false`.
 
 Apply the schema, create a publisher key, deploy, and run the smoke test:

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ comments do not exist yet.
 - **List and unshare documents.** Deleting destroys the stored files and leaves
   a `410 Gone` tombstone. Copies already in a reader's browser cache cannot be
   recalled.
-- **Bound abuse.** The current limits are 10 MB per document, 100 pushes per UTC
-  day, and 500 live documents per owner.
+- **Bound abuse.** Free accounts can hold three published documents total,
+  shared across all their agents and devices. Updating one does not use another
+  slot; unsharing one frees a slot. Paid Copilot licenses keep their 500-document
+  ceiling. Both paths allow 100 pushes per UTC day and 10 MB per document.
 
 ## Use from an agent
 
@@ -115,6 +117,13 @@ to that account:
 The separation is important. A document that is reported as phishing should
 not take down your API or brand domain. [Serving domain](docs/serving-domain.md)
 explains the boundary.
+
+Account-token publishing defaults to three live documents per account. Set
+`ACCOUNT_MAX_DOCS` in your Worker vars to a positive safe integer to choose a
+different ceiling for your deployment. An invalid value blocks account-token
+creates without affecting listing, updates, unsharing, or license-key publishing.
+This setting does not require a billing service; hosted subscription checkout
+and per-account paid plans are not implemented yet.
 
 Sign in to Cloudflare and create the storage resources. The names below are
 examples; any names work when these commands and `wrangler.jsonc` agree.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -555,7 +555,7 @@ exposes this API payload to a reader.
 | `gone` | 410 | Every request to the retired `api.symposium.md` host. The canonical API does not emit this code. |
 | `too_large` | 413 | `html` over 10MB. |
 | `quota_exceeded` | 429 | Daily push ceiling or license-key doc-count ceiling reached. |
-| `limit_reached` | 402 | Account-token create would exceed its live-document ceiling. Carries `limit: "documents"` and `plan: "account"` inside `error`. |
+| `limit_reached` | 402 | Account-token create would exceed its live-document ceiling. Carries the exceeded limit's identifier (`limit`) and the account's current plan name (`plan`) as strings inside `error`. |
 | `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |
 | `authorization_pending` | 400 | `POST /device/token`: nobody has approved the code yet. |
 | `slow_down` | 400 | `POST /device/token`: polled faster than the `interval`. |
@@ -608,7 +608,13 @@ An invalid value returns `500 internal` on account-token creates before any
 document or daily quota write; other operations and license-key caps are
 unchanged. No database migration is required.
 
-At the account-token document ceiling, the response is:
+`limit` identifies which limit was hit; `plan` names the account's current plan.
+These are values, not fixed enums: clients must accept unfamiliar strings and
+must not treat either field as proof of paid entitlement. The
+current values are `"documents"` and `"account"`, respectively; real account
+plan names will replace the latter when per-account plans ship.
+
+For example, the current account-token document-cap response is:
 
 ```json
 {"error":{"code":"limit_reached","message":"...","limit":"documents","plan":"account"}}

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -93,10 +93,13 @@ subscriber who wants the documents their plugin published presents the same
 license key the plugin does — this API accepts it from a terminal like any other
 caller.
 
-**Publishing works on a new account.** A token's account is entitled to publish
-under the quotas below from its first approval, so nobody has to buy anything
-before the first document lands. Per-plan limits and a `402` refusal are
-[#60](https://github.com/Brevilabs/OpenArtifacts/issues/60) and are not here yet.
+**Publishing works on a new account.** A token's account can hold three live
+documents by default, starting with its first approval. Creating another at
+the ceiling returns `402 limit_reached`; updating an existing document remains
+allowed. The ceiling is per account across all tokens and does not reset daily.
+Self-hosters can set `ACCOUNT_MAX_DOCS` to choose a different ceiling. Per-account
+paid plans and the admin plan API remain in
+[#60](https://github.com/Brevilabs/OpenArtifacts/issues/60).
 
 **Revocation is immediate.** A revoked token fails on its very next request,
 where a revoked license key keeps working until its cached validation ages out.
@@ -551,7 +554,8 @@ exposes this API payload to a reader.
 | `not_found` | 404 | No such doc, not yours, already deleted, or no route. |
 | `gone` | 410 | Every request to the retired `api.symposium.md` host. The canonical API does not emit this code. |
 | `too_large` | 413 | `html` over 10MB. |
-| `quota_exceeded` | 429 | Daily push or doc-count ceiling reached. |
+| `quota_exceeded` | 429 | Daily push ceiling or license-key doc-count ceiling reached. |
+| `limit_reached` | 402 | Account-token create would exceed its live-document ceiling. Carries `limit: "documents"` and `plan: "account"` inside `error`. |
 | `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |
 | `authorization_pending` | 400 | `POST /device/token`: nobody has approved the code yet. |
 | `slow_down` | 400 | `POST /device/token`: polled faster than the `interval`. |
@@ -578,26 +582,42 @@ Three of these are worth handling deliberately in a client:
 
 ## Quotas
 
-Per license key. They cap the abuse and hoarding tail; a real user never reaches
-one.
+Publishing limits follow the authenticated account, not the token, key, agent,
+or device. License-key and account-token identities remain separate.
 
 | Limit | Value | Exceeded |
 | --- | --- | --- |
 | HTML per doc | 10 MB | `413 too_large` |
 | Pushes per day | 100 (UTC day, rolls at midnight) | `429 quota_exceeded` |
-| Live docs held | 500 | `429 quota_exceeded` |
+| Live docs held, license-key account | 500 | `429 quota_exceeded` |
+| Live docs held, account-token account | 3 by default | `402 limit_reached` |
 
-Both limits are **per account, not per key**: two keys on one account share one
-daily allowance and one 500-document ceiling rather than getting two.
+Two credentials on one account share one daily allowance and one document
+ceiling rather than getting two. The document ceiling never resets with time.
 
 Both `POST` and `PUT` spend one push. A rejected push spends nothing: a `413`,
 a `400`, or a `PUT` at a doc you do not own leaves the day's allowance intact.
-Deleting a doc frees a slot against the 500.
+Unsharing a doc frees a document slot. Updating an existing doc uses a daily
+push but no new document slot. Accounts already above their document ceiling
+keep their existing documents and can update, list, and unshare them; they
+cannot create another until they are below the ceiling.
 
-An account that authenticates with tokens is counted the same way and against
-the same numbers: every token it has issued shares one daily allowance and one
-document ceiling, because the ceiling follows the account and not the
-credential.
+The account-token document ceiling is configured with the optional Worker var
+`ACCOUNT_MAX_DOCS`: a positive safe integer, defaulting to 3 when omitted.
+An invalid value returns `500 internal` on account-token creates before any
+document or daily quota write; other operations and license-key caps are
+unchanged. No database migration is required.
+
+At the account-token document ceiling, the response is:
+
+```json
+{"error":{"code":"limit_reached","message":"...","limit":"documents","plan":"account"}}
+```
+
+Waiting until tomorrow or signing in on another machine does not free a slot.
+The CLI already handles this refusal without suggesting a daily reset. No
+`upgrade_url` is returned until a real upgrade flow is configured; subscription
+checkout and individual paid account plans are separate follow-up work.
 
 Two further limits sit outside all of this. On `POST /device/code`, a single
 client address may ask for five sign-in codes a minute, and past that the mint

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -12,14 +12,14 @@
  * On the create path the `docs` insert *is* the reservation, so the same crash
  * burns a doc slot rather than a version number: a doc row with no versions and
  * no bytes, unreachable because its id was never returned, still counting
- * against the 500-doc ceiling. Only an R2 or D1 failure produces one, and the
+ * against the account's doc ceiling. Only an R2 or D1 failure produces one, and the
  * alternative — inserting the row after the write — would hand out a url before
  * anything pointed at it. Rolling the row back is deliberately not attempted:
  * the failure may equally be the version insert *after* a successful write, and
  * a rollback there would strand the object it names.
  */
-import type { Publisher } from "../auth.js";
-import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
+import { ACCOUNT_TOKEN_PLAN, type Publisher } from "../auth.js";
+import { accountMaxDocs, MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
 import type { Env } from "../config.js";
 import {
   deleteDocRow,
@@ -214,6 +214,8 @@ export async function createDoc(
   const parsed = await parsePushBody(request);
   if (!parsed.ok) return parsed.response;
 
+  const isAccount = publisher.plan === ACCOUNT_TOKEN_PLAN;
+  const maxDocs = isAccount ? accountMaxDocs(env) : MAX_DOCS_PER_PUBLISHER;
   const now = Date.now();
   // A create always names the doc something: absent and blank alike land on the
   // default rather than leaving it nameless in the list.
@@ -234,9 +236,17 @@ export async function createDoc(
       created_at: now,
       updated_at: now,
     },
-    MAX_DOCS_PER_PUBLISHER,
+    maxDocs,
   );
   if (!inserted) {
+    if (isAccount) {
+      return errorResponse(
+        "limit_reached",
+        `Your free account can hold ${maxDocs} published documents. Unshare one to publish another.`,
+        undefined,
+        { limit: "documents", plan: ACCOUNT_TOKEN_PLAN },
+      );
+    }
     return errorResponse(
       "quota_exceeded",
       `You are holding ${MAX_DOCS_PER_PUBLISHER} docs. Delete one to publish another.`,

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -242,7 +242,7 @@ export async function createDoc(
     if (isAccount) {
       return errorResponse(
         "limit_reached",
-        `Your free account can hold ${maxDocs} published documents. Unshare one to publish another.`,
+        `Your account can hold ${maxDocs} published documents. Unshare one to publish another.`,
         undefined,
         { limit: "documents", plan: ACCOUNT_TOKEN_PLAN },
       );

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -67,10 +67,8 @@ const UNKNOWN_PLAN = "unknown";
  * naming it `free` would hand publishing to every FREE license key at the same
  * time, which is the one mistake this constant exists to make impossible.
  *
- * It is a placeholder for `accounts.plan` and the per-plan limits config in
- * [#60](https://github.com/Brevilabs/OpenArtifacts/issues/60). Until then a
- * token account publishes under the same ceilings a license key does, since
- * both are counted per owner.
+ * Token accounts have their own live-document ceiling, counted per owner across
+ * all tokens. Paid subscription entitlements remain follow-up work in #60.
  */
 export const ACCOUNT_TOKEN_PLAN = "account";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,10 +123,13 @@ export const MAX_PUSHES_PER_DAY = 100;
 /** Live (non-deleted) docs a paid license owner may hold. */
 export const MAX_DOCS_PER_PUBLISHER = 500;
 
+/** Live docs a token account may hold when the deployment sets no override. */
+export const DEFAULT_ACCOUNT_MAX_DOCS = 3;
+
 /** Invalid deployment config must never silently grant the paid allowance. */
 export function accountMaxDocs(env: Env): number {
   const raw = env.ACCOUNT_MAX_DOCS;
-  if (raw === undefined) return 3;
+  if (raw === undefined) return DEFAULT_ACCOUNT_MAX_DOCS;
   const limit = Number(raw);
   if (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(limit)) {
     throw new Error("ACCOUNT_MAX_DOCS must be a positive safe integer.");

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,9 @@ export interface Env {
    */
   LICENSE_API_KEY?: string;
 
+  /** Live docs per token account. Defaults to 3; self-hosters may override. */
+  ACCOUNT_MAX_DOCS?: string;
+
   /**
    * OAuth client credentials for the approval page, one pair per provider.
    *
@@ -114,11 +117,22 @@ export const LICENSE_CACHE_TTL_MS = 60 * 60 * 1000;
 /** Largest HTML body a single push may carry, before injection. */
 export const MAX_DOC_BYTES = 10 * 1024 * 1024;
 
-/** Pushes a single publisher key may make in one UTC day. */
+/** Pushes a single owner may make in one UTC day, across credentials. */
 export const MAX_PUSHES_PER_DAY = 100;
 
-/** Live (non-deleted) docs a single publisher key may hold. */
+/** Live (non-deleted) docs a paid license owner may hold. */
 export const MAX_DOCS_PER_PUBLISHER = 500;
+
+/** Invalid deployment config must never silently grant the paid allowance. */
+export function accountMaxDocs(env: Env): number {
+  const raw = env.ACCOUNT_MAX_DOCS;
+  if (raw === undefined) return 3;
+  const limit = Number(raw);
+  if (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(limit)) {
+    throw new Error("ACCOUNT_MAX_DOCS must be a positive safe integer.");
+  }
+  return limit;
+}
 
 /**
  * How long a device code is worth approving.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,6 +9,7 @@ export type ErrorCode =
   | "gone"
   | "too_large"
   | "quota_exceeded"
+  | "limit_reached"
   | "internal"
   // The four conditions RFC 8628 §3.5 defines for a device-flow poll. They keep
   // the RFC's names so a client written against the standard recognises them,
@@ -27,6 +28,7 @@ const ERROR_STATUS: Record<ErrorCode, number> = {
   gone: 410,
   too_large: 413,
   quota_exceeded: 429,
+  limit_reached: 402,
   internal: 500,
   // 400 for all four, as RFC 6749 §5.2 requires of a token endpoint. None of
   // them is a failure of the request: three are the state of an approval nobody
@@ -38,13 +40,23 @@ const ERROR_STATUS: Record<ErrorCode, number> = {
   access_denied: 400,
 };
 
-/** The wire shape. Clients match on `code`; `message` is human-facing only. */
-export interface ErrorBody {
-  error: { code: ErrorCode; message: string };
+export interface LimitDetails {
+  limit: "documents";
+  plan: "account";
 }
 
-export function errorResponse(code: ErrorCode, message: string, headers?: HeadersInit): Response {
-  const body: ErrorBody = { error: { code, message } };
+/** The wire shape. Clients match on `code`; `message` is human-facing only. */
+export interface ErrorBody {
+  error: { code: ErrorCode; message: string } & Partial<LimitDetails>;
+}
+
+export function errorResponse(
+  code: ErrorCode,
+  message: string,
+  headers?: HeadersInit,
+  details?: LimitDetails,
+): Response {
+  const body: ErrorBody = { error: { code, message, ...details } };
   return Response.json(body, { status: ERROR_STATUS[code], headers });
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,8 +41,10 @@ const ERROR_STATUS: Record<ErrorCode, number> = {
 };
 
 export interface LimitDetails {
-  limit: "documents";
-  plan: "account";
+  /** Identifier of the exceeded limit, not display text. */
+  limit: string;
+  /** The account's current plan name. */
+  plan: string;
 }
 
 /** The wire shape. Clients match on `code`; `message` is human-facing only. */

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -72,6 +72,7 @@ async function send(
   path: string,
   credential: string | null,
   body?: unknown,
+  overrides: Partial<Env> = {},
 ): Promise<Response> {
   const headers = new Headers();
   if (credential !== null) headers.set("authorization", `Bearer ${credential}`);
@@ -82,7 +83,7 @@ async function send(
   }
 
   const ctx = createExecutionContext();
-  const response = await worker.fetch(new Request(`${ORIGIN}${path}`, init), local(), ctx);
+  const response = await worker.fetch(new Request(`${ORIGIN}${path}`, init), local(overrides), ctx);
   await waitOnExecutionContext(ctx);
   return response;
 }
@@ -219,6 +220,124 @@ async function tokensSeeDoc(credential: string): Promise<string[]> {
   const body = await listed.json<{ docs: { docId: string }[] }>();
   return body.docs.map((doc) => doc.docId);
 }
+
+describe("free account document limit", () => {
+  const create = (token: string, overrides?: Partial<Env>) =>
+    send("POST", "/api/v1/docs", token, { html: page("new") }, overrides);
+
+  const storage = async () => ({
+    docs: (await env.DB.prepare("SELECT * FROM docs ORDER BY id").all()).results,
+    versions: (await env.DB.prepare("SELECT * FROM versions ORDER BY doc_id, n").all()).results,
+    pushes: (await env.DB.prepare("SELECT * FROM push_quota ORDER BY owner, day").all()).results,
+    objects: (await env.DOCS.list()).objects.map((object) => object.key),
+  });
+
+  it("allows three across tokens, rejects the fourth without writes, and isolates other accounts", async () => {
+    const first = await issueToken(ACCOUNT_A);
+    const second = await issueToken(ACCOUNT_A);
+    for (const token of [first.token, second.token, first.token]) {
+      expect((await create(token)).status).toBe(201);
+    }
+
+    const before = await storage();
+    const refused = await create(second.token);
+    expect(refused.status).toBe(402);
+    expect(await refused.json()).toEqual({
+      error: {
+        code: "limit_reached",
+        message: expect.stringContaining("3 published documents"),
+        limit: "documents",
+        plan: "account",
+      },
+    });
+    expect(await storage()).toEqual(before);
+
+    const other = await issueToken(ACCOUNT_B);
+    expect((await create(other.token)).status).toBe(201);
+  });
+
+  it("does not reset document capacity when yesterday's push allowance rolls over", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+    for (let i = 0; i < 3; i++) await publish(token, `Doc ${i}`);
+    await env.DB.prepare("UPDATE push_quota SET day = '2000-01-01'").run();
+    const before = await storage();
+    expect((await create(token)).status).toBe(402);
+    expect(await storage()).toEqual(before);
+  });
+
+  it("keeps updates and public reads working at the limit, and unshare frees one slot", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+    const first = await publish(token, "First");
+    await publish(token, "Second");
+    await publish(token, "Third");
+    expect((await send("PUT", `/api/v1/docs/${first.docId}`, token, { html: page("v2") })).status)
+      .toBe(200);
+    expect((await send("GET", `/d/${first.docId}`, null)).status).toBe(200);
+    expect((await create(token)).status).toBe(402);
+
+    expect((await send("DELETE", `/api/v1/docs/${first.docId}`, token)).status).toBe(204);
+    expect((await create(token)).status).toBe(201);
+    expect((await create(token)).status).toBe(402);
+  });
+
+  it("atomically gives concurrent tokens only the remaining slot", async () => {
+    const first = await issueToken(ACCOUNT_A);
+    const second = await issueToken(ACCOUNT_A);
+    await publish(first.token, "First");
+    await publish(first.token, "Second");
+    const replies = await Promise.all([create(first.token), create(second.token)]);
+    expect(replies.map((response) => response.status).sort()).toEqual([201, 402]);
+    expect(await tokensSeeDoc(first.token)).toHaveLength(3);
+    expect((await env.DOCS.list()).objects).toHaveLength(3);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 3 }]);
+  });
+
+  it("preserves existing over-cap documents and blocks creates until below the cap", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+    const docs: PushResponse[] = [];
+    for (let i = 0; i < 4; i++) {
+      const response = await create(token, { ACCOUNT_MAX_DOCS: "4" });
+      expect(response.status).toBe(201);
+      docs.push(await response.json<PushResponse>());
+    }
+    expect((await create(token)).status).toBe(402);
+    expect(await tokensSeeDoc(token)).toHaveLength(4);
+    for (const doc of docs) {
+      expect((await send("GET", `/d/${doc.docId}`, null)).status).toBe(200);
+    }
+    expect((await send("PUT", `/api/v1/docs/${docs[0]!.docId}`, token, { html: page("v2") })).status)
+      .toBe(200);
+    await send("DELETE", `/api/v1/docs/${docs[0]!.docId}`, token);
+    expect((await create(token)).status).toBe(402);
+    await send("DELETE", `/api/v1/docs/${docs[1]!.docId}`, token);
+    expect((await create(token)).status).toBe(201);
+  });
+
+  it("honors a self-hosted account cap without changing paid license limits", async () => {
+    const { token } = await issueToken(ACCOUNT_A);
+    expect((await create(token, { ACCOUNT_MAX_DOCS: "1" })).status).toBe(201);
+    expect((await create(token, { ACCOUNT_MAX_DOCS: "1" })).status).toBe(402);
+    for (let i = 0; i < 4; i++) {
+      expect((await create(LICENSE_KEY, { ACCOUNT_MAX_DOCS: "1" })).status).toBe(201);
+    }
+  });
+
+  it.each(["", "0", "-1", "3.5", "Infinity", "oops", "9007199254740992"])(
+    "fails closed before document writes for invalid account cap %j",
+    async (value) => {
+      const { token } = await issueToken(ACCOUNT_A);
+      const before = await storage();
+      const response = await create(token, { ACCOUNT_MAX_DOCS: value });
+      expect(response.status).toBe(500);
+      expect(await errorOf(response)).toBe("internal");
+      expect(await storage()).toEqual(before);
+      // A typo must not disable existing readers, management, or paid access.
+      expect((await send("GET", "/api/v1/docs", token, undefined, { ACCOUNT_MAX_DOCS: value })).status)
+        .toBe(200);
+      expect((await create(LICENSE_KEY, { ACCOUNT_MAX_DOCS: value })).status).toBe(201);
+    },
+  );
+});
 
 describe("recording when a token was last used", () => {
   const lastUsed = async (id: string): Promise<number | null> =>

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -245,7 +245,7 @@ describe("free account document limit", () => {
     expect(await refused.json()).toEqual({
       error: {
         code: "limit_reached",
-        message: expect.stringContaining("3 published documents"),
+        message: "Your account can hold 3 published documents. Unshare one to publish another.",
         limit: "documents",
         plan: "account",
       },


### PR DESCRIPTION
Relates to Brevilabs/OpenArtifacts#60

## Why

A newly approved free account can currently publish 500 documents. The intended hosted allowance is three published documents total, not three per day, so the free-account cap must land before subscription checkout.

## What

| Account or action | Result |
| --- | --- |
| Free account creates a fourth live document | Refused with `402 limit_reached`; all tokens and devices share the same three slots |
| Update, list, or unshare at the cap | Still works; unsharing frees a slot |
| Existing account already above three | Existing documents remain; no new document until below the cap |
| Paid Copilot license | Existing limits and errors unchanged |
| Self-hosted deployment | Can override the account document ceiling; invalid configuration blocks new account-token publishes |

The existing CLI displays the refusal without suggesting a daily reset. No checkout link is advertised before checkout exists.

## Non goal

No payment, pricing, upgrade page, account-plan migration, or admin API in this slice. No product-specific billing integration, changes to license-key limits, or changes to public document serving. Daily push and document-size limits remain unchanged.

## Screenshot

Not applicable: this changes API enforcement and terminal error output, not a rendered page.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real D1/R2 tests cover the cap and allowed operations |
| A defect would fail CI or be obvious on first use | ✅ | Boundary and invalid-configuration tests exercise refusals |
| A revert fully restores prior state, including persisted data | ✅ | No migration or deletion of existing documents |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Free accounts receive a stricter publishing allowance |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Account-token creates gain a 402 error with limit and plan fields |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Uses the existing atomic reservation, with concurrent cap tests |
| No hot-path behavior lacks deterministic coverage | ✅ | Shared-account, paid-license, and configuration branches are tested |
| No new dependency | ✅ | No dependency changes |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The refusal appears on the next over-limit create |

Review: inspect `createDoc` in `src/api/push.ts`, `accountMaxDocs` in `src/config.ts`, and `errorResponse` in `src/errors.ts` line by line, then follow the verification below.

## Verification

1. Run `npm test` and `npm run typecheck`. Check the token-account tests for concurrent creates, shared tokens, account isolation, and unchanged paid-license publishing.
2. Against a local Worker, publish three documents with one account token. Try a fourth using another token on the same account: expect 402, not a new document or a spent daily push.
3. Update and list the three documents, then unshare one and publish a replacement. Confirm these operations succeed. Repeat with an already-over-cap account: its old documents remain usable, but creating another is refused.
4. Set `ACCOUNT_MAX_DOCS` to a different positive integer and verify that boundary. Set an invalid value: account-token creates should return 500 without writing data, while license-key publishing and account management remain available.
