### PR TITLE
[Account linking] - Step 1: Join document ownership and quotas

### DIFF
--- a/docs/identity.md
+++ b/docs/identity.md
@@ -37,17 +37,36 @@ two id spaces cannot collide, and no equality test between them can accidentally
 succeed and hand one account another's documents. That property is what makes it
 safe for one column to carry both.
 
-### Why they are not merged
+### Joining document ownership without changing credentials
 
-A Copilot user who approves with the address on their license gets a *new*
-account, not the one their license key resolves to. Merging them would mean
-treating a verified email as proof of holding a particular license, which is a
-claim OAuth cannot make and the license server was never asked. So a Copilot user
-who wants their plugin documents from the CLI presents the same license key the
-plugin does — the API accepts it — and the two shelves stay separate until there
-is a deliberate exchange between them. That exchange is the follow-up named in
-[#55](https://github.com/Brevilabs/OpenArtifacts/issues/55), and it is also what
-eventually moves the license code out of this repo.
+OAuth email matching never proves control of an external account. The two
+identities stay separate until a trusted caller proves both and confirms a
+permanent association through `linkExternalOwner`. No public linking route is
+provided by this database primitive. It must not accept stale outage validation
+as proof or infer external ownership from an email address.
+
+`owner_links` pairs one external owner with one existing local account. Both
+columns are unique, the ID spaces are disjoint, and associations cannot be
+updated or deleted. Reconfirming the same pair is idempotent; conflicting pairs
+are refused. Account deletion must therefore preserve the ownership record or
+use a separately designed operator process, never cascade an unlink.
+
+The local account is the canonical collection, but document rows retain their
+original `owner` as provenance. Each ownership query derives the joined owner
+set inside its SQL statement. New documents and daily reservations also retain
+the authenticated credential's owner. A request that started before linking
+cannot escape the combined limits after linking: the next reservation counts
+both owners atomically. A refund still returns its original `(owner, day)`
+reservation even when the association was created while the upload was pending.
+Previously over-limit collections are preserved; new reservations fail until
+there is room. Linking itself consumes no publishing allowance.
+
+No document IDs, versions, deletion tombstones, or stored objects move. Existing
+keys and tokens therefore reach the joined collection without relogin or URL
+changes. Credential identity remains unchanged for token administration: an
+external key does not gain permission to list or revoke a local account's tokens.
+An association grants document access, not a plan or a new authentication method;
+entitlement reconciliation belongs to the trusted integration using it.
 
 ## How an account comes into existence
 

--- a/migrations/0006_owner_links.sql
+++ b/migrations/0006_owner_links.sql
@@ -1,0 +1,19 @@
+-- Join document collections without rewriting ownership or in-flight counters.
+-- The credential owner remains unchanged, particularly for token administration.
+CREATE TABLE owner_links (
+  external_owner TEXT NOT NULL PRIMARY KEY
+    CHECK (length(external_owner) BETWEEN 1 AND 256
+           AND trim(external_owner) = external_owner
+           AND substr(external_owner, 1, 3) <> 'oa_'),
+  account_id TEXT NOT NULL UNIQUE REFERENCES accounts(id)
+    CHECK (length(account_id) = 29 AND substr(account_id, 1, 3) = 'oa_'
+           AND substr(account_id, 4) NOT GLOB '*[^0-9abcdefghjkmnpqrstvwxyz]*'),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0)
+);
+
+-- There is no unlink/transfer operation: credentials already granted access to
+-- the joined collection must never silently change which collection they name.
+CREATE TRIGGER owner_links_no_update BEFORE UPDATE ON owner_links
+BEGIN SELECT RAISE(ABORT, 'owner associations are immutable'); END;
+CREATE TRIGGER owner_links_no_delete BEFORE DELETE ON owner_links
+BEGIN SELECT RAISE(ABORT, 'owner associations are immutable'); END;

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,7 @@
  * every row here is reconstructible from it, so a lost D1 is a rebuild rather
  * than a data loss. Queries land here as the phase that needs them arrives.
  */
