### PR TITLE
Enforce account plan limits and enable billing-driven upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
+          package-manager-cache: false
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,14 +81,15 @@ jobs:
       # Full history: the migration check below diffs against the push's base
       # commit, which a shallow clone does not contain.
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
+          package-manager-cache: false
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release-openartifacts.yml
+++ b/.github/workflows/release-openartifacts.yml
@@ -44,15 +44,16 @@ jobs:
 
       - name: Check out merge commit
         if: steps.release.outputs.is_release == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up Node.js
         if: steps.release.outputs.is_release == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Validate package version
         if: steps.release.outputs.is_release == 'true'
@@ -101,14 +102,15 @@ jobs:
 
     steps:
       - name: Check out merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Install JavaScript dependencies
         run: npm ci
@@ -129,16 +131,17 @@ jobs:
 
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
       - name: Use an npm version with Trusted Publishing support
         run: npm install --global npm@11.5.1 --ignore-scripts
 
       - name: Check out pristine merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ comments do not exist yet.
 - **List and unshare documents.** Deleting destroys the stored files and leaves
   a `410 Gone` tombstone. Copies already in a reader's browser cache cannot be
   recalled.
-- **Bound abuse.** Free accounts can hold three published documents total,
-  shared across all their agents and devices. Updating one does not use another
-  slot; unsharing one frees a slot. Paid Copilot licenses keep their 500-document
-  ceiling. Both paths allow 100 pushes per UTC day and 10 MB per document.
+- **Bound abuse.** Hosted free accounts get three live documents, six
+  publishes/updates per UTC day, and 1 MiB HTML per document. The paid plan and
+  paid Copilot licenses allow 500 documents, 100 pushes per day, and 10 MiB.
+  All credentials share their account's allowance. Unsharing frees a document
+  slot, not a daily push. Standalone checkout is not available yet.
 
 ## Use from an agent
 
@@ -118,12 +119,11 @@ The separation is important. A document that is reported as phishing should
 not take down your API or brand domain. [Serving domain](docs/serving-domain.md)
 explains the boundary.
 
