### PR TITLE
[Account linking] - Step 2: Authenticate browser actions

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -718,3 +718,65 @@ curl -sS "$DOC" -o /dev/null -w '%{http_code}\n'            # → 410
 
 `scripts/smoke.sh` runs exactly this sequence against a deployment and checks
 every status.
+
+## Account status and trusted browser actions
+
+These additive routes are served on the API host. They use no browser cookies.
+`GET /api/v1/account` requires a live OAuth-issued bearer token. License keys
+cannot access it. It returns `200` with `cache-control: no-store`:
+
+```json
+{"accountId":"oa_…","plan":"free","limits":{"documents":3,"pushesPerDay":6,"htmlBytes":1048576},"usage":{"documents":1,"pushesToday":2},"externalLinked":false}
+```
+
+Limits reflect the deployment configuration. Usage counts live documents and
+UTC-day reservations across linked owners, including uploads still pending.
+The external identity and email are not included in this publisher response.
+
+`POST /api/v1/account/handoffs` requires the same token and exactly one JSON
+field: `{"purpose":"upgrade"}`, `{"purpose":"billing"}`, or `{"purpose":"link"}`.
+It returns `200` with `{"url":"https://trusted.example/actions?code=…","expiresAt":1800000600000}`
+and `cache-control: no-store`. The timestamp is epoch milliseconds. The URL is
+configured by `ACCOUNT_ACTION_URL`; it must be absolute HTTPS without credentials
+or a fragment. HTTP is allowed only for localhost, 127.0.0.1, or [::1]. An absent
+configuration returns `404` without creating a code; invalid configuration fails
+closed with `500`. Do not send the publisher token to this URL.
+
+Codes contain 256 random bits, expire after ten minutes, and are stored only as
+hashes. At most five actions may remain outstanding per account; the sixth
+returns `429 quota_exceeded`. Minting clears that account's expired entries.
+Revoking the originating machine token also invalidates its unconsumed codes.
+Unknown purposes, extra fields, malformed JSON, and bodies over 1024 bytes
+return `400 bad_request`. Account routes reject license credentials with `401`.
+
+### Trusted service endpoints
+
+These routes require `Authorization: Bearer <ADMIN_API_KEY>`, never a publisher
+credential. They return `404` if the service API is unconfigured and `401` for an
+incorrect credential. Successful responses use `cache-control: no-store`.
+
+`POST /admin/v1/handoffs/consume` accepts exactly `{"code":"…"}`. It atomically
+consumes a live code once and returns:
+
+```json
+{"accountId":"oa_…","email":"user@example.test","purpose":"link","externalOwner":null}
+```
+
+`externalOwner` is the linked identity or null. The service must dispatch only
+the returned purpose and preserve this server-verified account identity through
+its confirmation flow; email is informational, never account proof. Replayed,
+expired, unknown, or originating-token-revoked codes all return `404 not_found`.
+Malformed codes or extra body fields return `400`. A failed authorization does
+not consume the code. Never log codes, include them in analytics, or forward
+these action URLs to third-party resources. The trusted page should remove the
+code from its browser URL after exchange and require explicit confirmation for
+consequential actions; a GET of that page must not itself link an account.
+
+`PUT /admin/v1/accounts/{accountId}/external-owner` accepts exactly
+`{"externalOwner":"…"}`. The trusted caller must freshly prove the external
+identity and obtain the account holder's confirmation before calling this route;
+a license outage cache or matching email does not prove ownership. Success and
+an identical retry return `200` with `{"accountId":"oa_…","externalOwner":"…"}`.
+A conflicting association returns `409 conflict`; invalid identities return
+`400`; a missing local account returns `404`. Associations are permanent and do
+not change plans, credential permissions, document IDs, or stored versions.

