### PR TITLE
Keep rejected license keys out of the outage cache

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -201,29 +201,33 @@ export async function resolvePublisher(
       return { ok: true, publisher: { owner: check.owner, plan: check.plan } };
 
     case "denied":
-      // Deliberately no row write and no row delete. A previously valid key that
-      // has since lapsed keeps its `publishers` row — that row is what an
-      // outage falls back to, and throwing it away would turn a revoked key
-      // into a lost account. It simply stops resolving.
+      // This row caches a credential, not ownership: docs belong to `owner`
+      // independently. Forget rejected credentials so an outage cannot revive
+      // their last successful validation. A fresh valid response may restore it.
+      await store.remove(id);
       return {
         ok: false,
         reason: "invalid_license",
         message: "That license key is not valid for publishing.",
       };
 
-    case "unreachable":
-      if (cached) {
+    case "unreachable": {
+      // Another request may have rejected this key while our check was pending.
+      // Only the current cache can authorize fallback, never the earlier snapshot.
+      const fallback = await store.read(id);
+      if (fallback) {
         // Stale but real. An outage must not lock out a publisher who has
         // published before. The plan rides along, so a publisher downgraded
         // since their last successful validation loses publishing here too
         // while keeping list and delete.
-        return { ok: true, publisher: { owner: cached.owner, plan: cached.plan } };
+        return { ok: true, publisher: { owner: fallback.owner, plan: fallback.plan } };
       }
       return {
         ok: false,
         reason: "license_unavailable",
         message: "License validation is temporarily unavailable. Please try again shortly.",
       };
+    }
   }
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -161,6 +161,7 @@ export type ListedTokenRow = Pick<TokenRow, "id" | "label" | "created_at" | "las
 export interface PublisherStore {
   read(keyHash: string): Promise<PublisherRow | null>;
   save(row: PublisherRow): Promise<void>;
+  remove(keyHash: string): Promise<void>;
 }
 
 /** Version numbers start at 1; a `docs` row at 0 has never been pushed to. */
@@ -173,6 +174,10 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
         .prepare("SELECT key_hash, plan, validated_at, owner FROM publishers WHERE key_hash = ?")
         .bind(keyHash)
         .first<PublisherRow>();
+    },
+
+    async remove(keyHash) {
+      await db.prepare("DELETE FROM publishers WHERE key_hash = ?").bind(keyHash).run();
     },
 
     // `owner` is written on every validation, like `plan` is. That is a refresh,

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -49,6 +49,9 @@ function memoryStore(...seed: PublisherRow[]): MemoryStore {
     async read(keyHash) {
       return rows.get(keyHash) ?? null;
     },
+    async remove(keyHash) {
+      rows.delete(keyHash);
+    },
     async save(row) {
       rows.set(row.key_hash, { ...row });
     },
@@ -343,8 +346,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    // Nothing is written, so an unauthorized key never gets a publishers row a
-    // later doc insert records as its owner.
+    // An unauthorized key never acquires a cached validation.
     expect(store.rows.size).toBe(0);
   };
 
@@ -365,7 +367,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     denied(answers({ isValid: false, backendAccess: true })),
   );
 