-Account-token publishing defaults to three live documents per account. Set
-`ACCOUNT_MAX_DOCS` in your Worker vars to a positive safe integer to choose a
-different ceiling for your deployment. An invalid value blocks account-token
-creates without affecting listing, updates, unsharing, or license-key publishing.
-This setting does not require a billing service; hosted subscription checkout
-and per-account paid plans are not implemented yet.
+Choose your own account limits with `PLAN_LIMITS` and `DEFAULT_PLAN` in Worker
+vars; the checked-in values are the hosted free/paid policy. Without a plan map,
+`ACCOUNT_MAX_DOCS` remains supported (default 3), with 100 pushes/day and 10 MiB
+per document. Billing is optional: [plan configuration and the admin API](docs/http-api.md#account-plans)
+let your own service change plans. Never expose the admin secret to clients.
 
 Sign in to Cloudflare and create the storage resources. The names below are
 examples; any names work when these commands and `wrangler.jsonc` agree.
@@ -145,7 +145,7 @@ The D1 command prints a `database_id`. Update `wrangler.jsonc` for your account:
 3. Set `database_name` and `database_id` to your D1 values.
 4. Replace `routes` with exactly two `custom_domain` entries: your document
    host and your API host.
-5. Keep `SERVING_HOST` and `API_HOST` under `vars`, using those same hosts, plus `ACCOUNT_MAX_DOCS` if you set a custom document ceiling.
+5. Set `SERVING_HOST` and `API_HOST` under `vars` to those hosts and remove the two legacy host vars. Keep your chosen `PLAN_LIMITS`/`DEFAULT_PLAN`, or remove the plan map and retain `ACCOUNT_MAX_DOCS` for the legacy configuration.
 6. Keep `workers_dev` set to `false`.
 
 Apply the schema, create a publisher key, deploy, and run the smoke test:

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ not take down your API or brand domain. [Serving domain](docs/serving-domain.md)
 explains the boundary.
 
 Choose your own account limits with `PLAN_LIMITS` and `DEFAULT_PLAN` in Worker
-vars; the checked-in values are the hosted free/paid policy. Without a plan map,
-`ACCOUNT_MAX_DOCS` remains supported (default 3), with 100 pushes/day and 10 MiB
-per document. Billing is optional: [plan configuration and the admin API](docs/http-api.md#account-plans)
+vars; the checked-in values are the hosted free/paid policy. Without an override,
+the built-in map has one free plan: 3 documents, 6 pushes/day, and 1 MiB HTML.
+Billing is optional: [plan configuration and the admin API](docs/http-api.md#account-plans)
 let your own service change plans. Never expose the admin secret to clients.
 
 Sign in to Cloudflare and create the storage resources. The names below are
@@ -145,7 +145,7 @@ The D1 command prints a `database_id`. Update `wrangler.jsonc` for your account:
 3. Set `database_name` and `database_id` to your D1 values.
 4. Replace `routes` with exactly two `custom_domain` entries: your document
    host and your API host.
-5. Set `SERVING_HOST` and `API_HOST` under `vars` to those hosts and remove the two legacy host vars. Keep your chosen `PLAN_LIMITS`/`DEFAULT_PLAN`, or remove the plan map and retain `ACCOUNT_MAX_DOCS` for the legacy configuration.
+5. Set `SERVING_HOST` and `API_HOST` under `vars` to those hosts and remove the two legacy host vars. Keep your chosen `PLAN_LIMITS`/`DEFAULT_PLAN`.
 6. Keep `workers_dev` set to `false`.
 
 Apply the schema, create a publisher key, deploy, and run the smoke test:

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -555,7 +555,7 @@ exposes this API payload to a reader.
 | `gone` | 410 | Every request to the retired `api.symposium.md` host. The canonical API does not emit this code. |
 | `too_large` | 413 | `html` over 10MB. |
 | `quota_exceeded` | 429 | License-key publishing ceiling or device-flow rate limit reached. |
-| `limit_reached` | 402 | Account-token publish would exceed a plan limit. Carries the exceeded limit's identifier (`limit`), current plan name (`plan`), and optional `upgradeUrl` inside `error`. |
+| `limit_reached` | 402 | Account-token publish would exceed a plan limit. Carries the exceeded limit's identifier (`limit`), current plan name (`plan`), and optional `upgrade_url` inside `error`. |
 | `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |
 | `authorization_pending` | 400 | `POST /device/token`: nobody has approved the code yet. |
 | `slow_down` | 400 | `POST /device/token`: polled faster than the `interval`. |

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -50,8 +50,10 @@ Only the key's SHA-256 is ever stored; the raw key is never persisted or logged.
 resolves the key to the account that holds it, and that account owns everything
 published with it. So every key on one account sees one list, and any of them
 can push a new version of, or unshare, a document another one created. Replacing
-a key changes nothing about which documents you have. Nothing in this API takes
-an account id as input, and none is ever returned.
+a key changes nothing about which documents you have. Publisher operations never
+accept an account id to select whose documents to access; ownership is derived
+from the credential. The separate admin API and optional account-token upgrade
+link expose account ids for routing, not as publisher credentials.
 
 **Publishing requires a paid plan.** Both current license-server paid plans are
 entitled: `PLUS` subscriptions and the lifetime `BELIEVER` plan (sold as
@@ -592,15 +594,17 @@ Apply `0005_account_plans.sql` before deploying this version, following the
 [migration procedure](deploying.md#later-deploys-happen-in-ci). Existing accounts become
 `free`; their tokens and documents remain valid. Unknown plans or malformed
 configuration fail closed for publishing, but do not block listing or unsharing.
-Absent or blank `PLAN_LIMITS` retains the self-hosting fallback: `free` uses
-`ACCOUNT_MAX_DOCS` (default 3), 100 pushes/day and 10 MiB HTML.
+Absent or blank `PLAN_LIMITS` uses the built-in map with one `free` entry:
+3 documents, 6 pushes/day and 1 MiB HTML. `PLAN_LIMITS` replaces that map.
 
 ### Change an account's plan
 
 `PUT /admin/v1/accounts/{owner}/plan` on the API host accepts `{"plan":"pro"}`
 and returns `200 {"owner":"…","plan":"pro"}`. Authorize with
 `Authorization: Bearer <ADMIN_API_KEY>`, a separate Worker secret held only by
-your billing service. Publisher tokens and license keys cannot administer plans.
+your billing service. Use a long, cryptographically random secret (at least 32
+random bytes); this route has no application-level rate limiter. Publisher
+tokens and license keys cannot administer plans.
 No configured secret disables the route (`404`); incorrect credentials return
 `401`, an unknown plan `400`, and a missing account `404`. Retrying the same
 change is safe. Every account token sees the new plan on its next request.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -93,13 +93,11 @@ subscriber who wants the documents their plugin published presents the same
 license key the plugin does — this API accepts it from a terminal like any other
 caller.
 
-**Publishing works on a new account.** A token's account can hold three live
-documents by default, starting with its first approval. Creating another at
-the ceiling returns `402 limit_reached`; updating an existing document remains
-allowed. The ceiling is per account across all tokens and does not reset daily.
-Self-hosters can set `ACCOUNT_MAX_DOCS` to choose a different ceiling. Per-account
-paid plans and the admin plan API remain in
-[#60](https://github.com/Brevilabs/OpenArtifacts/issues/60).
+**Publishing follows the account's plan.** First approval uses the deployment's
+default plan. Every token shares its account's limits, and a plan change takes
+effect on the next request without signing in again. The hosted free plan has
+three live documents, six publishes/updates per UTC day, and 1 MiB HTML per doc.
+Listing and unsharing never require available publishing quota.
 
 **Revocation is immediate.** A revoked token fails on its very next request,
 where a revoked license key keeps working until its cached validation ages out.
@@ -554,8 +552,8 @@ exposes this API payload to a reader.
 | `not_found` | 404 | No such doc, not yours, already deleted, or no route. |
 | `gone` | 410 | Every request to the retired `api.symposium.md` host. The canonical API does not emit this code. |
 | `too_large` | 413 | `html` over 10MB. |
-| `quota_exceeded` | 429 | Daily push ceiling or license-key doc-count ceiling reached. |
-| `limit_reached` | 402 | Account-token create would exceed its live-document ceiling. Carries the exceeded limit's identifier (`limit`) and the account's current plan name (`plan`) as strings inside `error`. |
+| `quota_exceeded` | 429 | License-key publishing ceiling or device-flow rate limit reached. |
+| `limit_reached` | 402 | Account-token publish would exceed a plan limit. Carries the exceeded limit's identifier (`limit`), current plan name (`plan`), and optional `upgradeUrl` inside `error`. |
 | `internal` | 500 | Our fault, including the license server being unreachable for a key we have never seen. |
 | `authorization_pending` | 400 | `POST /device/token`: nobody has approved the code yet. |
 | `slow_down` | 400 | `POST /device/token`: polled faster than the `interval`. |
@@ -580,17 +578,54 @@ Three of these are worth handling deliberately in a client:
   no `403`. A doc belonging to another account answers exactly like a doc that
   never existed, because a distinguishable reply would confirm the id is real.
 
+## Account plans
+
+Worker var `PLAN_LIMITS` is a JSON string mapping plan names to positive integer
+ceilings. HTML is measured in UTF-8 bytes and cannot exceed the 10 MiB safety bound:
+
+```json
+{"free":{"documents":3,"pushesPerDay":6,"htmlBytes":1048576},"pro":{"documents":500,"pushesPerDay":100,"htmlBytes":10485760}}
+```
+
+`DEFAULT_PLAN` (default `free`) selects the plan for newly created accounts.
+Apply `0005_account_plans.sql` before deploying this version, following the
+[migration procedure](deploying.md#later-deploys-happen-in-ci). Existing accounts become
+`free`; their tokens and documents remain valid. Unknown plans or malformed
+configuration fail closed for publishing, but do not block listing or unsharing.
+Absent or blank `PLAN_LIMITS` retains the self-hosting fallback: `free` uses
+`ACCOUNT_MAX_DOCS` (default 3), 100 pushes/day and 10 MiB HTML.
+
+### Change an account's plan
+
+`PUT /admin/v1/accounts/{owner}/plan` on the API host accepts `{"plan":"pro"}`
+and returns `200 {"owner":"…","plan":"pro"}`. Authorize with
+`Authorization: Bearer <ADMIN_API_KEY>`, a separate Worker secret held only by
+your billing service. Publisher tokens and license keys cannot administer plans.
+No configured secret disables the route (`404`); incorrect credentials return
+`401`, an unknown plan `400`, and a missing account `404`. Retrying the same
+change is safe. Every account token sees the new plan on its next request.
+
+Optional `UPGRADE_URL` adds an absolute HTTP(S) link to plan-limit errors, with
+the account's `owner` query parameter. That ID routes checkout; it does **not**
+authorize access. Billing must independently verify account ownership. Leave
+this variable unset until checkout exists. No billing or admin secret belongs
+in a CLI, skill, public link, or this repository.
+
 ## Quotas
 
 Publishing limits follow the authenticated account, not the token, key, agent,
 or device. License-key and account-token identities remain separate.
 
-| Limit | Value | Exceeded |
+| Limit | Hosted free account | Hosted paid account / paid license |
 | --- | --- | --- |
-| HTML per doc | 10 MB | `413 too_large` |
-| Pushes per day | 100 (UTC day, rolls at midnight) | `429 quota_exceeded` |
-| Live docs held, license-key account | 500 | `429 quota_exceeded` |
-| Live docs held, account-token account | 3 by default | `402 limit_reached` |
+| HTML per doc | 1 MiB | 10 MiB |
+| Pushes per UTC day | 6 | 100 |
+| Live docs held | 3 | 500 |
+
+Account plan refusals use `402 limit_reached`. License-key refusals are unchanged:
+`413 too_large` for HTML size, `429 quota_exceeded` for document/daily limits.
+The absolute 10 MiB HTML ceiling and the bounded request reader remain safety
+limits on every plan; exceeding those returns `413 too_large`.
 
 Two credentials on one account share one daily allowance and one document
 ceiling rather than getting two. The document ceiling never resets with time.
@@ -600,30 +635,24 @@ a `400`, or a `PUT` at a doc you do not own leaves the day's allowance intact.
 Unsharing a doc frees a document slot. Updating an existing doc uses a daily
 push but no new document slot. Accounts already above their document ceiling
 keep their existing documents and can update, list, and unshare them; they
-cannot create another until they are below the ceiling.
+cannot create another until they are below the ceiling. Updates must still fit
+the active daily and byte limits. Downgrades do not remove existing content,
+including documents larger than the new plan permits uploading.
 
-The account-token document ceiling is configured with the optional Worker var
-`ACCOUNT_MAX_DOCS`: a positive safe integer, defaulting to 3 when omitted.
-An invalid value returns `500 internal` on account-token creates before any
-document or daily quota write; other operations and license-key caps are
-unchanged. No database migration is required.
-
-`limit` identifies which limit was hit; `plan` names the account's current plan.
+`limit` identifies which limit was hit (`documents`, `pushesPerDay`, or
+`htmlBytes` today); `plan` names the account's current plan.
 These are values, not fixed enums: clients must accept unfamiliar strings and
-must not treat either field as proof of paid entitlement. The
-current values are `"documents"` and `"account"`, respectively; real account
-plan names will replace the latter when per-account plans ship.
+must not treat either field as proof of paid entitlement.
 
 For example, the current account-token document-cap response is:
 
 ```json
-{"error":{"code":"limit_reached","message":"...","limit":"documents","plan":"account"}}
+{"error":{"code":"limit_reached","message":"...","limit":"documents","plan":"free"}}
 ```
 
-Waiting until tomorrow or signing in on another machine does not free a slot.
-The CLI already handles this refusal without suggesting a daily reset. No
-`upgrade_url` is returned until a real upgrade flow is configured; subscription
-checkout and individual paid account plans are separate follow-up work.
+Waiting until tomorrow only resets daily pushes, not document capacity.
+Signing in on another machine resets neither. The CLI displays the refusal
+and upgrade link when present. Hosted checkout remains separate work.
 
 Two further limits sit outside all of this. On `POST /device/code`, a single
 client address may ask for five sign-in codes a minute, and past that the mint

--- a/migrations/0005_account_plans.sql
+++ b/migrations/0005_account_plans.sql
@@ -1,0 +1,3 @@
+-- Additive only: preserve every account, token and document. Deploy before the Worker.
+-- Existing accounts start on the generic free plan; new ones use DEFAULT_PLAN.
+ALTER TABLE accounts ADD COLUMN plan TEXT NOT NULL DEFAULT 'free';

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,0 +1,40 @@
+import { parseBearerToken } from "./auth.js";
+import type { Env } from "./config.js";
+import { errorResponse } from "./errors.js";
+import { configuredPlans } from "./plans.js";
+import { readBodyWithin } from "./quota.js";
+
+export const ADMIN_PREFIX = "/admin/v1";
+
+/** Billing owns subscription state. This narrowly scoped API only changes an existing account's plan. */
+export async function handleAdmin(request: Request, url: URL, env: Env): Promise<Response> {
+  const match = /^\/admin\/v1\/accounts\/([^/]+)\/plan$/.exec(url.pathname);
+  if (!env.ADMIN_API_KEY?.trim() || request.method !== "PUT" || !match) {
+    return errorResponse("not_found", "No admin route.");
+  }
+  const token = parseBearerToken(request.headers.get("authorization"));
+  // The service secret is not a publisher token; never forward it to license authentication.
+  const digest = (value: string) => crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  if (!token || !crypto.subtle.timingSafeEqual(await digest(token), await digest(env.ADMIN_API_KEY))) {
+    return errorResponse("unauthorized", "Expected the admin bearer credential.", { "www-authenticate": "Bearer" });
+  }
+  const raw = await readBodyWithin(request, 1024);
+  if (!raw) return errorResponse("bad_request", "Admin body must be at most 1024 bytes.");
+  let body: unknown;
+  try { body = JSON.parse(new TextDecoder().decode(raw)); } catch {
+    return errorResponse("bad_request", "Body must be JSON.");
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body) || !("plan" in body) ||
+    typeof body.plan !== "string" || Object.keys(body).length !== 1) {
+    return errorResponse("bad_request", "Expected only a plan name.");
+  }
+  // A malformed deployment is a 500, while a caller naming no configured plan is a 400.
+  if (!Object.hasOwn(configuredPlans(env), body.plan)) {
+    return errorResponse("bad_request", "Unknown plan.");
+  }
+  const owner = decodeURIComponent(match[1]!);
+  const updated = await env.DB.prepare("UPDATE accounts SET plan = ? WHERE id = ? RETURNING id, plan")
+    .bind(body.plan, owner).first<{ id: string; plan: string }>();
+  if (!updated) return errorResponse("not_found", "No account with that id.");
+  return Response.json({ owner: updated.id, plan: updated.plan }, { headers: { "cache-control": "no-store" } });
+}

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -32,7 +32,10 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   if (!Object.hasOwn(configuredPlans(env), body.plan)) {
     return errorResponse("bad_request", "Unknown plan.");
   }
-  const owner = decodeURIComponent(match[1]!);
+  let owner: string;
+  try { owner = decodeURIComponent(match[1]!); } catch {
+    return errorResponse("not_found", "No account with that id.");
+  }
   const updated = await env.DB.prepare("UPDATE accounts SET plan = ? WHERE id = ? RETURNING id, plan")
     .bind(body.plan, owner).first<{ id: string; plan: string }>();
   if (!updated) return errorResponse("not_found", "No account with that id.");

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -20,7 +20,7 @@
  */
 import type { Publisher } from "../auth.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
-import { limitReached, planLimits } from "../plans.js";
+import { limitReached, planLimits, type PlanLimits } from "../plans.js";
 import type { Env } from "../config.js";
 import {
   deleteDocRow,
@@ -65,6 +65,7 @@ interface PushBody {
    */
   title: string | null | undefined;
   html: string;
+  htmlBytes: number;
 }
 
 type ParsedPush = { ok: true; body: PushBody } | { ok: false; response: Response };
@@ -115,7 +116,8 @@ async function parsePushBody(request: Request): Promise<ParsedPush> {
       response: errorResponse("bad_request", "`html` must be a non-empty string."),
     };
   }
-  if (utf8Length(html) > MAX_DOC_BYTES) {
+  const htmlBytes = utf8Length(html);
+  if (htmlBytes > MAX_DOC_BYTES) {
     return {
       ok: false,
       response: errorResponse("too_large", `A doc may be at most ${MAX_DOC_BYTES} bytes of HTML.`),
@@ -132,15 +134,18 @@ async function parsePushBody(request: Request): Promise<ParsedPush> {
       // `null` for a present-but-blank title, `undefined` for an absent one.
       title: titleGiven ? (typeof title === "string" ? normalizeTitle(title) : null) : undefined,
       html,
+      htmlBytes,
     },
   };
 }
 
-function dailyQuotaExceeded(): Response {
-  return errorResponse(
-    "quota_exceeded",
-    `You have used all ${MAX_PUSHES_PER_DAY} of today's pushes. Try again tomorrow (UTC).`,
-  );
+function dailyQuotaExceeded(env: Env, publisher: Publisher, limits: PlanLimits | null): Response {
+  const message = `You have used all ${limits?.pushesPerDay ?? MAX_PUSHES_PER_DAY} of today's pushes. Try again tomorrow (UTC).`;
+  return limits ? limitReached(env, publisher, "pushesPerDay", message) : errorResponse("quota_exceeded", message);
+}
+
+function planHtmlExceeded(env: Env, publisher: Publisher, limits: PlanLimits): Response {
+  return limitReached(env, publisher, "htmlBytes", `Your plan allows ${limits.htmlBytes} bytes of HTML per document.`);
 }
 
 /**
@@ -215,8 +220,8 @@ export async function createDoc(
   const limits = publisher.authKind === "account" ? planLimits(env, publisher.plan) : null;
   const parsed = await parsePushBody(request);
   if (!parsed.ok) return parsed.response;
-  if (limits && utf8Length(parsed.body.html) > limits.htmlBytes) {
-    return limitReached(env, publisher, "htmlBytes", `Your plan allows ${limits.htmlBytes} bytes of HTML per document.`);
+  if (limits && parsed.body.htmlBytes > limits.htmlBytes) {
+    return planHtmlExceeded(env, publisher, limits);
   }
 
   const maxDocs = limits?.documents ?? MAX_DOCS_PER_PUBLISHER;
@@ -258,7 +263,7 @@ export async function createDoc(
   const day = utcDay(now);
   if (!(await reserveDailyPush(env.DB, publisher.owner, day, limits?.pushesPerDay))) {
     await deleteDocRow(env.DB, docId);
-    return limits ? limitReached(env, publisher, "pushesPerDay", `You have used all ${limits.pushesPerDay} of today's pushes. Try again tomorrow (UTC).`) : dailyQuotaExceeded();
+    return dailyQuotaExceeded(env, publisher, limits);
   }
 
   // A create is deletable before it answers: the row is visible to this
@@ -294,14 +299,14 @@ export async function updateDoc(
   if (!(await ownsLiveDoc(env.DB, docId, publisher.owner))) {
     return docNotFound(docId);
   }
-  if (limits && utf8Length(parsed.body.html) > limits.htmlBytes) {
-    return limitReached(env, publisher, "htmlBytes", `Your plan allows ${limits.htmlBytes} bytes of HTML per document.`);
+  if (limits && parsed.body.htmlBytes > limits.htmlBytes) {
+    return planHtmlExceeded(env, publisher, limits);
   }
 
   const now = Date.now();
   const day = utcDay(now);
   if (!(await reserveDailyPush(env.DB, publisher.owner, day, limits?.pushesPerDay))) {
-    return limits ? limitReached(env, publisher, "pushesPerDay", `You have used all ${limits.pushesPerDay} of today's pushes. Try again tomorrow (UTC).`) : dailyQuotaExceeded();
+    return dailyQuotaExceeded(env, publisher, limits);
   }
 
   // Past this point the push is paid for, and a delete can still land at either

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -18,8 +18,9 @@
  * the failure may equally be the version insert *after* a successful write, and
  * a rollback there would strand the object it names.
  */
-import { ACCOUNT_TOKEN_PLAN, type Publisher } from "../auth.js";
-import { accountMaxDocs, MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
+import type { Publisher } from "../auth.js";
+import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
+import { limitReached, planLimits } from "../plans.js";
 import type { Env } from "../config.js";
 import {
   deleteDocRow,
@@ -211,11 +212,14 @@ export async function createDoc(
   env: Env,
   publisher: Publisher,
 ): Promise<Response> {
+  const limits = publisher.authKind === "account" ? planLimits(env, publisher.plan) : null;
   const parsed = await parsePushBody(request);
   if (!parsed.ok) return parsed.response;
+  if (limits && utf8Length(parsed.body.html) > limits.htmlBytes) {
+    return limitReached(env, publisher, "htmlBytes", `Your plan allows ${limits.htmlBytes} bytes of HTML per document.`);
+  }
 
-  const isAccount = publisher.plan === ACCOUNT_TOKEN_PLAN;
-  const maxDocs = isAccount ? accountMaxDocs(env) : MAX_DOCS_PER_PUBLISHER;
+  const maxDocs = limits?.documents ?? MAX_DOCS_PER_PUBLISHER;
   const now = Date.now();
   // A create always names the doc something: absent and blank alike land on the
   // default rather than leaving it nameless in the list.
@@ -239,12 +243,10 @@ export async function createDoc(
     maxDocs,
   );
   if (!inserted) {
-    if (isAccount) {
-      return errorResponse(
-        "limit_reached",
+    if (limits) {
+      return limitReached(
+        env, publisher, "documents",
         `Your account can hold ${maxDocs} published documents. Unshare one to publish another.`,
-        undefined,
-        { limit: "documents", plan: ACCOUNT_TOKEN_PLAN },
       );
     }
     return errorResponse(
@@ -254,9 +256,9 @@ export async function createDoc(
   }
 
   const day = utcDay(now);
-  if (!(await reserveDailyPush(env.DB, publisher.owner, day))) {
+  if (!(await reserveDailyPush(env.DB, publisher.owner, day, limits?.pushesPerDay))) {
     await deleteDocRow(env.DB, docId);
-    return dailyQuotaExceeded();
+    return limits ? limitReached(env, publisher, "pushesPerDay", `You have used all ${limits.pushesPerDay} of today's pushes. Try again tomorrow (UTC).`) : dailyQuotaExceeded();
   }
 
   // A create is deletable before it answers: the row is visible to this
@@ -281,6 +283,7 @@ export async function updateDoc(
   // An id that cannot exist is answered without touching D1.
   if (!isDocId(docId)) return docNotFound(docId);
 
+  const limits = publisher.authKind === "account" ? planLimits(env, publisher.plan) : null;
   const parsed = await parsePushBody(request);
   if (!parsed.ok) return parsed.response;
 
@@ -291,11 +294,14 @@ export async function updateDoc(
   if (!(await ownsLiveDoc(env.DB, docId, publisher.owner))) {
     return docNotFound(docId);
   }
+  if (limits && utf8Length(parsed.body.html) > limits.htmlBytes) {
+    return limitReached(env, publisher, "htmlBytes", `Your plan allows ${limits.htmlBytes} bytes of HTML per document.`);
+  }
 
   const now = Date.now();
   const day = utcDay(now);
-  if (!(await reserveDailyPush(env.DB, publisher.owner, day))) {
-    return dailyQuotaExceeded();
+  if (!(await reserveDailyPush(env.DB, publisher.owner, day, limits?.pushesPerDay))) {
+    return limits ? limitReached(env, publisher, "pushesPerDay", `You have used all ${limits.pushesPerDay} of today's pushes. Try again tomorrow (UTC).`) : dailyQuotaExceeded();
   }
 
   // Past this point the push is paid for, and a delete can still land at either

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -40,6 +40,7 @@ import {
   startDeviceHandshake,
 } from "../db.js";
 import { newAccountId, newHandshakeToken } from "../ids.js";
+import { defaultPlan } from "../plans.js";
 import { isTopLevelRequest, withinClientLimit } from "../limits.js";
 import { readBodyWithin } from "../quota.js";
 import { ABOUT_LINK, brandPageHtml, escapeHtml, type BrandPage } from "../page.js";
@@ -362,6 +363,7 @@ async function prove(
     email,
     newAccountId(),
     now,
+    defaultPlan(env),
   );
   if (account === null) return page(EMAIL_CLAIMED, 409);
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -58,21 +58,6 @@ const LICENSE_TIMEOUT_MS = 5_000;
 const UNKNOWN_PLAN = "unknown";
 
 /**
- * The plan an account authenticated by its own token publishes under.
- *
- * A token account holds no license, so it has no plan the license server could
- * name, and `mayPublish` is the only gate on the push path — a brand-new
- * account that could not publish would make the whole approval flow end in a
- * refusal. It therefore has to be a value the license server can never return:
- * naming it `free` would hand publishing to every FREE license key at the same
- * time, which is the one mistake this constant exists to make impossible.
- *
- * Token accounts have their own live-document ceiling, counted per owner across
- * all tokens. Paid subscription entitlements remain follow-up work in #60.
- */
-export const ACCOUNT_TOKEN_PLAN = "account";
-
-/**
  * The paid Copilot plans entitled to publish.
  *
  * The license server currently has two paid plans: Plus subscriptions and the
@@ -83,7 +68,7 @@ export const ACCOUNT_TOKEN_PLAN = "account";
  * Lowercase because `validateLicense` folds the license server's uppercase enum
  * before it gets here, and because `publishers.plan` stores the folded form.
  */
-const PUBLISHING_PLANS: ReadonlySet<string> = new Set(["plus", "believer", ACCOUNT_TOKEN_PLAN]);
+const PUBLISHING_PLANS: ReadonlySet<string> = new Set(["plus", "believer"]);
 
 /**
  * Entitlement is per *operation*, not per identity, so this is deliberately not
@@ -121,6 +106,8 @@ export interface Publisher {
    */
   owner: string;
   plan: string;
+  /** Present only for our own tokens; never infer identity type from a plan name. */
+  authKind?: "account";
 }
 
 export type PublisherFailure =
@@ -273,7 +260,7 @@ async function resolveAccountToken(
     await touchTokenUse(env.DB, live.id, at, at - TOKEN_LAST_USED_RESOLUTION_MS);
   }
 
-  return { ok: true, publisher: { owner: live.account_id, plan: ACCOUNT_TOKEN_PLAN } };
+  return { ok: true, publisher: { owner: live.account_id, plan: live.plan, authKind: "account" } };
 }
 
 const FAILURE_STATUS: Record<PublisherFailure, ErrorCode> = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,14 @@ export interface Env {
 
   /** Live docs per token account. Defaults to 3; self-hosters may override. */
   ACCOUNT_MAX_DOCS?: string;
+  /** JSON map of plan names to documents, pushesPerDay and htmlBytes limits. */
+  PLAN_LIMITS?: string;
+  /** Assigned only when a new account is created. Existing plans never reset. */
+  DEFAULT_PLAN?: string;
+  /** Optional absolute checkout URL. The authenticated owner is added as a query. */
+  UPGRADE_URL?: string;
+  /** Server-to-server bearer credential. Unset disables the admin surface. */
+  ADMIN_API_KEY?: string;
 
   /**
    * OAuth client credentials for the approval page, one pair per provider.

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,8 +86,6 @@ export interface Env {
    */
   LICENSE_API_KEY?: string;
 
-  /** Live docs per token account. Defaults to 3; self-hosters may override. */
-  ACCOUNT_MAX_DOCS?: string;
   /** JSON map of plan names to documents, pushesPerDay and htmlBytes limits. */
   PLAN_LIMITS?: string;
   /** Assigned only when a new account is created. Existing plans never reset. */
@@ -130,20 +128,6 @@ export const MAX_PUSHES_PER_DAY = 100;
 
 /** Live (non-deleted) docs a paid license owner may hold. */
 export const MAX_DOCS_PER_PUBLISHER = 500;
-
-/** Live docs a token account may hold when the deployment sets no override. */
-export const DEFAULT_ACCOUNT_MAX_DOCS = 3;
-
-/** Invalid deployment config must never silently grant the paid allowance. */
-export function accountMaxDocs(env: Env): number {
-  const raw = env.ACCOUNT_MAX_DOCS;
-  if (raw === undefined) return DEFAULT_ACCOUNT_MAX_DOCS;
-  const limit = Number(raw);
-  if (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(limit)) {
-    throw new Error("ACCOUNT_MAX_DOCS must be a positive safe integer.");
-  }
-  return limit;
-}
 
 /**
  * How long a device code is worth approving.

--- a/src/db.ts
+++ b/src/db.ts
@@ -590,14 +590,15 @@ export async function findOrCreateAccount(
   id: string,
   email: string,
   atMs: number,
+  plan = "free",
 ): Promise<AccountRow> {
   const inserted = await db
     .prepare(
-      `INSERT INTO accounts (id, email, created_at) VALUES (?, ?, ?)
+      `INSERT INTO accounts (id, email, created_at, plan) VALUES (?, ?, ?, ?)
        ON CONFLICT(email) DO NOTHING
        RETURNING id, email, created_at`,
     )
-    .bind(id, email, atMs)
+    .bind(id, email, atMs, plan)
     .first<AccountRow>();
   if (inserted !== null) return inserted;
 
@@ -648,6 +649,7 @@ export async function resolveAccountForIdentity(
   email: string,
   newId: string,
   nowMs: number,
+  plan = "free",
 ): Promise<AccountRow | null> {
   const linked = await db
     .prepare(
@@ -664,7 +666,7 @@ export async function resolveAccountForIdentity(
     .bind(email)
     .first<AccountRow>();
 
-  const account = byEmail ?? (await findOrCreateAccount(db, newId, email, nowMs));
+  const account = byEmail ?? (await findOrCreateAccount(db, newId, email, nowMs, plan));
 
   // No conflict target, so *either* constraint refuses the insert quietly. The
   // two mean opposite things, and the read below is what tells them apart.
@@ -1136,14 +1138,15 @@ export async function collectDeviceToken(
 export async function findLiveToken(
   db: D1Database,
   tokenHash: string,
-): Promise<Pick<TokenRow, "id" | "account_id" | "last_used_at"> | null> {
+): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string }) | null> {
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT id, account_id, last_used_at FROM tokens WHERE token_hash = ?`,
+      `SELECT t.id, t.account_id, t.last_used_at, a.plan
+         FROM tokens t JOIN accounts a ON a.id = t.account_id WHERE t.token_hash = ?`,
     )
     .bind(tokenHash)
-    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at">>();
+    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string }>();
 }
 
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,7 +46,7 @@ export interface LimitDetails {
   /** The account's current plan name. */
   plan: string;
   /** Optional deployment-owned checkout URL; never contains the bearer token. */
-  upgradeUrl?: string;
+  upgrade_url?: string;
 }
 
 /** The wire shape. Clients match on `code`; `message` is human-facing only. */

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -45,6 +45,8 @@ export interface LimitDetails {
   limit: string;
   /** The account's current plan name. */
   plan: string;
+  /** Optional deployment-owned checkout URL; never contains the bearer token. */
+  upgradeUrl?: string;
 }
 
 /** The wire shape. Clients match on `code`; `message` is human-facing only. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { deleteDoc, listDocs } from "./api/manage.js";
+import { ADMIN_PREFIX, handleAdmin } from "./admin.js";
 import { APPROVAL_PREFIX, handleApproval } from "./approval/handler.js";
 import { createDoc, updateDoc } from "./api/push.js";
 import {
@@ -85,6 +86,7 @@ export function resolveSurface(hostname: string, pathname: string, config: Surfa
   if (hostsAreConfigured(config)) return "unknown";
 
   if (pathIsUnder(pathname, API_PREFIX)) return "api";
+  if (pathIsUnder(pathname, ADMIN_PREFIX)) return "api";
   // The approval page and the device flow share the API host in production;
   // locally they share the API surface's path fallback, so `wrangler dev` can
   // serve them too.
@@ -123,7 +125,7 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
     extra.length === 0 &&
     ((docId === undefined && request.method === "POST") ||
       (docId !== undefined && request.method === "PUT"));
-  if (publishing && !mayPublish(auth.publisher.plan)) {
+  if (publishing && auth.publisher.authKind !== "account" && !mayPublish(auth.publisher.plan)) {
     return publisherErrorResponse(INELIGIBLE_PLAN);
   }
 
@@ -214,6 +216,9 @@ export default {
       // handle it, which fails the whole test run.
       switch (surface) {
         case "api":
+          if (pathIsUnder(url.pathname, ADMIN_PREFIX)) {
+            return await handleAdmin(request, url, env);
+          }
           // Before `handleApi`, because approval is the one thing on this host
           // a person reaches with a browser and no credential — authenticating
           // it would answer a human with `401` JSON. It is not under

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1,0 +1,57 @@
+import { accountMaxDocs, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY, type Env } from "./config.js";
+import type { Publisher } from "./auth.js";
+import { errorResponse } from "./errors.js";
+
+export interface PlanLimits {
+  documents: number;
+  pushesPerDay: number;
+  htmlBytes: number;
+}
+
+/** Finite positive ceilings only; the HTML memory safety bound is never configurable. */
+export function configuredPlans(env: Env): Record<string, PlanLimits> {
+  const raw: unknown = env.PLAN_LIMITS?.trim()
+    ? JSON.parse(env.PLAN_LIMITS)
+    : { free: { documents: accountMaxDocs(env), pushesPerDay: MAX_PUSHES_PER_DAY, htmlBytes: MAX_DOC_BYTES } };
+  if (!raw || typeof raw !== "object" || Array.isArray(raw) || Object.keys(raw).length === 0) {
+    throw new Error("Invalid PLAN_LIMITS.");
+  }
+  for (const [name, value] of Object.entries(raw)) {
+    if (!/^[a-z][a-z0-9_-]{0,63}$/.test(name) || !value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("Invalid PLAN_LIMITS entry.");
+    }
+    const limits = value as Record<string, unknown>;
+    if (Object.keys(limits).length !== 3 || ["documents", "pushesPerDay", "htmlBytes"].some(
+      (field) => typeof limits[field] !== "number" || !Number.isSafeInteger(limits[field]) || (limits[field] as number) <= 0,
+    ) || (limits.htmlBytes as number) > MAX_DOC_BYTES) throw new Error("Invalid plan ceilings.");
+  }
+  return raw as Record<string, PlanLimits>;
+}
+
+export function planLimits(env: Env, plan: string): PlanLimits {
+  const plans = configuredPlans(env);
+  if (!Object.hasOwn(plans, plan)) throw new Error("Account plan is not configured.");
+  return plans[plan]!;
+}
+
+export function defaultPlan(env: Env): string {
+  const plan = env.DEFAULT_PLAN ?? "free";
+  planLimits(env, plan);
+  return plan;
+}
+
+export function limitReached(env: Env, publisher: Publisher, limit: string, message: string): Response {
+  let upgradeUrl: string | undefined;
+  if (env.UPGRADE_URL?.trim()) {
+    const url = new URL(env.UPGRADE_URL);
+    if (!["https:", "http:"].includes(url.protocol) || url.username || url.password) {
+      throw new Error("UPGRADE_URL must be an absolute HTTP(S) URL without credentials.");
+    }
+    // This routes checkout, never authenticates it. Billing must prove account ownership.
+    url.searchParams.set("owner", publisher.owner);
+    upgradeUrl = url.toString();
+  }
+  return errorResponse("limit_reached", message, undefined, {
+    plan: publisher.plan, limit, ...(upgradeUrl ? { upgradeUrl } : {}),
+  });
+}

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -56,6 +56,6 @@ export function limitReached(env: Env, publisher: Publisher, limit: string, mess
     upgradeUrl = url.toString();
   }
   return errorResponse("limit_reached", message, undefined, {
-    plan: publisher.plan, limit, ...(upgradeUrl ? { upgradeUrl } : {}),
+    plan: publisher.plan, limit, ...(upgradeUrl ? { upgrade_url: upgradeUrl } : {}),
   });
 }

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1,4 +1,4 @@
-import { accountMaxDocs, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY, type Env } from "./config.js";
+import { MAX_DOC_BYTES, type Env } from "./config.js";
 import type { Publisher } from "./auth.js";
 import { errorResponse } from "./errors.js";
 
@@ -8,11 +8,15 @@ export interface PlanLimits {
   htmlBytes: number;
 }
 
+const DEFAULT_PLANS: Record<string, PlanLimits> = {
+  free: { documents: 3, pushesPerDay: 6, htmlBytes: 1024 * 1024 },
+};
+
 /** Finite positive ceilings only; the HTML memory safety bound is never configurable. */
 export function configuredPlans(env: Env): Record<string, PlanLimits> {
   const raw: unknown = env.PLAN_LIMITS?.trim()
     ? JSON.parse(env.PLAN_LIMITS)
-    : { free: { documents: accountMaxDocs(env), pushesPerDay: MAX_PUSHES_PER_DAY, htmlBytes: MAX_DOC_BYTES } };
+    : DEFAULT_PLANS;
   if (!raw || typeof raw !== "object" || Array.isArray(raw) || Object.keys(raw).length === 0) {
     throw new Error("Invalid PLAN_LIMITS.");
   }

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -96,6 +96,7 @@ export async function reserveDailyPush(
   db: D1Database,
   owner: string,
   day: string,
+  limit = MAX_PUSHES_PER_DAY,
 ): Promise<boolean> {
   const claimed = await db
     .prepare(
@@ -104,7 +105,7 @@ export async function reserveDailyPush(
          WHERE push_quota.pushes < ?
        RETURNING pushes`,
     )
-    .bind(owner, day, MAX_PUSHES_PER_DAY)
+    .bind(owner, day, limit)
     .first<{ pushes: number }>();
 
   return claimed !== null;

--- a/test/cli-client.test.ts
+++ b/test/cli-client.test.ts
@@ -19,6 +19,8 @@ const local = (): Env => ({
 }) as Env;
 
 async function issueToken(): Promise<{ token: string; id: string }> {
+  await env.DB.prepare("INSERT INTO accounts (id, email, created_at) VALUES (?, ?, ?)")
+    .bind("oa_cli_test_account000000000", "cli@example.test", Date.now()).run();
   const token = newApiToken();
   const id = newTokenId();
   await env.DB.prepare(

--- a/test/env.d.ts
+++ b/test/env.d.ts
@@ -4,5 +4,6 @@ declare module "cloudflare:test" {
   /** `env` inside a test is the worker's own Env, plus the migrations to apply. */
   interface ProvidedEnv extends Env {
     TEST_MIGRATIONS: D1Migration[];
+    HOSTED_PLAN_LIMITS: string;
   }
 }

--- a/test/env.d.ts
+++ b/test/env.d.ts
@@ -4,6 +4,5 @@ declare module "cloudflare:test" {
   /** `env` inside a test is the worker's own Env, plus the migrations to apply. */
   interface ProvidedEnv extends Env {
     TEST_MIGRATIONS: D1Migration[];
-    HOSTED_PLAN_LIMITS: string;
   }
 }

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -34,7 +34,7 @@ async function send(method: string, path: string, body?: unknown, overrides: Par
 const create = (html = "<p>one</p>", overrides: Partial<Env> = {}, credential = token) => send("POST", "/api/v1/docs", { html }, overrides, credential);
 const setPlan = (plan: string, owner = OWNER, overrides: Partial<Env> = {}, credential = ADMIN) => send("PUT", `/admin/v1/accounts/${owner}/plan`, { plan }, overrides, credential);
 const usage = async () => (await env.DB.prepare("SELECT pushes FROM push_quota WHERE owner = ? AND day = ?").bind(OWNER, utcDay(Date.now())).first<{ pushes: number }>())?.pushes ?? 0;
-const error = (response: Response) => response.json<{ error: { code: string; limit?: string; plan?: string; upgradeUrl?: string } }>();
+const error = (response: Response) => response.json<{ error: { code: string; limit?: string; plan?: string; upgrade_url?: string } }>();
 beforeEach(async () => {
   await findOrCreateAccount(env.DB, OWNER, "plans@example.test", Date.now());
   token = await issue();
@@ -132,9 +132,10 @@ describe("configured account plans", () => {
   it("returns an optional checkout URL carrying only the authenticated owner", async () => {
     const response = await create("x".repeat(1048577), { UPGRADE_URL: "https://billing.test/upgrade?owner=forged&source=cli" });
     const details = (await error(response)).error;
-    expect(details.upgradeUrl).toBe(`https://billing.test/upgrade?owner=${OWNER}&source=cli`);
+    expect(details.upgrade_url).toBe(`https://billing.test/upgrade?owner=${OWNER}&source=cli`);
+    expect(details).not.toHaveProperty("upgradeUrl");
     expect(JSON.stringify(details)).not.toContain(token);
-    expect((await error(await create("x".repeat(1048577)))).error).not.toHaveProperty("upgradeUrl");
+    expect((await error(await create("x".repeat(1048577)))).error).not.toHaveProperty("upgrade_url");
   });
 
   it.each(["no json", "[]", "{}", '{"free":{"documents":3,"pushesPerDay":0,"htmlBytes":1}}', '{"free":{"documents":3,"pushesPerDay":6,"htmlBytes":10485761}}'])("fails closed on bad plan config %s without blocking management", async (PLAN_LIMITS) => {

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -14,7 +14,7 @@ const ADMIN = "test-service-secret";
 let token: string;
 const local = (overrides: Partial<Env> = {}): Env => ({
   ...env, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "",
-  PLAN_LIMITS: env.HOSTED_PLAN_LIMITS, DEFAULT_PLAN: "free", ADMIN_API_KEY: ADMIN, ...overrides,
+  ADMIN_API_KEY: ADMIN, ...overrides,
 });
 async function issue(owner = OWNER) {
   const value = newApiToken();
@@ -56,8 +56,9 @@ describe("configured account plans", () => {
   it("loads the agreed hosted values from wrangler, not a separate test copy", () => {
     expect(planLimits(local(), "free")).toEqual({ documents: 3, pushesPerDay: 6, htmlBytes: 1048576 });
     expect(planLimits(local(), "pro")).toEqual({ documents: 500, pushesPerDay: 100, htmlBytes: 10485760 });
-    expect(planLimits(local({ PLAN_LIMITS: undefined, ACCOUNT_MAX_DOCS: "50" }), "free"))
-      .toEqual({ documents: 50, pushesPerDay: 100, htmlBytes: 10485760 });
+    for (const PLAN_LIMITS of [undefined, ""]) {
+      expect(planLimits(local({ PLAN_LIMITS }), "free")).toEqual(planLimits(local(), "free"));
+    }
   });
 
   it("assigns the configured default once and never resets a returning account", async () => {
@@ -184,6 +185,7 @@ describe("service-only plan changes", () => {
     }
     expect((await setPlan("not-configured")).status).toBe(400);
     expect((await setPlan("pro", "license-owner")).status).toBe(404);
+    expect((await setPlan("pro", "%broken")).status).toBe(404);
     expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "free", owner: "other" }, {}, ADMIN)).status).toBe(400);
   });
   it("never exposes admin writes on serving, retired or unknown hosts", async () => {

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -1,0 +1,197 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/config.js";
+import { MAX_DOC_BYTES } from "../src/config.js";
+import { findOrCreateAccount, resolveAccountForIdentity } from "../src/db.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId } from "../src/ids.js";
+import worker from "../src/index.js";
+import { defaultPlan, planLimits } from "../src/plans.js";
+import { utcDay } from "../src/quota.js";
+
+const OWNER = "oa_plan_test";
+const ADMIN = "test-service-secret";
+let token: string;
+const local = (overrides: Partial<Env> = {}): Env => ({
+  ...env, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "",
+  PLAN_LIMITS: env.HOSTED_PLAN_LIMITS, DEFAULT_PLAN: "free", ADMIN_API_KEY: ADMIN, ...overrides,
+});
+async function issue(owner = OWNER) {
+  const value = newApiToken();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, ?)")
+    .bind(newTokenId(), await sha256Hex(value), owner, Date.now()).run();
+  return value;
+}
+async function send(method: string, path: string, body?: unknown, overrides: Partial<Env> = {}, credential = token, origin = "https://local.test") {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`${origin}${path}`, {
+    method, headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), local(overrides), ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+const create = (html = "<p>one</p>", overrides: Partial<Env> = {}, credential = token) => send("POST", "/api/v1/docs", { html }, overrides, credential);
+const setPlan = (plan: string, owner = OWNER, overrides: Partial<Env> = {}, credential = ADMIN) => send("PUT", `/admin/v1/accounts/${owner}/plan`, { plan }, overrides, credential);
+const usage = async () => (await env.DB.prepare("SELECT pushes FROM push_quota WHERE owner = ? AND day = ?").bind(OWNER, utcDay(Date.now())).first<{ pushes: number }>())?.pushes ?? 0;
+const error = (response: Response) => response.json<{ error: { code: string; limit?: string; plan?: string; upgradeUrl?: string } }>();
+beforeEach(async () => {
+  await findOrCreateAccount(env.DB, OWNER, "plans@example.test", Date.now());
+  token = await issue();
+});
+
+describe("configured account plans", () => {
+  it("migrates an existing account without changing its token, email or document", async () => {
+    const doc = await (await create()).json<{ docId: string }>();
+    const before = await env.DB.prepare("SELECT id, email, created_at FROM accounts WHERE id = ?").bind(OWNER).first();
+    // Recreate the immediately preceding schema, then apply the actual committed migration.
+    await env.DB.prepare("ALTER TABLE accounts DROP COLUMN plan").run();
+    const migration = env.TEST_MIGRATIONS.find((entry) => entry.name === "0005_account_plans.sql")!;
+    for (const query of migration.queries) await env.DB.prepare(query).run();
+    expect(await env.DB.prepare("SELECT id, email, created_at FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual(before);
+    expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan: "free" });
+    expect((await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "after migration" })).status).toBe(200);
+  });
+
+  it("loads the agreed hosted values from wrangler, not a separate test copy", () => {
+    expect(planLimits(local(), "free")).toEqual({ documents: 3, pushesPerDay: 6, htmlBytes: 1048576 });
+    expect(planLimits(local(), "pro")).toEqual({ documents: 500, pushesPerDay: 100, htmlBytes: 10485760 });
+    expect(planLimits(local({ PLAN_LIMITS: undefined, ACCOUNT_MAX_DOCS: "50" }), "free"))
+      .toEqual({ documents: 50, pushesPerDay: 100, htmlBytes: 10485760 });
+  });
+
+  it("assigns the configured default once and never resets a returning account", async () => {
+    const config = local({ DEFAULT_PLAN: "pro" });
+    const account = await resolveAccountForIdentity(env.DB, "google", "first", "new@example.test", "oa_new", Date.now(), defaultPlan(config));
+    expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(account!.id).first()).toEqual({ plan: "pro" });
+    await resolveAccountForIdentity(env.DB, "google", "first", "new@example.test", "oa_unused", Date.now(), "free");
+    expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(account!.id).first()).toEqual({ plan: "pro" });
+    expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan: "free" });
+  });
+
+  it("shares six successful creates and updates across tokens, rolling over in UTC", async () => {
+    const other = await issue();
+    const doc = await (await create()).json<{ docId: string }>();
+    for (let i = 0; i < 5; i++) expect((await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "updated" }, {}, other)).status).toBe(200);
+    const rejected = await create();
+    expect(rejected.status).toBe(402);
+    expect(await error(rejected)).toMatchObject({ error: { limit: "pushesPerDay", plan: "free" } });
+    expect(await usage()).toBe(6);
+    expect((await send("DELETE", `/api/v1/docs/${doc.docId}`)).status).toBe(204);
+    expect((await create()).status).toBe(402);
+    expect(await usage()).toBe(6);
+    const tomorrow = Date.now() + 86400000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(tomorrow);
+    try { expect((await create()).status).toBe(201); } finally { clock.mockRestore(); }
+  });
+
+  it("atomically awards the last daily push across two token updates", async () => {
+    const doc = await (await create()).json<{ docId: string }>();
+    await env.DB.prepare("UPDATE push_quota SET pushes = 5 WHERE owner = ?").bind(OWNER).run();
+    const other = await issue();
+    const responses = await Promise.all([token, other].map((key) => send("PUT", `/api/v1/docs/${doc.docId}`, { html: "updated" }, {}, key)));
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 402]);
+    expect(await usage()).toBe(6);
+  });
+
+  it("checks UTF-8 HTML bytes on create and update without spending rejected attempts", async () => {
+    const html = "é".repeat(524288);
+    const doc = await (await create(html)).json<{ docId: string }>();
+    for (const response of [await create(`${html}x`), await send("PUT", `/api/v1/docs/${doc.docId}`, { html: `${html}x` })]) {
+      expect(response.status).toBe(402);
+      expect(await error(response)).toMatchObject({ error: { limit: "htmlBytes" } });
+    }
+    expect((await create("")).status).toBe(400);
+    expect((await send("PUT", "/api/v1/docs/0123456789abcdef", { html: "x" })).status).toBe(404);
+    expect(await usage()).toBe(1);
+  });
+
+  it("upgrades existing tokens immediately and downgrades without removing or locking documents", async () => {
+    const doc = await (await create()).json<{ docId: string }>();
+    expect((await setPlan("pro")).status).toBe(200);
+    let largeId = "";
+    for (let i = 0; i < 3; i++) {
+      const created = await create("x".repeat(1048577));
+      expect(created.status).toBe(201);
+      largeId = (await created.json<{ docId: string }>()).docId;
+    }
+    expect((await setPlan("free")).status).toBe(200);
+    const large = await send("GET", `/d/${largeId}`);
+    expect(large.status).toBe(200);
+    expect((await large.text()).length).toBeGreaterThan(1048576);
+    expect((await create()).status).toBe(402);
+    expect((await send("GET", `/d/${doc.docId}`)).status).toBe(200);
+    expect((await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "small update" })).status).toBe(200);
+    expect((await send("GET", "/api/v1/docs")).status).toBe(200);
+    expect((await send("DELETE", `/api/v1/docs/${doc.docId}`)).status).toBe(204);
+    expect((await create()).status).toBe(402); // Three live docs still fill the downgraded cap.
+    expect(await usage()).toBe(5);
+  });
+
+  it("returns an optional checkout URL carrying only the authenticated owner", async () => {
+    const response = await create("x".repeat(1048577), { UPGRADE_URL: "https://billing.test/upgrade?owner=forged&source=cli" });
+    const details = (await error(response)).error;
+    expect(details.upgradeUrl).toBe(`https://billing.test/upgrade?owner=${OWNER}&source=cli`);
+    expect(JSON.stringify(details)).not.toContain(token);
+    expect((await error(await create("x".repeat(1048577)))).error).not.toHaveProperty("upgradeUrl");
+  });
+
+  it.each(["no json", "[]", "{}", '{"free":{"documents":3,"pushesPerDay":0,"htmlBytes":1}}', '{"free":{"documents":3,"pushesPerDay":6,"htmlBytes":10485761}}'])("fails closed on bad plan config %s without blocking management", async (PLAN_LIMITS) => {
+    const doc = await (await create()).json<{ docId: string }>();
+    expect((await create("x", { PLAN_LIMITS })).status).toBe(500);
+    expect((await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "x" }, { PLAN_LIMITS })).status).toBe(500);
+    expect((await send("GET", "/api/v1/docs", undefined, { PLAN_LIMITS })).status).toBe(200);
+    expect((await send("DELETE", `/api/v1/docs/${doc.docId}`, undefined, { PLAN_LIMITS })).status).toBe(204);
+    expect(await usage()).toBe(1);
+  });
+
+  it("fails closed for a removed plan, while old tokens still list and unshare", async () => {
+    const doc = await (await create()).json<{ docId: string }>();
+    await env.DB.prepare("UPDATE accounts SET plan = 'removed' WHERE id = ?").bind(OWNER).run();
+    expect((await create()).status).toBe(500);
+    expect((await send("GET", "/api/v1/docs")).status).toBe(200);
+    expect((await send("DELETE", `/api/v1/docs/${doc.docId}`)).status).toBe(204);
+  });
+
+  it("retains the absolute HTML safety ceiling for paid plans", async () => {
+    await setPlan("pro");
+    expect((await create("x".repeat(MAX_DOC_BYTES + 1))).status).toBe(413);
+    expect(await usage()).toBe(0);
+  });
+
+  it("preserves existing partial-storage-failure semantics, including the reserved quota", async () => {
+    const DOCS = new Proxy(env.DOCS, { get(target, key, receiver) {
+      return key === "put" ? () => Promise.reject(new Error("R2 unavailable")) : Reflect.get(target, key, receiver);
+    } });
+    expect((await create("x", { DOCS })).status).toBe(500);
+    expect(await usage()).toBe(1);
+    expect(await env.DB.prepare("SELECT COUNT(*) AS n FROM docs WHERE owner = ?").bind(OWNER).first()).toEqual({ n: 1 });
+  });
+});
+
+describe("service-only plan changes", () => {
+  it("is disabled without a secret and refuses publisher tokens or wrong secrets", async () => {
+    expect((await setPlan("pro", OWNER, { ADMIN_API_KEY: undefined })).status).toBe(404);
+    expect((await setPlan("pro", OWNER, {}, token)).status).toBe(401);
+    expect((await setPlan("pro", OWNER, {}, "wrong")).status).toBe(401);
+    expect((await send("POST", "/admin/v1/tokens", {}, {}, ADMIN)).status).toBe(404);
+  });
+  it("idempotently changes only a real account to a configured plan", async () => {
+    for (let i = 0; i < 2; i++) {
+      const response = await setPlan("pro");
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ owner: OWNER, plan: "pro" });
+    }
+    expect((await setPlan("not-configured")).status).toBe(400);
+    expect((await setPlan("pro", "license-owner")).status).toBe(404);
+    expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "free", owner: "other" }, {}, ADMIN)).status).toBe(400);
+  });
+  it("never exposes admin writes on serving, retired or unknown hosts", async () => {
+    const hosts = { API_HOST: "api.test", SERVING_HOST: "docs.test", RETIRED_API_HOST: "retired.test" };
+    for (const [host, status] of [["docs.test", 404], ["retired.test", 410], ["unknown.test", 404]] as const) {
+      expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "pro" }, hosts, ADMIN, `https://${host}`)).status).toBe(status);
+    }
+    expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan: "free" });
+    expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "pro" }, hosts, ADMIN, "https://api.test")).status).toBe(200);
+  });
+});