+import { OWNER_SCOPE_SQL } from "./owners.js";
 
 /** Publisher row, which doubles as the license-validation cache (phase 2). */
 export interface PublisherRow {
@@ -223,18 +224,20 @@ export async function insertDocWithinQuota(
 ): Promise<boolean> {
   const result = await db
     .prepare(
-      `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
+      `${OWNER_SCOPE_SQL}
+       INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
        SELECT ?, ?, ?, ?, ?, ?
-        WHERE (SELECT COUNT(*) FROM docs WHERE owner = ? AND deleted_at IS NULL) < ?`,
+        WHERE (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) < ?`,
     )
     .bind(
+      doc.owner,
+      doc.owner,
       doc.id,
       doc.owner,
       doc.title,
       FIRST_VERSION,
       doc.created_at,
       doc.updated_at,
-      doc.owner,
       maxDocs,
     )
     .run();
@@ -304,12 +307,13 @@ export async function reserveNextVersion(
 ): Promise<number | null> {
   const reserved = await db
     .prepare(
-      `UPDATE docs
+      `${OWNER_SCOPE_SQL}
+       UPDATE docs
           SET latest_version = latest_version + 1
-        WHERE id = ? AND owner = ? AND deleted_at IS NULL
+        WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL
         RETURNING latest_version`,
     )
-    .bind(docId, owner)
+    .bind(owner, owner, docId)
     .first<{ latest_version: number }>();
 
   return reserved?.latest_version ?? null;
@@ -445,8 +449,8 @@ export async function ownsLiveDoc(
   owner: string,
 ): Promise<boolean> {
   const row = await db
-    .prepare("SELECT 1 FROM docs WHERE id = ? AND owner = ? AND deleted_at IS NULL")
-    .bind(docId, owner)
+    .prepare(`${OWNER_SCOPE_SQL} SELECT 1 FROM docs WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL`)
+    .bind(owner, owner, docId)
     .first();
 
   return row !== null;
@@ -474,12 +478,13 @@ export async function softDeleteDoc(
 ): Promise<boolean> {
   const deleted = await db
     .prepare(
-      `UPDATE docs
+      `${OWNER_SCOPE_SQL}
+       UPDATE docs
           SET deleted_at = ?
-        WHERE id = ? AND owner = ? AND deleted_at IS NULL
+        WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL
         RETURNING id`,
     )
-    .bind(atMs, docId, owner)
+    .bind(owner, owner, atMs, docId)
     .first<{ id: string }>();
 
   return deleted !== null;
@@ -551,19 +556,21 @@ export async function listPublisherDocs(
     after === null
       ? db
           .prepare(
-            `SELECT ${columns} FROM docs d
-              WHERE d.owner = ? AND d.deleted_at IS NULL
+            `${OWNER_SCOPE_SQL}
+             SELECT ${columns} FROM docs d
+              WHERE d.owner IN (SELECT owner FROM owner_scope) AND d.deleted_at IS NULL
               ${order}`,
           )
-          .bind(owner, limit)
+          .bind(owner, owner, limit)
       : db
           .prepare(
-            `SELECT ${columns} FROM docs d
-              WHERE d.owner = ? AND d.deleted_at IS NULL
+            `${OWNER_SCOPE_SQL}
+             SELECT ${columns} FROM docs d
+              WHERE d.owner IN (SELECT owner FROM owner_scope) AND d.deleted_at IS NULL
                 AND (d.created_at, d.id) < (?, ?)
               ${order}`,
           )
-          .bind(owner, after.created_at, after.id, limit);
+          .bind(owner, owner, after.created_at, after.id, limit);
 
   return (await statement.all<DocListRow>()).results;
 }

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -69,7 +69,7 @@ export function isDocId(value: string): boolean {
  *
  * `docs.owner` holds two kinds of value: an app-sites `User.id` that the
  * license server resolved, and an id this repo minted for an account created by
- * approval. They are never merged, and this prefix is what makes that
+ * approval. The credential IDs stay distinct, and this prefix makes that
  * structural rather than a convention — an app-sites uuid cannot start with
  * `oa_`, so no equality test between the two spaces can ever accidentally
  * succeed and hand one account another's documents.

--- a/src/owners.ts
+++ b/src/owners.ts
@@ -1,0 +1,55 @@
+/**
+ * Document ownership can join two proven identities without moving their rows.
+ * Keep credential identity separate: these aliases never authorize token access.
+ */
+import { ACCOUNT_ID_PREFIX } from "./ids.js";
+
+/**
+ * Bind the authenticated owner twice, before the statement's other parameters.
+ * Resolve inside each statement so a link committed during a request applies to
+ * its next reservation or ownership check, including a request using an old key.
+ */
+export const OWNER_SCOPE_SQL = `WITH canonical AS (
+  SELECT COALESCE((SELECT account_id FROM owner_links WHERE external_owner = ?), ?) AS id
+), owner_scope AS (
+  SELECT id AS owner FROM canonical
+  UNION ALL
+  SELECT external_owner FROM owner_links JOIN canonical ON account_id = id
+)`;
+
+export type OwnerLinkResult = "linked" | "conflict" | "invalid" | "account_not_found";
+
+/**
+ * Trusted callers must prove both identities before invoking this primitive.
+ * Email equality or an outage cache is not proof. Associations are permanent;
+ * repeated confirmation of the same pair succeeds without changing anything.
+ */
+export async function linkExternalOwner(
+  db: D1Database,
+  externalOwner: string,
+  accountId: string,
+  atMs: number,
+): Promise<OwnerLinkResult> {
+  if (
+    externalOwner.trim() !== externalOwner || externalOwner.length === 0 ||
+    /[\u0000-\u0020\u007f]/.test(externalOwner) ||
+    externalOwner.length > 256 || externalOwner.startsWith(ACCOUNT_ID_PREFIX) ||
+    !/^oa_[0-9abcdefghjkmnpqrstvwxyz]{26}$/.test(accountId) ||
+    !Number.isSafeInteger(atMs) || atMs < 0
+  ) return "invalid";
+
+  const inserted = await db.prepare(
+    `INSERT INTO owner_links (external_owner, account_id, created_at)
+     SELECT ?, id, ? FROM accounts WHERE id = ?
+     ON CONFLICT DO NOTHING RETURNING account_id`,
+  ).bind(externalOwner, atMs, accountId).first<{ account_id: string }>();
+  if (inserted !== null) return "linked";
+
+  const existing = await db.prepare(
+    "SELECT account_id FROM owner_links WHERE external_owner = ?",
+  ).bind(externalOwner).first<{ account_id: string }>();
+  if (existing?.account_id === accountId) return "linked";
+  const account = await db.prepare("SELECT id FROM accounts WHERE id = ?")
+    .bind(accountId).first();
+  return account === null ? "account_not_found" : "conflict";
+}

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -5,6 +5,7 @@
  * Copilot user never reaches any of them. The numbers themselves live in
  * `config.ts`; this file is how they are counted.
  */
+import { OWNER_SCOPE_SQL } from "./owners.js";
 import { MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "./config.js";
 
 /**
@@ -88,9 +89,10 @@ export function utcDay(atMs: number): string {
  *
  * Claim rather than check: the count is read and incremented by a single
  * statement, so two concurrent pushes cannot both see 99 and both proceed. The
- * `WHERE` on the upsert's update branch is what enforces the limit — when it
- * fails SQLite leaves the row alone and `RETURNING` yields nothing, which is
- * the rejection.
+ * insert's predicate sums both linked owners before either insert or update.
+ * When it fails SQLite leaves the row alone and `RETURNING` yields nothing.
+ * The bucket retains the credential owner so refunds crossing a link still
+ * return the exact reservation, without moving or resetting either counter.
  */
 export async function reserveDailyPush(
   db: D1Database,
@@ -100,12 +102,16 @@ export async function reserveDailyPush(
 ): Promise<boolean> {
   const claimed = await db
     .prepare(
-      `INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, 1)
+      `${OWNER_SCOPE_SQL}
+       INSERT INTO push_quota (owner, day, pushes)
+       SELECT ?, ?, 1 WHERE (
+         SELECT COALESCE(SUM(pushes), 0) FROM push_quota
+          WHERE owner IN (SELECT owner FROM owner_scope) AND day = ?
+       ) < ?
        ON CONFLICT(owner, day) DO UPDATE SET pushes = push_quota.pushes + 1
-         WHERE push_quota.pushes < ?
        RETURNING pushes`,
     )
-    .bind(owner, day, limit)
+    .bind(owner, owner, owner, day, day, limit)
     .first<{ pushes: number }>();
 
   return claimed !== null;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -673,7 +673,7 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
       // first handler on the other side of it, and all it wants to know is that
       // this publisher holds no docs. Auth is what these tests are about.
       async all() {
-        if (!/^\s*SELECT/i.test(sql)) throw new Error(`all() on non-select: ${sql}`);
+        if (!/^\s*(SELECT|WITH)/i.test(sql)) throw new Error(`all() on non-select: ${sql}`);
         return { results: [] };
       },
     };

--- a/test/owners.test.ts
+++ b/test/owners.test.ts
@@ -1,0 +1,167 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, expect, it } from "vitest";
+import { insertDocWithinQuota, listPublisherDocs, ownsLiveDoc, reserveNextVersion, softDeleteDoc } from "../src/db.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newDocId, newTokenId } from "../src/ids.js";
+import { linkExternalOwner } from "../src/owners.js";
+import { refundDailyPush, reserveDailyPush } from "../src/quota.js";
+import worker from "../src/index.js";
+
+const ACCOUNT = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_ACCOUNT = "oa_bbbbbbbbbbbbbbbbbbbbbbbbbb";
+const EXTERNAL = "external-owner-a";
+const OTHER_EXTERNAL = "external-owner-b";
+const DAY = "2026-09-09";
+const KEY = "test-license-a";
+const SECOND_KEY = "test-license-a2";
+let token: string;
+let tokenId: string;
+
+beforeEach(async () => {
+  for (const account of [ACCOUNT, OTHER_ACCOUNT]) {
+    await env.DB.prepare("INSERT INTO accounts (id, email, created_at, plan) VALUES (?, ?, 0, 'pro')")
+      .bind(account, `${account}@example.test`).run();
+  }
+  token = newApiToken();
+  tokenId = newTokenId();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+    .bind(tokenId, await sha256Hex(token), ACCOUNT).run();
+  for (const key of [KEY, SECOND_KEY]) {
+    await env.DB.prepare("INSERT INTO publishers (key_hash, plan, owner, validated_at) VALUES (?, 'plus', ?, ?)")
+      .bind(await sha256Hex(key), EXTERNAL, Date.now()).run();
+  }
+});
+
+const link = () => linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 123);
+const doc = (owner: string, at = 0) => ({ id: newDocId(), owner, title: owner, created_at: at, updated_at: at });
+
+async function send(method: string, path: string, credential: string, body?: unknown) {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`https://local.test${path}`, {
+    method,
+    headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), { ...env, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "" }, ctx);
+  await waitOnExecutionContext(ctx);
+  const bytes = await response.arrayBuffer();
+  return new Response(response.status === 204 ? null : bytes, { status: response.status, headers: response.headers });
+}
+
+async function publish(credential: string) {
+  const response = await send("POST", "/api/v1/docs", credential, { title: "Kept", html: "<!doctype html><html><body>Kept</body></html>" });
+  expect(response.status).toBe(201);
+  return await response.json() as { docId: string; url: string; version: number };
+}
+
+it("links one existing account once, without transfers, chains, or missing accounts", async () => {
+  expect(await link()).toBe("linked");
+  expect(await linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 999)).toBe("linked");
+  expect(await linkExternalOwner(env.DB, EXTERNAL, OTHER_ACCOUNT, 999)).toBe("conflict");
+  expect(await linkExternalOwner(env.DB, OTHER_EXTERNAL, ACCOUNT, 999)).toBe("conflict");
+  expect(await linkExternalOwner(env.DB, OTHER_EXTERNAL, "oa_cccccccccccccccccccccccccc", 999)).toBe("account_not_found");
+  for (const external of ["", " ", " trailing ", ACCOUNT, "x".repeat(257)]) {
+    expect(await linkExternalOwner(env.DB, external, OTHER_ACCOUNT, 999)).toBe("invalid");
+  }
+  for (const account of [EXTERNAL, "oa_", "oa_" + "!".repeat(26)]) {
+    expect(await linkExternalOwner(env.DB, OTHER_EXTERNAL, account, 999)).toBe("invalid");
+  }
+  expect(await env.DB.prepare("SELECT * FROM owner_links").all()).toMatchObject({ results: [
+    { external_owner: EXTERNAL, account_id: ACCOUNT, created_at: 123 },
+  ] });
+  await expect(env.DB.prepare("UPDATE owner_links SET account_id = ?").bind(OTHER_ACCOUNT).run()).rejects.toThrow();
+  await expect(env.DB.prepare("DELETE FROM owner_links").run()).rejects.toThrow();
+});
+
+it("resolves competing links atomically with one winner", async () => {
+  const results = await Promise.all([
+    linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 1),
+    linkExternalOwner(env.DB, EXTERNAL, OTHER_ACCOUNT, 1),
+  ]);
+  expect(results.sort()).toEqual(["conflict", "linked"]);
+});
+
+it("joins both live collections with stable pagination and preserves deleted provenance", async () => {
+  const a = doc(EXTERNAL, 1);
+  const b = doc(ACCOUNT, 2);
+  const c = doc(EXTERNAL, 3);
+  const unrelated = doc(OTHER_ACCOUNT, 4);
+  for (const row of [a, b, c, unrelated]) expect(await insertDocWithinQuota(env.DB, row, 10)).toBe(true);
+  await softDeleteDoc(env.DB, c.id, EXTERNAL, 4);
+  expect(await ownsLiveDoc(env.DB, a.id, ACCOUNT)).toBe(false);
+  await link();
+  for (const owner of [ACCOUNT, EXTERNAL]) {
+    const first = await listPublisherDocs(env.DB, owner, null, 1);
+    expect(first.map((r) => r.id)).toEqual([b.id]);
+    expect((await listPublisherDocs(env.DB, owner, { created_at: b.created_at, id: b.id }, 1)).map((r) => r.id)).toEqual([a.id]);
+    expect(await ownsLiveDoc(env.DB, unrelated.id, owner)).toBe(false);
+    expect(await reserveNextVersion(env.DB, unrelated.id, owner)).toBeNull();
+    expect(await softDeleteDoc(env.DB, unrelated.id, owner, 5)).toBe(false);
+  }
+  expect(await reserveNextVersion(env.DB, a.id, ACCOUNT)).toBe(2);
+  expect(await softDeleteDoc(env.DB, b.id, EXTERNAL, 5)).toBe(true);
+  expect(await env.DB.prepare("SELECT owner, deleted_at FROM docs WHERE id = ?").bind(c.id).first())
+    .toEqual({ owner: EXTERNAL, deleted_at: 4 });
+});
+
+it("counts both document owners inside reservation, including requests started before linking", async () => {
+  const oldRequest = doc(EXTERNAL);
+  expect(await insertDocWithinQuota(env.DB, doc(ACCOUNT), 3)).toBe(true);
+  await link();
+  const attempts = await Promise.all([
+    insertDocWithinQuota(env.DB, oldRequest, 2),
+    insertDocWithinQuota(env.DB, doc(ACCOUNT), 2),
+  ]);
+  expect(attempts.filter(Boolean)).toHaveLength(1);
+  expect(await insertDocWithinQuota(env.DB, doc(EXTERNAL), 2)).toBe(false);
+  expect(await insertDocWithinQuota(env.DB, doc(ACCOUNT), 2)).toBe(false);
+});
+
+it("combines existing daily usage and refunds its original bucket across linking", async () => {
+  expect(await reserveDailyPush(env.DB, EXTERNAL, DAY, 3)).toBe(true);
+  expect(await reserveDailyPush(env.DB, ACCOUNT, DAY, 3)).toBe(true);
+  await link();
+  const claims = await Promise.all([
+    reserveDailyPush(env.DB, EXTERNAL, DAY, 3), reserveDailyPush(env.DB, ACCOUNT, DAY, 3),
+  ]);
+  expect(claims.filter(Boolean)).toHaveLength(1);
+  await refundDailyPush(env.DB, EXTERNAL, DAY);
+  expect(await reserveDailyPush(env.DB, ACCOUNT, DAY, 3)).toBe(true);
+  expect(await reserveDailyPush(env.DB, EXTERNAL, DAY, 3)).toBe(false);
+  expect(await reserveDailyPush(env.DB, EXTERNAL, "2026-09-10", 3)).toBe(true);
+  expect(await reserveDailyPush(env.DB, OTHER_EXTERNAL, DAY, 3)).toBe(true);
+  expect(await env.DB.prepare("SELECT SUM(pushes) AS n FROM push_quota WHERE day = ? AND owner IN (?, ?)")
+    .bind(DAY, EXTERNAL, ACCOUNT).first()).toEqual({ n: 3 });
+});
+
+it("handles linking between document and daily reservations without quota reset", async () => {
+  const pending = doc(EXTERNAL);
+  expect(await insertDocWithinQuota(env.DB, pending, 1)).toBe(true);
+  expect(await reserveDailyPush(env.DB, ACCOUNT, DAY, 1)).toBe(true);
+  await link();
+  expect(await reserveDailyPush(env.DB, EXTERNAL, DAY, 1)).toBe(false);
+  expect(await insertDocWithinQuota(env.DB, doc(ACCOUNT), 1)).toBe(false);
+});
+
+it("keeps URLs, versions, active tokens, and legacy key access without token administration", async () => {
+  const legacy = await publish(KEY);
+  const native = await publish(token);
+  const original = await env.DOCS.get(`docs/${legacy.docId}/v1.html`);
+  const originalBytes = await original!.text();
+  await link();
+  for (const credential of [KEY, SECOND_KEY, token]) {
+    const response = await send("GET", "/api/v1/docs", credential);
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain(legacy.docId);
+    expect(text).toContain(native.docId);
+  }
+  const update = await send("PUT", `/api/v1/docs/${legacy.docId}`, token, { html: "<!doctype html><html><body>Updated</body></html>" });
+  expect(update.status).toBe(200);
+  expect(await update.json()).toMatchObject({ docId: legacy.docId, url: legacy.url, version: 2 });
+  expect(await (await env.DOCS.get(`docs/${legacy.docId}/v1.html`))!.text()).toBe(originalBytes);
+  expect(await (await send("GET", "/api/v1/tokens", KEY)).json()).toEqual({ tokens: [] });
+  expect((await send("DELETE", `/api/v1/tokens/${tokenId}`, KEY)).status).toBe(404);
+  expect((await send("GET", "/api/v1/tokens", token)).status).toBe(200);
+  expect((await send("DELETE", `/api/v1/docs/${native.docId}`, SECOND_KEY)).status).toBe(204);
+  expect((await send("GET", `/d/${native.docId}`, token)).status).toBe(410);
+});


### PR DESCRIPTION
Relates to Brevilabs/app-sites#466

## Why

An external publisher credential and an OAuth account currently see separate document collections. Joining them by moving documents and quota counters could miss an upload or refund already in progress.

## What

A trusted integration can now associate one external owner with one local account. Both credentials then access the same documents and count against the combined publishing allowance, while URLs, versions, deleted-document records, and in-flight reservations stay intact.

| Situation | Result |
| --- | --- |
| Both identities already published documents | Both collections become accessible without moving content |
| The same association is requested again | It succeeds without changing the association |
| Either identity is already linked elsewhere | The conflicting association is refused |
| Publishing or refunding overlaps linking | The next reservation counts joined usage; refunds return the original reservation |
| A license attempts OAuth token administration | It receives no additional access |

## Non goal

Expose a browser or admin linking route, change entitlements, support unlink/reassignment, merge unrelated OAuth accounts, or retire license authentication.

## Screenshot

Not applicable; this adds database ownership behavior without a visual surface.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real D1/R2 tests cover joined ownership, quota reservations, conflicts, and preservation |
| A defect would fail CI or be obvious on first use | ✅ | Ownership integration tests run with the existing Worker suite |
| A revert fully restores prior state, including persisted data | ❌ | Persisted associations remain and require code that understands joined ownership |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Document authorization now recognizes proven associations |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Adds a durable association table with immutable links |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Quota reservations resolve joined ownership inside the database statement |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests cover joined publication, update, deletion, and interleaved reservations/refunds |
| No new dependency | ✅ | Reuses D1 and existing ownership queries |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | This slice has no human-only behavior |

Review: inspect `OWNER_SCOPE_SQL` and `linkExternalOwner` in `src/owners.ts`, ownership predicates in `src/db.ts`, `reserveDailyPush` in `src/quota.ts`, and `migrations/0006_owner_links.sql`; run Verification steps 1–3.

## Verification

1. Run `npm ci`, `npm run typecheck`, and `npm test` from this branch.
2. Run the owner integration tests and verify that two populated collections retain their document IDs, versions, content, and withdrawn records after association. Verify conflict refusal and unchanged OAuth-token permissions.
3. Verify that linking between reservations or before a refund preserves the combined count, and that concurrently requesting the last available allowance cannot exceed it.

## Note

Apply migration 0006 before deploying this Worker. This slice has no public linking endpoint. Once an integration starts creating associations, rolling back to code that cannot resolve them would split the visible collection; preserve the ownership-aware Worker as the rollback floor.