--- a/migrations/0007_account_handoffs.sql
+++ b/migrations/0007_account_handoffs.sql
@@ -1,0 +1,9 @@
+-- Short-lived account proof for a trusted integration; never store raw codes.
+CREATE TABLE account_handoffs (
+  code_hash TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id),
+  token_id TEXT NOT NULL,
+  purpose TEXT NOT NULL CHECK (purpose IN ('upgrade', 'billing', 'link')),
+  expires_at INTEGER NOT NULL
+);
+CREATE INDEX account_handoffs_by_account ON account_handoffs(account_id, expires_at);

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,89 @@
+import { parseBearerToken, type Publisher } from "./auth.js";
+import type { Env } from "./config.js";
+import { errorResponse } from "./errors.js";
+import { sha256Hex } from "./hash.js";
+import { OWNER_SCOPE_SQL } from "./owners.js";
+import { planLimits } from "./plans.js";
+import { readBodyWithin, utcDay } from "./quota.js";
+
+const NO_STORE = { "cache-control": "no-store" };
+const PURPOSES = new Set(["upgrade", "billing", "link"]);
+const HANDOFF_MS = 10 * 60 * 1000;
+
+/** Bounded, exact one-field JSON shared by the account and service APIs. */
+export async function stringField(request: Request, field: string): Promise<string | null> {
+  const raw = await readBodyWithin(request, 1024);
+  if (!raw) return null;
+  try {
+    const body: unknown = JSON.parse(new TextDecoder().decode(raw));
+    if (!body || typeof body !== "object" || Array.isArray(body) ||
+      Object.keys(body).length !== 1 || !(field in body)) return null;
+    const value = (body as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : null;
+  } catch { return null; }
+}
+
+function actionUrl(env: Env): URL | null {
+  if (!env.ACCOUNT_ACTION_URL?.trim()) return null;
+  const url = new URL(env.ACCOUNT_ACTION_URL);
+  const local = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (url.username || url.password || url.hash ||
+    (url.protocol !== "https:" && !(url.protocol === "http:" && local))) {
+    throw new Error("ACCOUNT_ACTION_URL must be HTTPS without credentials or fragment (local HTTP is allowed).");
+  }
+  return url;
+}
+
+export async function handleAccount(request: Request, env: Env, publisher: Publisher): Promise<Response> {
+  if (publisher.authKind !== "account") return errorResponse("unauthorized", "Sign in with an account token.");
+  const path = new URL(request.url).pathname;
+  if (path === "/api/v1/account" && request.method === "GET") {
+    const row = await env.DB.prepare(`${OWNER_SCOPE_SQL}
+      SELECT a.id AS accountId, a.plan,
+        (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) AS documents,
+        (SELECT COALESCE(SUM(pushes), 0) FROM push_quota WHERE owner IN (SELECT owner FROM owner_scope) AND day = ?) AS pushesToday,
+        EXISTS(SELECT 1 FROM owner_links WHERE account_id = a.id) AS externalLinked
+      FROM accounts a WHERE a.id = ?`)
+      .bind(publisher.owner, publisher.owner, utcDay(Date.now()), publisher.owner)
+      .first<{ accountId: string; plan: string; documents: number; pushesToday: number; externalLinked: number }>();
+    if (!row) return errorResponse("unauthorized", "Sign in again.");
+    return Response.json({ accountId: row.accountId, plan: row.plan, limits: planLimits(env, row.plan),
+      usage: { documents: row.documents, pushesToday: row.pushesToday }, externalLinked: !!row.externalLinked }, { headers: NO_STORE });
+  }
+  if (path !== "/api/v1/account/handoffs" || request.method !== "POST") return errorResponse("not_found", "No account route.");
+  const url = actionUrl(env);
+  if (!url) return errorResponse("not_found", "Account actions are not configured.");
+  const purpose = await stringField(request, "purpose");
+  if (!purpose || !PURPOSES.has(purpose)) return errorResponse("bad_request", "Expected purpose upgrade, billing, or link.");
+  const tokenHash = await sha256Hex(parseBearerToken(request.headers.get("authorization"))!);
+  const code = Array.from(crypto.getRandomValues(new Uint8Array(32)), (b) => b.toString(16).padStart(2, "0")).join("");
+  const now = Date.now();
+  const expiresAt = now + HANDOFF_MS;
+  const results = await env.DB.batch([
+    env.DB.prepare("DELETE FROM account_handoffs WHERE account_id = ? AND expires_at <= ?").bind(publisher.owner, now),
+    env.DB.prepare(`INSERT INTO account_handoffs (code_hash, account_id, token_id, purpose, expires_at)
+      SELECT ?, a.id, t.id, ?, ? FROM tokens t JOIN accounts a ON a.id = t.account_id
+      WHERE t.token_hash = ? AND a.id = ?
+        AND (SELECT COUNT(*) FROM account_handoffs WHERE account_id = a.id) < 5
+      RETURNING code_hash`).bind(await sha256Hex(code), purpose, expiresAt, tokenHash, publisher.owner),
+  ]);
+  if (results[1]!.results.length === 0) return errorResponse("quota_exceeded", "Too many pending account actions, or token revoked. Sign in again or wait ten minutes.");
+  url.searchParams.set("code", code);
+  return Response.json({ url: url.toString(), expiresAt }, { headers: NO_STORE });
+}
+
+/** The service credential is checked by handleAdmin before this one-use proof. */
+export async function consumeHandoff(request: Request, env: Env): Promise<Response> {
+  const code = await stringField(request, "code");
+  if (!code || !/^[0-9a-f]{64}$/.test(code)) return errorResponse("bad_request", "Expected a handoff code.");
+  const row = await env.DB.prepare(`DELETE FROM account_handoffs
+    WHERE code_hash = ? AND expires_at > ?
+      AND EXISTS(SELECT 1 FROM tokens t JOIN accounts a ON a.id = t.account_id
+                 WHERE t.id = account_handoffs.token_id AND a.id = account_handoffs.account_id)
+    RETURNING account_id AS accountId, purpose,
+      (SELECT email FROM accounts WHERE id = account_handoffs.account_id) AS email,
+      (SELECT external_owner FROM owner_links WHERE account_id = account_handoffs.account_id) AS externalOwner`)
+    .bind(await sha256Hex(code), Date.now()).first();
+  if (!row) return errorResponse("not_found", "No live handoff.");
+  return Response.json(row, { headers: NO_STORE });
+}

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,3 +1,5 @@
+import { consumeHandoff, stringField } from "./account.js";
+import { linkExternalOwner } from "./owners.js";
 import { parseBearerToken } from "./auth.js";
 import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
@@ -6,10 +8,11 @@ import { readBodyWithin } from "./quota.js";
 
 export const ADMIN_PREFIX = "/admin/v1";
 
-/** Billing owns subscription state. This narrowly scoped API only changes an existing account's plan. */
+/** Trusted service API: account plans, ownership associations, and one-use account proofs. */
 export async function handleAdmin(request: Request, url: URL, env: Env): Promise<Response> {
-  const match = /^\/admin\/v1\/accounts\/([^/]+)\/plan$/.exec(url.pathname);
-  if (!env.ADMIN_API_KEY?.trim() || request.method !== "PUT" || !match) {
+  const match = /^\/admin\/v1\/accounts\/([^/]+)\/(plan|external-owner)$/.exec(url.pathname);
+  const consume = request.method === "POST" && url.pathname === "/admin/v1/handoffs/consume";
+  if (!env.ADMIN_API_KEY?.trim() || (!consume && (request.method !== "PUT" || !match))) {
     return errorResponse("not_found", "No admin route.");
   }
   const token = parseBearerToken(request.headers.get("authorization"));
@@ -17,6 +20,20 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   const digest = (value: string) => crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   if (!token || !crypto.subtle.timingSafeEqual(await digest(token), await digest(env.ADMIN_API_KEY))) {
     return errorResponse("unauthorized", "Expected the admin bearer credential.", { "www-authenticate": "Bearer" });
+  }
+  if (consume) return await consumeHandoff(request, env);
+  let owner: string;
+  try { owner = decodeURIComponent(match![1]!); } catch {
+    return errorResponse("not_found", "No account with that id.");
+  }
+  if (match![2] === "external-owner") {
+    const externalOwner = await stringField(request, "externalOwner");
+    if (externalOwner === null) return errorResponse("bad_request", "Expected only externalOwner.");
+    const result = await linkExternalOwner(env.DB, externalOwner, owner, Date.now());
+    if (result === "invalid") return errorResponse("bad_request", "Invalid owner identity.");
+    if (result === "account_not_found") return errorResponse("not_found", "No account with that id.");
+    if (result === "conflict") return errorResponse("conflict", "An owner is already associated with another account.");
+    return Response.json({ accountId: owner, externalOwner }, { headers: { "cache-control": "no-store" } });
   }
   const raw = await readBodyWithin(request, 1024);
   if (!raw) return errorResponse("bad_request", "Admin body must be at most 1024 bytes.");
@@ -31,10 +48,6 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   // A malformed deployment is a 500, while a caller naming no configured plan is a 400.
   if (!Object.hasOwn(configuredPlans(env), body.plan)) {
     return errorResponse("bad_request", "Unknown plan.");
-  }
-  let owner: string;
-  try { owner = decodeURIComponent(match[1]!); } catch {
-    return errorResponse("not_found", "No account with that id.");
   }
   const updated = await env.DB.prepare("UPDATE accounts SET plan = ? WHERE id = ? RETURNING id, plan")
     .bind(body.plan, owner).first<{ id: string; plan: string }>();

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,8 @@ export interface Env {
   UPGRADE_URL?: string;
   /** Server-to-server bearer credential. Unset disables the admin surface. */
   ADMIN_API_KEY?: string;
+  /** Trusted browser action endpoint. HTTPS, or loopback HTTP for development. */
+  ACCOUNT_ACTION_URL?: string;
 
   /**
    * OAuth client credentials for the approval page, one pair per provider.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@
  * The code is stable for clients to match; the message stays free to change.
  */
 export type ErrorCode =
+  | "conflict"
   | "bad_request"
   | "unauthorized"
   | "not_found"
@@ -22,6 +23,7 @@ export type ErrorCode =
   | "access_denied";
 
 const ERROR_STATUS: Record<ErrorCode, number> = {
+  conflict: 409,
   bad_request: 400,
   unauthorized: 401,
   not_found: 404,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { handleAccount } from "./account.js";
 import { deleteDoc, listDocs } from "./api/manage.js";
 import { ADMIN_PREFIX, handleAdmin } from "./admin.js";
 import { APPROVAL_PREFIX, handleApproval } from "./approval/handler.js";
@@ -111,6 +112,10 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
     .slice(API_PREFIX.length)
     .split("/")
     .filter(Boolean);
+
+  if (collection === "account" && extra.length === 0) {
+    return await handleAccount(request, env, auth.publisher);
+  }
 
   // Entitlement is per operation. Authentication above says *who* this is;
   // only publishing asks whether their plan may. Applying it to the whole

--- a/test/account-actions.test.ts
+++ b/test/account-actions.test.ts
@@ -1,0 +1,145 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId } from "../src/ids.js";
+import worker from "../src/index.js";
+
+const ACCOUNT = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER = "oa_bbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SERVICE = "test-service-secret";
+const EXTERNAL = "external-account";
+let token: string;
+let tokenId: string;
+let otherToken: string;
+const defaults = { ADMIN_API_KEY: SERVICE, ACCOUNT_ACTION_URL: "https://actions.example.test/continue" };
+
+beforeEach(async () => {
+  for (const id of [ACCOUNT, OTHER]) {
+    await env.DB.prepare("INSERT INTO accounts (id, email, created_at) VALUES (?, ?, 0)")
+      .bind(id, `${id}@example.test`).run();
+  }
+  token = newApiToken(); tokenId = newTokenId(); otherToken = newApiToken();
+  for (const [id, value, account] of [[tokenId, token, ACCOUNT], [newTokenId(), otherToken, OTHER]]) {
+    await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+      .bind(id, await sha256Hex(value!), account).run();
+  }
+});
+
+async function send(method: string, path: string, credential: string, body?: unknown, overrides: Partial<Env> = {}) {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`https://api.local.test${path}`, {
+    method, headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), { ...env, ...defaults, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "", ...overrides }, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+const consume = (code: string, credential = SERVICE) => send("POST", "/admin/v1/handoffs/consume", credential, { code });
+const count = async () => (await env.DB.prepare("SELECT COUNT(*) AS n FROM account_handoffs").first<{ n: number }>())!.n;
+async function mint(purpose = "upgrade", credential = token) {
+  const response = await send("POST", "/api/v1/account/handoffs", credential, { purpose });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  const result = await response.json() as { url: string; expiresAt: number };
+  return { ...result, code: new URL(result.url).searchParams.get("code")! };
+}
+
+it("reports account plan, limits, combined usage and association without revealing external identity", async () => {
+  expect((await send("PUT", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE, { externalOwner: EXTERNAL })).status).toBe(200);
+  for (const owner of [ACCOUNT, EXTERNAL]) {
+    await env.DB.prepare("INSERT INTO docs (id, owner, title, created_at, updated_at) VALUES (?, ?, '', 0, 0)").bind(owner, owner).run();
+    await env.DB.prepare("INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, 2)").bind(owner, new Date().toISOString().slice(0, 10)).run();
+  }
+  const response = await send("GET", "/api/v1/account", token);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ accountId: ACCOUNT, plan: "free", limits: { documents: 3, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 2, pushesToday: 4 }, externalLinked: true });
+  const other = await (await send("GET", "/api/v1/account", otherToken)).json();
+  expect(other).toMatchObject({ accountId: OTHER, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
+});
+
+it("preserves each purpose, consumes once, stores only hashes and returns linked identity to the service", async () => {
+  await send("PUT", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE, { externalOwner: EXTERNAL });
+  for (const purpose of ["upgrade", "billing", "link"]) {
+    const before = Date.now();
+    const handoff = await mint(purpose);
+    expect(handoff.expiresAt).toBeGreaterThanOrEqual(before + 600000);
+    expect(handoff.expiresAt).toBeLessThanOrEqual(Date.now() + 600000);
+    const stored = await env.DB.prepare("SELECT * FROM account_handoffs").all();
+    expect(JSON.stringify(stored)).not.toContain(handoff.code);
+    expect(JSON.stringify(stored)).not.toContain(token);
+    const response = await consume(handoff.code);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ accountId: ACCOUNT, email: `${ACCOUNT}@example.test`, purpose, externalOwner: EXTERNAL });
+    expect((await consume(handoff.code)).status).toBe(404);
+  }
+});
+
+it("allows one concurrent consumption and at most five concurrent outstanding actions per account", async () => {
+  const attempts = await Promise.all(Array.from({ length: 8 }, () => send("POST", "/api/v1/account/handoffs", token, { purpose: "link" })));
+  expect(attempts.filter((r) => r.status === 200)).toHaveLength(5);
+  expect(attempts.filter((r) => r.status === 429)).toHaveLength(3);
+  const body = await attempts.find((r) => r.status === 200)!.json() as { url: string };
+  const code = new URL(body.url).searchParams.get("code")!;
+  expect((await Promise.all([consume(code), consume(code)])).map((r) => r.status).sort()).toEqual([200, 404]);
+  expect(await count()).toBe(4);
+  await mint("billing", otherToken);
+  expect(await count()).toBe(5);
+});
+
+it("refuses expired and revoked originating credentials and clears only the owner's expired actions", async () => {
+  const expired = await mint();
+  await env.DB.prepare("UPDATE account_handoffs SET expires_at = 0").run();
+  expect((await consume(expired.code)).status).toBe(404);
+  await mint("link", otherToken);
+  const revoked = await mint();
+  expect(await count()).toBe(2);
+  await env.DB.prepare("DELETE FROM tokens WHERE id = ?").bind(tokenId).run();
+  expect((await consume(revoked.code)).status).toBe(404);
+  expect((await send("POST", "/api/v1/account/handoffs", token, { purpose: "billing" })).status).toBe(401);
+});
+
+it("requires the service credential and does not consume proof on an unauthorized request", async () => {
+  const handoff = await mint();
+  for (const credential of [token, otherToken, "wrong"]) expect((await consume(handoff.code, credential)).status).toBe(401);
+  expect(await count()).toBe(1);
+  expect((await consume(handoff.code)).status).toBe(200);
+});
+
+it("rejects extra fields, forged purposes, oversized input and malformed codes", async () => {
+  for (const body of [{ purpose: "delete" }, { purpose: "link", accountId: OTHER }, { purpose: 1 }, [], null, { purpose: "x".repeat(2000) }]) {
+    expect((await send("POST", "/api/v1/account/handoffs", token, body)).status).toBe(400);
+  }
+  for (const body of [{ code: "x" }, { code: "a".repeat(64), purpose: "link" }, { code: 1 }]) {
+    expect((await send("POST", "/admin/v1/handoffs/consume", SERVICE, body)).status).toBe(400);
+  }
+  expect(await count()).toBe(0);
+});
+
+it("fails closed before writing for unconfigured or unsafe action destinations", async () => {
+  for (const [url, status] of [["", 404], ["http://evil.test/path", 500], ["https://user:pass@example.test", 500], ["https://example.test/#fragment", 500], ["javascript:alert(1)", 500]] as const) {
+    expect((await send("POST", "/api/v1/account/handoffs", token, { purpose: "link" }, { ACCOUNT_ACTION_URL: url })).status).toBe(status);
+  }
+  expect(await count()).toBe(0);
+  const local = await send("POST", "/api/v1/account/handoffs", token, { purpose: "link" }, { ACCOUNT_ACTION_URL: "http://localhost:3000/action" });
+  expect(local.status).toBe(200);
+});
+
+it("requires OAuth credentials and confines service routes to the API host", async () => {
+  const key = "license-test-key";
+  await env.DB.prepare("INSERT INTO publishers (key_hash, owner, plan, validated_at) VALUES (?, ?, 'plus', ?)").bind(await sha256Hex(key), EXTERNAL, Date.now()).run();
+  expect((await send("GET", "/api/v1/account", key)).status).toBe(401);
+  expect((await send("POST", "/api/v1/account/handoffs", key, { purpose: "link" })).status).toBe(401);
+  expect((await send("POST", "/admin/v1/handoffs/consume", SERVICE, { code: "a".repeat(64) }, { API_HOST: "other.test", SERVING_HOST: "api.local.test" })).status).toBe(404);
+});
+
+it("associates only through service authorization, repeats safely, rejects conflicting pairs", async () => {
+  const path = `/admin/v1/accounts/${ACCOUNT}/external-owner`;
+  expect((await send("PUT", path, token, { externalOwner: EXTERNAL })).status).toBe(401);
+  for (let n = 0; n < 2; n++) expect((await send("PUT", path, SERVICE, { externalOwner: EXTERNAL })).status).toBe(200);
+  expect((await send("PUT", path, SERVICE, { externalOwner: "other-external" })).status).toBe(409);
+  expect((await send("PUT", `/admin/v1/accounts/${OTHER}/external-owner`, SERVICE, { externalOwner: EXTERNAL })).status).toBe(409);
+  expect((await send("PUT", path, SERVICE, { externalOwner: ACCOUNT })).status).toBe(400);
+  expect((await send("PUT", path, SERVICE, { externalOwner: EXTERNAL, plan: "pro" })).status).toBe(400);
+});


### PR DESCRIPTION
Relates to Brevilabs/app-sites#467

## Why

An account identifier in a browser link does not prove who requested an account action. Signed-in clients need a safe way to start a trusted browser flow and inspect their current limits.

## What

Account tokens can read plan, joined usage, and linking status, or request a ten-minute browser handoff. The trusted service consumes that proof once and can associate a verified external owner.

| Condition | Result |
| --- | --- |
| Live account token | Account status and up to five pending handoffs |
| Expired, replayed, or revoked handoff | Refused |
| External owner already linked elsewhere | Conflict; existing association stays intact |
| Browser endpoint unconfigured | Handoff creation unavailable |

## Non goal

Browser pages, CLI commands, payment handling, automatic email-based merging, and permanent browser sessions are separate work. External-license credentials do not gain account-token administration.

## Screenshot

Not applicable: this adds API behavior without a visual surface.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | D1 tests cover status, handoff bounds, consumption, and association conflicts |
| A defect would fail CI or be obvious on first use | ✅ | Account API tests run in CI |
| A revert fully restores prior state, including persisted data | ❌ | Owner associations persist; older ownership queries cannot safely serve linked accounts |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Account proof and trusted association endpoints are new |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Additive account/service APIs and a handoff table |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Bounded creation and single-use consumption are atomic |
| No hot-path behavior lacks deterministic coverage | ✅ | Concurrent consumption and revoked-token cases have real D1 coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | API outcomes are directly observable; browser behavior is separate |

Review: inspect `handleAccount`, `consumeHandoff`, `actionUrl`, and `stringField` in `src/account.ts`, `handleAdmin` in `src/admin.ts`, account dispatch in `src/index.ts`, and the table definition in `migrations/0007_account_handoffs.sql` line by line; exercise Verification 2–4.

## Verification

1. Apply migrations through 0007 locally and configure the service credential plus a trusted HTTPS account-action URL. Obtain an account token and read account status.
2. Create a handoff for each supported purpose. Consume one with the service credential and confirm its account and purpose; replay it and expect refusal. Concurrent consumption must have one winner.
3. Revoke the originating token before consuming another handoff. Expect refusal. Test expiry, malformed bodies, an unsafe action URL, and a sixth pending handoff.
4. Associate a verified external owner using the service credential. Retry the same pair successfully, then attempt a conflicting pair and confirm neither existing association changes. A license credential must not access account status or create a handoff.

## Note

Deploy migration 0007 before this Worker. Enable the browser endpoint only after its trusted service enforces the returned purpose and obtains explicit confirmation before linking. Retain joined ownership queries when rolling back accounts that have been linked.