--- a/test/release-workflow.node.cjs
+++ b/test/release-workflow.node.cjs
@@ -36,9 +36,11 @@ test("publication uses pristine source, not files from the test job", () => {
   assert.doesNotMatch(jobs.prepare, /npm (?:pack|publish)\b/);
   assert.doesNotMatch(workflow, /actions\/(?:upload|download)-artifact/);
   for (const job of [jobs.prepare, jobs.publish]) {
-    assert.match(job, /actions\/checkout@v4\n\s+with:\n\s+ref: \$\{\{ github\.event\.pull_request\.merge_commit_sha \}\}/);
+    assert.match(job, /actions\/checkout@v7\n\s+with:\n\s+ref: \$\{\{ github\.event\.pull_request\.merge_commit_sha \}\}/);
   }
   assert.match(jobs.publish, /persist-credentials: false/);
+  assert.match(jobs.publish, /package-manager-cache: false/);
+  assert.doesNotMatch(jobs.publish, /^\s+cache:/m);
   assert.match(jobs.publish, /npm publish --workspace packages\/openartifacts --ignore-scripts --access public --provenance/);
   assert.match(jobs.publish, /if: steps\.recheck\.outputs\.exists != 'true'/);
 });

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -1,6 +1,6 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { ACCOUNT_TOKEN_PLAN, resolvePublisher } from "../src/auth.js";
+import { resolvePublisher } from "../src/auth.js";
 import { TOKEN_LAST_USED_RESOLUTION_MS } from "../src/config.js";
 import type { Env } from "../src/config.js";
 import { sha256Hex } from "../src/hash.js";