-  it("leaves an existing row untouched when the key has since lapsed", async () => {
+  it("forgets a cached validation when the key has since lapsed", async () => {
     const stale = validatedAt(2 * 60 * 60 * 1000);
     const store = memoryStore(stale);
 
@@ -376,9 +378,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    // The row stays: it is the only record of which account owns the docs.
-    // It simply stops resolving.
-    expect(store.rows.get(KEY_HASH)).toEqual(stale);
+    expect(store.rows.has(KEY_HASH)).toBe(false);
   });
 
   it("locks out a revoked key that still has a cached validation", async () => {
@@ -394,6 +394,47 @@ describe("resolvePublisher — a key the license server rejects", () => {
     // If it did, revocation would never take effect: each request would fail to
     // revalidate and be waved through on the stale row, forever.
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
+  });
+});
+
+describe("rejected credentials cannot use outage fallback", () => {
+  for (const [label, reply] of [
+    ["NOT_FOUND", trpcError("NOT_FOUND", 404)],
+    ["invalid", answers({ isValid: false })],
+    ["no backend access", answers({ isValid: true, backendAccess: false })],
+  ] as const) {
+    it(`forgets ${label} until a fresh validation succeeds`, async () => {
+      const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
+      expect(await resolvePublisher(KEY, env(), {
+        store, now, fetch: licenseServer(reply).fetch,
+      })).toMatchObject({ ok: false, reason: "invalid_license" });
+
+      expect(await resolvePublisher(KEY, env(), {
+        store, now, fetch: licenseServer(() => Promise.reject(new Error("down"))).fetch,
+      })).toMatchObject({ ok: false, reason: "license_unavailable" });
+
+      expect(await resolvePublisher(KEY, env(), {
+        store, now, fetch: licenseServer(validBeliever).fetch,
+      })).toEqual({ ok: true, publisher: { owner: ACCOUNT, plan: "believer" } });
+      expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
+    });
+  }
+
+  it("does not reuse an outage request's snapshot after another request rejects the key", async () => {
+    const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
+    let started!: () => void;
+    const pending = new Promise<void>((resolve) => { started = resolve; });
+    let finish!: (response: Response) => void;
+    const response = new Promise<Response>((resolve) => { finish = resolve; });
+    const outage = resolvePublisher(KEY, env(), {
+      store, now, fetch: licenseServer(() => { started(); return response; }).fetch,
+    });
+    await pending;
+    expect(await resolvePublisher(KEY, env(), {
+      store, now, fetch: licenseServer(trpcError("NOT_FOUND", 404)).fetch,
+    })).toMatchObject({ ok: false, reason: "invalid_license" });
+    finish(new Response("down", { status: 503 }));
+    expect(await outage).toMatchObject({ ok: false, reason: "license_unavailable" });
   });
 });
 
@@ -628,6 +669,7 @@ describe("authenticateRequest", () => {
     const store = {
       read: () => Promise.reject(new Error("must not be read")),
       save: () => Promise.reject(new Error("must not be written")),
+      remove: () => Promise.reject(new Error("must not be removed")),
     } satisfies PublisherStore;
 
     for (const header of [undefined, "", "Basic hunter2", "Bearer", `Token ${KEY}`]) {
@@ -660,6 +702,10 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
         return rows.get(String(args[0])) ?? null;
       },
       async run() {
+        if (/^\s*DELETE FROM publishers/i.test(sql)) {
+          rows.delete(String(args[0]));
+          return { success: true };
+        }
         if (!/^\s*INSERT/i.test(sql)) throw new Error(`run() on non-insert: ${sql}`);
         rows.set(String(args[0]), {
           key_hash: String(args[0]),

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -1,7 +1,7 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { deleteDoc } from "../src/api/manage.js";
-import type { Publisher } from "../src/auth.js";
+import { resolvePublisher, type Publisher } from "../src/auth.js";
 import type { Env } from "../src/config.js";
 import type { DocRow } from "../src/db.js";
 import { DOC_ID_LENGTH } from "../src/ids.js";
@@ -733,4 +733,33 @@ describe("a publisher whose plan may no longer publish", () => {
     expect(await objectKeys(created.docId)).toEqual([versionObjectKey(created.docId, 1)]);
     expect((await docRow(created.docId))?.latest_version).toBe(1);
   });
+});
+
+it("evicts a rejected credential without losing its documents or another key's access", async () => {
+  await seedPublisher(KEY_B, ownerA);
+  const doc = await publish(KEY_A, "Keep this document");
+  const before = await docRow(doc.docId);
+  const keys = await objectKeys(doc.docId);
+  await env.DB.prepare("UPDATE publishers SET validated_at = 0 WHERE key_hash = ?")
+    .bind(await sha256Hex(KEY_A)).run();
+
+  const rejected = await resolvePublisher(KEY_A, {
+    ...env, LICENSE_API_URL: "https://license.test", LICENSE_API_KEY: "test-server-key",
+  }, {
+    fetch: (async () => Response.json({
+      error: { json: { data: { code: "NOT_FOUND" } } },
+    }, { status: 404 })) as typeof fetch,
+  });
+  expect(rejected).toMatchObject({ ok: false, reason: "invalid_license" });
+  expect(await env.DB.prepare("SELECT key_hash FROM publishers WHERE key_hash = ?")
+    .bind(await sha256Hex(KEY_A)).first()).toBeNull();
+  expect(await docRow(doc.docId)).toEqual(before);
+  expect(await objectKeys(doc.docId)).toEqual(keys);
+  expect(await env.DB.prepare("SELECT n FROM versions WHERE doc_id = ?")
+    .bind(doc.docId).first()).toEqual({ n: 1 });
+  const response = await list(KEY_B);
+  expect(response.status).toBe(200);
+  expect(await response.text()).toContain(doc.docId);
+  expect(await resolvePublisher(KEY_A, { ...env, LICENSE_API_URL: "" }))
+    .toMatchObject({ ok: false, reason: "license_unavailable" });
 });


### PR DESCRIPTION
Fixes Brevilabs/OpenArtifacts#10

## Why

A key rejected by the license server can regain access during a later server outage because its previous successful validation stays cached.

## What

An explicit rejection now removes that key's cached validation. An outage cannot reuse the rejected entry, including when another request recorded the rejection while validation was pending. A later successful validation restores access to the same account. Published documents and other keys on that account remain intact.

| License result | Result |
| --- | --- |
| Explicit rejection | Refuse access and remove the cached validation |
| Outage after rejection | Refuse access because no valid cached entry remains |
| Outage with an unrejected cached entry | Keep the existing outage fallback |
| Later successful validation | Restore access to the same account |

## Non goal

Change the one-hour positive cache, OAuth tokens, account linking, or publishing limits.

## Screenshot

Not applicable; this changes API authentication without a visual surface.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Regression tests cover rejection, outage fallback, and successful recovery |
| A defect would fail CI or be obvious on first use | ✅ | Authentication regressions run in the existing test suite |
| A revert fully restores prior state, including persisted data | ❌ | Evicted validation entries need successful revalidation; document data is preserved |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Changes license authentication after rejection |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing response shapes and schema remain unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Outage fallback rereads validation state after concurrent requests |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests include an outage overlapping an authoritative rejection |
| No new dependency | ✅ | No dependencies added |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Changed behavior is verified through deterministic API tests |

Review: inspect `resolvePublisher` in `src/auth.ts` and `PublisherStore`/`d1PublisherStore` in `src/db.ts`, then run Verification steps 1–3, including rejection, concurrent outage, and ownership preservation.

## Verification

1. Run `npm ci`, `npm run typecheck`, and `npm test` from this branch.
2. In the authentication regressions, verify that a previously valid key is denied after `NOT_FOUND`, `isValid: false`, or `backendAccess: false`, and cannot fall back to its old validation during an outage. Verify that an outage already in flight also refuses after another request removes the entry.
3. Verify the real-D1 regression preserves the document and its version after rejection and allows a different key for the same owner to list it. The authentication regressions should restore access to the same owner after a new successful validation.

## Note

No database migration is required: document ownership is independent of the disposable credential cache. The explicit rejection keeps its existing authentication response; a subsequent outage without cached validation uses the existing service-unavailable response.
