### PR TITLE
Explain the self-hosted architecture with a diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,38 @@ deployment.
 
 ## Self-host on Cloudflare
 
+### How it fits together
+
+One Cloudflare Worker runs the backend. A Worker is a serverless application:
+Cloudflare runs its code when requests arrive and manages the servers and
+scaling. The API and public document hostnames reach the same Worker, but expose
+different operations.
+
+```mermaid
+flowchart TD
+    Publisher["CLI, agent, or other API client"] -->|"Publish, update, list, unshare"| API["API hostname<br/>api.example.com"]
+    Reader["Reader's browser"] -->|"Open a public link"| Serving["Document hostname<br/>exampleusercontent.net"]
+
+    subgraph Account["Your Cloudflare account"]
+        API --> Worker["One OpenArtifacts Worker<br/>Authenticate publishers, enforce limits,<br/>manage and serve documents"]
+        Serving --> Worker
+        Worker --> DB[("D1 database<br/>Ownership and version records,<br/>accounts, tokens, and quotas")]
+        Worker --> Files[("R2 storage<br/>Published HTML versions")]
+    end
+```
+
+D1 and R2 keep the persistent data; they are storage services, not additional
+Workers. Use a separate registrable domain for document HTML, not just another
+subdomain of your API's domain. Readers need no account, and the document host
+does not expose the publishing API.
+
+This deployment uses your own Cloudflare resources. It does not require the
+OpenArtifacts hosted website, a Copilot subscription, or a billing service. The
+setup below uses a self-managed publisher key; browser sign-in is optional and
+requires separate OAuth configuration.
+
+### Set up your deployment
+
 You need a Cloudflare account with Workers, R2, and D1, plus two domains added
 to that account:
 


### PR DESCRIPTION
## Why

The self-hosting instructions name Workers, D1, and R2 without showing how they fit together. Readers need to distinguish their own deployment from the proprietary hosted website and billing service.

## What

Add a self-hosting diagram with example domains: one Worker handles the API and public documents, while D1 and R2 store persistent data. Explain serverless execution, domain separation, and the optional browser sign-in setup.

## Non goal

No runtime, deployment configuration, authentication, or billing changes.

## Screenshot

Documentation only; the native Mermaid diagram is available in the branch's rendered README rather than duplicated as a screenshot.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | README documentation only |
| A defect would fail CI or be obvious on first use | ✅ | Diagram and copy are visible in the rendered README |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Describes existing boundaries without changing them |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No contracts changed |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No executable changes |
| No hot-path behavior lacks deterministic coverage | ✅ | Runtime paths are untouched |
| No new dependency | ✅ | No dependency changes |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | One self-hosting README section |

Review: follow Verification and confirm the diagram describes a self-owned deployment.

## Verification

1. Open this branch's README on GitHub and navigate to **Self-host on Cloudflare → How it fits together**.
2. Confirm the diagram renders with one Worker, separate API/document domains, D1, and R2.
3. Confirm the text explains that a proprietary website, subscription, and billing service are not required, then follow into the existing deployment instructions.