@@ -38,6 +38,8 @@ async function issueToken(
   accountId: string,
   over: { label?: string | null; createdAt?: number } = {},
 ): Promise<{ token: string; id: string }> {
+  await env.DB.prepare("INSERT INTO accounts (id, email, created_at) VALUES (?, ?, ?) ON CONFLICT DO NOTHING")
+    .bind(accountId, `${accountId}@example.test`, NOW).run();
   const token = newApiToken();
   const id = newTokenId();
   await env.DB.prepare(
@@ -177,7 +179,7 @@ describe("Authorization: Bearer <token>", () => {
     expect(calls).toBe(0);
     expect(resolved).toEqual({
       ok: true,
-      publisher: { owner: ACCOUNT_A, plan: ACCOUNT_TOKEN_PLAN },
+      publisher: { owner: ACCOUNT_A, plan: "free", authKind: "account" },
     });
   });
 
@@ -247,7 +249,7 @@ describe("free account document limit", () => {
         code: "limit_reached",
         message: "Your account can hold 3 published documents. Unshare one to publish another.",
         limit: "documents",
-        plan: "account",
+        plan: "free",
       },
     });
     expect(await storage()).toEqual(before);

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -224,6 +224,9 @@ async function tokensSeeDoc(credential: string): Promise<string[]> {
 }
 
 describe("free account document limit", () => {
+  const cap = (documents: number): Partial<Env> => ({
+    PLAN_LIMITS: JSON.stringify({ free: { documents, pushesPerDay: 6, htmlBytes: 1048576 } }),
+  });
   const create = (token: string, overrides?: Partial<Env>) =>
     send("POST", "/api/v1/docs", token, { html: page("new") }, overrides);
 
@@ -298,7 +301,7 @@ describe("free account document limit", () => {
     const { token } = await issueToken(ACCOUNT_A);
     const docs: PushResponse[] = [];
     for (let i = 0; i < 4; i++) {
-      const response = await create(token, { ACCOUNT_MAX_DOCS: "4" });
+      const response = await create(token, cap(4));
       expect(response.status).toBe(201);
       docs.push(await response.json<PushResponse>());
     }
@@ -317,28 +320,26 @@ describe("free account document limit", () => {
 
   it("honors a self-hosted account cap without changing paid license limits", async () => {
     const { token } = await issueToken(ACCOUNT_A);
-    expect((await create(token, { ACCOUNT_MAX_DOCS: "1" })).status).toBe(201);
-    expect((await create(token, { ACCOUNT_MAX_DOCS: "1" })).status).toBe(402);
+    expect((await create(token, cap(1))).status).toBe(201);
+    expect((await create(token, cap(1))).status).toBe(402);
     for (let i = 0; i < 4; i++) {
-      expect((await create(LICENSE_KEY, { ACCOUNT_MAX_DOCS: "1" })).status).toBe(201);
+      expect((await create(LICENSE_KEY, cap(1))).status).toBe(201);
     }
   });
 
-  it.each(["", "0", "-1", "3.5", "Infinity", "oops", "9007199254740992"])(
-    "fails closed before document writes for invalid account cap %j",
-    async (value) => {
-      const { token } = await issueToken(ACCOUNT_A);
-      const before = await storage();
-      const response = await create(token, { ACCOUNT_MAX_DOCS: value });
-      expect(response.status).toBe(500);
-      expect(await errorOf(response)).toBe("internal");
-      expect(await storage()).toEqual(before);
-      // A typo must not disable existing readers, management, or paid access.
-      expect((await send("GET", "/api/v1/docs", token, undefined, { ACCOUNT_MAX_DOCS: value })).status)
-        .toBe(200);
-      expect((await create(LICENSE_KEY, { ACCOUNT_MAX_DOCS: value })).status).toBe(201);
-    },
-  );
+  it("fails closed before document writes for invalid plans without changing paid licenses", async () => {
+    const overrides = cap(0);
+    const { token } = await issueToken(ACCOUNT_A);
+    const before = await storage();
+    const response = await create(token, overrides);
+    expect(response.status).toBe(500);
+    expect(await errorOf(response)).toBe("internal");
+    expect(await storage()).toEqual(before);
+    // A typo must not disable existing readers, management, or paid access.
+    expect((await send("GET", "/api/v1/docs", token, undefined, overrides)).status)
+      .toBe(200);
+    expect((await create(LICENSE_KEY, overrides)).status).toBe(201);
+  });
 });
 
 describe("recording when a token was last used", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,4 @@
 import { defineWorkersConfig, readD1Migrations } from "@cloudflare/vitest-pool-workers/config";
-import { readFileSync } from "node:fs";
 
 /**
  * Tests run inside workerd, not Node.
@@ -13,8 +12,6 @@ export default defineWorkersConfig(async () => {
   // The same files `wrangler d1 migrations apply` runs, so the schema under
   // test is the schema that ships rather than a hand-maintained copy.
   const migrations = await readD1Migrations(new URL("migrations", import.meta.url).pathname);
-  const configText = readFileSync(new URL("wrangler.jsonc", import.meta.url), "utf8");
-  const hostedLimits = JSON.parse(configText.match(/"PLAN_LIMITS"\s*:\s*("(?:[^"\\]|\\.)*")/)![1]!);
 
   return {
     test: {
@@ -34,9 +31,7 @@ export default defineWorkersConfig(async () => {
             // binary supports rather than left to drift silently.
             compatibilityDate: "2026-03-01",
 
-            // Legacy tests exercise the no-plan-map self-hosting compatibility path.
-            // plans.test exercises the deployed configuration separately.
-            bindings: { TEST_MIGRATIONS: migrations, PLAN_LIMITS: "", DEFAULT_PLAN: "free", HOSTED_PLAN_LIMITS: hostedLimits },
+            bindings: { TEST_MIGRATIONS: migrations },
           },
         },
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineWorkersConfig, readD1Migrations } from "@cloudflare/vitest-pool-workers/config";
+import { readFileSync } from "node:fs";
 
 /**
  * Tests run inside workerd, not Node.
@@ -12,6 +13,8 @@ export default defineWorkersConfig(async () => {
   // The same files `wrangler d1 migrations apply` runs, so the schema under
   // test is the schema that ships rather than a hand-maintained copy.
   const migrations = await readD1Migrations(new URL("migrations", import.meta.url).pathname);
+  const configText = readFileSync(new URL("wrangler.jsonc", import.meta.url), "utf8");
+  const hostedLimits = JSON.parse(configText.match(/"PLAN_LIMITS"\s*:\s*("(?:[^"\\]|\\.)*")/)![1]!);
 
   return {
     test: {
@@ -31,7 +34,9 @@ export default defineWorkersConfig(async () => {
             // binary supports rather than left to drift silently.
             compatibilityDate: "2026-03-01",
 
-            bindings: { TEST_MIGRATIONS: migrations },
+            // Legacy tests exercise the no-plan-map self-hosting compatibility path.
+            // plans.test exercises the deployed configuration separately.
+            bindings: { TEST_MIGRATIONS: migrations, PLAN_LIMITS: "", DEFAULT_PLAN: "free", HOSTED_PLAN_LIMITS: hostedLimits },
           },
         },
       },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -112,6 +112,8 @@
     "SERVING_HOST": "openartifacts.site",
     "API_HOST": "api.openartifacts.ai",
     "LEGACY_SERVING_HOST": "symposium.site",
-    "RETIRED_API_HOST": "api.symposium.md"
+    "RETIRED_API_HOST": "api.symposium.md",
+    "DEFAULT_PLAN": "free",
+    "PLAN_LIMITS": "{\"free\":{\"documents\":3,\"pushesPerDay\":6,\"htmlBytes\":1048576},\"pro\":{\"documents\":500,\"pushesPerDay\":100,\"htmlBytes\":10485760}}"
   }
 }


### PR DESCRIPTION
Fixes Brevilabs/OpenArtifacts#60

## Why

Free accounts currently share the paid daily and HTML-size ceilings, and there is no way for billing to upgrade an account without changing its credentials.

## What

| Hosted account | Live documents | Publishes + updates / UTC day | HTML / document |
| --- | ---: | ---: | ---: |
| Free | 3 | 6 | 1 MiB |
| Paid | 500 | 100 | 10 MiB |

All tokens share the account's allowance. Plan changes apply on the next request; downgrades preserve documents, listing, and unsharing. Updates at the document cap remain possible within daily and size limits. Self-hosters choose their own limits and may connect a billing service through a secret-protected plan-change endpoint. Upgrade links are optional.

Upgrade GitHub Actions to their Node 24 runtime while retaining Node 22 for CI/deploy and Node 24 for npm-release commands and preserving the release security boundary.

## Non goal

No checkout, payment processing, upgrade page, product-specific entitlement rules, admin token issuance, or license/account merging. Paid Copilot license behavior is unchanged. This does not publish a new CLI version or apply production migrations.

## Screenshot

Not applicable: API, quota, and deployment-workflow changes only.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Plan tests cover limits, upgrades, downgrades, configuration failures, and admin authorization |
| A defect would fail CI or be obvious on first use | ✅ | The Worker and release-boundary tests run in CI |
| A revert fully restores prior state, including persisted data | ❌ | The additive account-plan column and assigned plans remain after code rollback |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Adds a service-secret admin endpoint and reads account plans during token authentication |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Adds the admin API, account-plan column, and optional upgrade link; token quotas return 402 |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Existing atomic daily reservations now use the account's plan ceiling |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests exercise shared quotas, concurrent reservations, byte boundaries, and fresh plan lookup |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | No new UI or external billing integration |

Review: inspect `src/admin.ts:handleAdmin`, `src/plans.ts`, `src/auth.ts:resolveAccountToken`, `src/db.ts:findLiveToken` and `findOrCreateAccount`, `src/approval/handler.ts:prove`, `src/index.ts:handleApi` and admin routing, `src/api/push.ts:createDoc` and `updateDoc`, `src/quota.ts:reserveDailyPush`, and `migrations/0005_account_plans.sql`. Check the npm publish job's credential/cache boundary, then follow Verification.

## Verification

1. Run `npm ci`, `npm run typecheck`, `npm test`, and `node --test test/release-workflow.node.cjs`. Inspect the plan tests for six combined pushes, UTC reset, concurrent last-slot claims, UTF-8 limits, malformed config, wrong admin credentials, and migration compatibility.
2. With a local migrated Worker, sign in and create three documents. A fourth must return `402` with `limit: documents`; updates work until six total pushes. Unsharing frees a document slot but does not refund daily pushes.
3. Configure a local admin secret and change the account to `pro` through the documented admin endpoint. Reuse the same publisher token to upload more than 1 MiB. Downgrade to `free`: the old document stays readable, but another oversized upload is refused. Without the admin secret the route returns 404; a publisher token returns 401.

## Note

Apply `0005_account_plans.sql` with separate maintainer approval **before merging**. Deployment intentionally fails if it is missing. The old Worker remains compatible with the added column; a code rollback leaves it in place. Production is unchanged, and `UPGRADE_URL` stays unset until the separate billing integration exists. Existing partial storage-failure recovery is unchanged.
