### PR TITLE
[Account linking] - Step 3: Add account and browser commands

### DIFF
--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -4,7 +4,7 @@ Install the CLI and the OpenArtifacts skill into detected Claude Code, Codex, Op
 and pi installations:
 
 ```bash
-npx openartifacts install
+npx --yes openartifacts@latest install
 ```
 
 Hermes Agent needs only its native skill install:
@@ -49,6 +49,35 @@ The first authenticated command opens the browser device flow and stores the res
 token with owner-only permissions. Set `OPENARTIFACTS_TOKEN` to supply a credential
 without browser sign-in; it accepts an OpenArtifacts token or a Brevilabs license key.
 Set `OPENARTIFACTS_API_HOST` to target a self-hosted deployment.
+
+## Account and browser actions
+
+An OpenArtifacts account can publish within the deployment's free limits.
+Signing in is separate from purchasing an upgrade. Check current access with:
+
+```bash
+openartifacts account
+openartifacts upgrade
+openartifacts billing
+openartifacts link-copilot
+```
+
+`account` prints JSON with the plan, limits, current usage, and whether an external
+account is linked. The other commands print `{"url":"…","expiresAt":…}` and open
+the browser. These links expire after ten minutes and can be used once. Their
+availability depends on the deployment's configured account-action service.
+
+These four commands require an OAuth-issued OpenArtifacts token. The CLI uses
+the current API host's stored token, or `OPENARTIFACTS_TOKEN` when set. Without a
+credential it starts the normal sign-in flow. If the environment contains a
+license key, unset it and run `openartifacts login` before these account commands.
+A rejected credential is reported; it does not silently start another sign-in.
+
+For linking, enter the license key only on the trusted browser page and confirm
+the association there. Never put the key in command arguments or chat. Linking
+joins document history while preserving published URLs and existing machine tokens.
+It does not itself complete a purchase. On a publishing limit, run `upgrade` to
+obtain authenticated browser access; an owner ID in a URL is not account proof.
 
 ## Hosts
 

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -71,12 +71,22 @@ The CLI reads `OPENARTIFACTS_TOKEN` from the environment. It accepts an OpenArti
 token or a Brevilabs license key. Without it, the first authenticated command starts a
 browser sign-in: relay both urls and the code the CLI prints, then keep waiting.
 
-Publishing needs a paid OpenArtifacts plan. On `unauthorized`, tell the user they need a
-credential with publishing access before anything can be published. Never read
-credential files, print tokens, or ask the user to paste a credential into the chat.
+OpenArtifacts accounts can publish within their free limits. Sign-in does not
+require buying a plan. On `unauthorized`, relay the sign-in guidance rather than
+claiming payment is required. Never read credential files, print tokens, or ask
+the user to paste a credential into the chat.
+
+Use `openartifacts account` to report the current plan, limits, usage, and linked
+status. When the user asks to upgrade, manage billing, or link their existing
+Copilot account, run `openartifacts upgrade`, `openartifacts billing`, or
+`openartifacts link-copilot`. Relay the returned short-lived browser URL. The user
+enters a license key and confirms linking only on that page, never in chat or
+command arguments. These commands require an OAuth-issued account token; follow
+the CLI guidance if an environment license key overrides the stored token.
 
 ## Errors
 
 Relay the CLI's message verbatim and do not retry blindly. For `quota_exceeded`, say
 whether to wait or unshare an unused page. For `limit_reached`, show the limit and the
-upgrade link the CLI prints.
+guidance to run `openartifacts upgrade`. Generate that browser link when the user
+asks to upgrade; do not treat a limit error as purchase authorization.

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -212,6 +212,10 @@ const HELP = `Usage: openartifacts <command> [argument] [options]
 Commands:
   install            Install or upgrade the CLI and detected agent skills
   login              Approve this machine and store its token
+  account            Show this account's plan, limits, and usage as JSON
+  upgrade            Open account upgrade options
+  billing            Open account billing management
+  link-copilot       Open secure browser confirmation to link an existing license
   publish <file.html> [--title <title>] [--doc-id <docId>]
                      Publish an HTML file; pass --doc-id to update an existing document
   list               List published documents
@@ -254,7 +258,7 @@ export async function main(args) {
     console.log(HELP);
     return;
   }
-  if (!["install", "login", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
+  if (!["install", "login", "account", "upgrade", "billing", "link-copilot", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
     throw new Error(HELP);
   }
   const needsArgument = ["publish", "get", "unshare", "revoke"].includes(command);
@@ -274,6 +278,33 @@ export async function main(args) {
 
   const token = await credential(host, directory);
   const client = createClient({ host, token });
+  /** @type {Record<string, "upgrade" | "billing" | "link">} */
+  const actions = { upgrade: "upgrade", billing: "billing", "link-copilot": "link" };
+  const purpose = actions[command];
+  if ((command === "account" || purpose) && !token.startsWith("oat_")) {
+    throw new Error("This command needs an OpenArtifacts account token. Run `openartifacts login`; unset OPENARTIFACTS_TOKEN if it contains a license key.");
+  }
+  if (command === "account") {
+    const result = await client.account();
+    console.log(JSON.stringify({ accountId: result.accountId, plan: result.plan,
+      limits: { documents: result.limits.documents, pushesPerDay: result.limits.pushesPerDay, htmlBytes: result.limits.htmlBytes },
+      usage: { documents: result.usage.documents, pushesToday: result.usage.pushesToday }, externalLinked: result.externalLinked }));
+    return;
+  }
+  if (purpose) {
+    const result = await client.createHandoff(purpose);
+    const url = new URL(result.url);
+    const local = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    if (url.username || url.password || url.hash || url.href.includes(token) ||
+      (url.protocol !== "https:" && !(url.protocol === "http:" && local)) ||
+      !/^[0-9a-f]{64}$/.test(url.searchParams.get("code") ?? "") ||
+      !Number.isSafeInteger(result.expiresAt) || result.expiresAt <= Date.now()) {
+      throw new Error("The server returned an invalid account action link.");
+    }
+    console.log(JSON.stringify({ url: url.toString(), expiresAt: result.expiresAt }));
+    openBrowser(url.toString());
+    return;
+  }
 
   if (prepared) {
     try {
@@ -326,7 +357,7 @@ export function presentError(error) {
     }
     if (error.code === "limit_reached") {
       if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);
-      if (error.detail.upgrade_url) console.error(`Upgrade: ${error.detail.upgrade_url}`);
+      console.error("Run `openartifacts upgrade` to get a secure account upgrade link.");
     }
   } else {
     console.error(error instanceof Error ? error.message : String(error));

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -90,12 +90,21 @@ async function writePrivateJson(path, value) {
   await chmod(path, 0o600);
 }
 
+/** Keep browser URLs as data, including Windows shell metacharacters.
+ * @param {string} url @param {NodeJS.Platform} [os]
+ */
+export function browserProcess(url, os = platform()) {
+  return os === "win32"
+    ? { command: "powershell.exe", args: ["-NoProfile", "-NonInteractive", "-Command", "Start-Process -FilePath $env:OPENARTIFACTS_BROWSER_URL"],
+      env: { ...process.env, OPENARTIFACTS_BROWSER_URL: url } }
+    : { command: os === "darwin" ? "open" : "xdg-open", args: [url], env: process.env };
+}
+
 /** @param {string} url */
 function openBrowser(url) {
-  const command = platform() === "darwin" ? "open" : platform() === "win32" ? "cmd" : "xdg-open";
-  const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
+  const opener = browserProcess(url);
   try {
-    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    const child = spawn(opener.command, opener.args, { env: opener.env, shell: false, detached: true, stdio: "ignore" });
     child.on("error", () => {});
     child.unref();
   } catch {}

--- a/packages/openartifacts/src/client.js
+++ b/packages/openartifacts/src/client.js
@@ -42,6 +42,11 @@ export function createClient({ host, token, fetcher = fetch }) {
   }
 
   return {
+    account: () => request("/api/v1/account"),
+    /** @param {"upgrade" | "billing" | "link"} purpose */
+    createHandoff: (purpose) => request("/api/v1/account/handoffs", {
+      method: "POST", body: JSON.stringify({ purpose }),
+    }),
     /** @param {string} label */
     deviceCode: (label) =>
       request("/device/code", { method: "POST", body: JSON.stringify({ label }) }),

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -5,7 +5,7 @@ import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { collectToken, configDir, detectAgents, installSkills, main, npmProcess, preparePublish, presentError } from "../src/cli.js";
+import { browserProcess, collectToken, configDir, detectAgents, installSkills, main, npmProcess, preparePublish, presentError } from "../src/cli.js";
 import { APIError } from "../src/client.js";
 
 /** Point the CLI at a scratch config directory and host for one test. */
@@ -464,4 +464,15 @@ test("account actions reject unsafe browser URLs without printing them", async (
     assert.match(result.stderr, /invalid account action link/);
     assert(!result.stderr.includes("javascript:"));
   } finally { remote.server.close(); }
+});
+
+test("Windows browser launch passes the complete URL as data rather than command text", () => {
+  const url = 'https://actions.example.test/?source=cli&code=abc&x=";Write-Output injected"';
+  const windows = browserProcess(url, "win32");
+  assert.equal(windows.command, "powershell.exe");
+  assert.deepEqual(windows.args, ["-NoProfile", "-NonInteractive", "-Command", "Start-Process -FilePath $env:OPENARTIFACTS_BROWSER_URL"]);
+  assert.equal(windows.env.OPENARTIFACTS_BROWSER_URL, url);
+  assert(!windows.args.some((arg) => arg.includes(url)));
+  assert.deepEqual(browserProcess(url, "darwin").args, [url]);
+  assert.deepEqual(browserProcess(url, "linux").args, [url]);
 });

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -351,5 +351,117 @@ test("prints guidance for current quota and future plan limits", () => {
   }
   assert(lines.some((line) => line.includes("quota window")));
   assert(lines.includes("Limit: 10 documents"));
-  assert(lines.includes("Upgrade: https://example.test/upgrade"));
+  assert(lines.some((line) => line.includes("openartifacts upgrade")));
+  assert(!lines.some((line) => line.includes("https://example.test/upgrade")));
+});
+
+async function accountServer() {
+  const requests = [];
+  const control = { status: 200, unsafeUrl: false };
+  const server = createServer((request, response) => {
+    let raw = "";
+    request.on("data", (chunk) => { raw += chunk; });
+    request.on("end", () => {
+      requests.push({ method: request.method, path: request.url, authorization: request.headers.authorization, body: raw ? JSON.parse(raw) : undefined });
+      response.setHeader("content-type", "application/json");
+      response.statusCode = control.status;
+      if (control.status !== 200) {
+        response.end(JSON.stringify({ error: { code: "unauthorized", message: "Sign in again." } }));
+      } else if (request.url === "/api/v1/account") {
+        response.end(JSON.stringify({ accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false, access_token: "never-print-response-extra" }));
+      } else if (request.url === "/api/v1/account/handoffs") {
+        response.end(JSON.stringify({ url: control.unsafeUrl ? "javascript:alert(1)" : `https://actions.example.test/continue?code=${"a".repeat(64)}`, expiresAt: Date.now() + 600000, token: "never-print-response-extra" }));
+      } else {
+        response.statusCode = 500;
+        response.end(JSON.stringify({ error: { message: "Unexpected login or request." } }));
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { server, requests, control, host: `http://127.0.0.1:${server.address().port}` };
+}
+
+async function cliProcess(args, values) {
+  const { spawn } = await import("node:child_process");
+  const env = { ...process.env, ...values, PATH: "" }; // Browser launch fails harmlessly; never open a real browser in tests.
+  if (!values.OPENARTIFACTS_TOKEN) delete env.OPENARTIFACTS_TOKEN;
+  const child = spawn(process.execPath, [new URL("../bin/openartifacts.js", import.meta.url).pathname, ...args], { env });
+  let stdout = "", stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const [code] = await once(child, "close");
+  return { code, stdout, stderr };
+}
+
+test("account commands use host-scoped stored OAuth tokens and print only safe JSON fields", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "oa-01a08465-cli-account-"));
+  const remote = await accountServer();
+  await writeFile(join(directory, "credentials.json"), JSON.stringify({ hosts: {
+    [remote.host]: { token: "oat_stored-secret" }, "https://other.test": { token: "oat_other-secret" },
+  } }));
+  const env = { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host };
+  try {
+    const account = await cliProcess(["account"], env);
+    assert.equal(account.code, 0, account.stderr);
+    assert.deepEqual(JSON.parse(account.stdout), { accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
+    for (const command of ["upgrade", "billing", "link-copilot"]) {
+      const result = await cliProcess([command], env);
+      assert.equal(result.code, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.deepEqual(Object.keys(parsed).sort(), ["expiresAt", "url"]);
+      assert.equal(new URL(parsed.url).searchParams.get("code"), "a".repeat(64));
+      assert(!`${result.stdout}${result.stderr}`.includes("secret"));
+      assert(!result.stdout.includes("never-print-response-extra"));
+    }
+    assert.deepEqual(remote.requests.map(({ method, path, body }) => [method, path, body]), [
+      ["GET", "/api/v1/account", undefined],
+      ["POST", "/api/v1/account/handoffs", { purpose: "upgrade" }],
+      ["POST", "/api/v1/account/handoffs", { purpose: "billing" }],
+      ["POST", "/api/v1/account/handoffs", { purpose: "link" }],
+    ]);
+    assert(remote.requests.every((r) => r.authorization === "Bearer oat_stored-secret"));
+  } finally { remote.server.close(); }
+});
+
+test("account actions honor environment credentials, refuse license arguments, and never silently re-login", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "oa-01a08465-cli-credentials-"));
+  const remote = await accountServer();
+  const env = { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host, OPENARTIFACTS_TOKEN: "oat_environment-secret" };
+  await writeFile(join(directory, "credentials.json"), JSON.stringify({ hosts: { [remote.host]: { token: "oat_stored-secret" } } }));
+  try {
+    assert.equal((await cliProcess(["account"], env)).code, 0);
+    assert.equal(remote.requests[0].authorization, "Bearer oat_environment-secret");
+    for (const command of ["account", "upgrade", "billing", "link-copilot"]) {
+      const result = await cliProcess([command, "license-secret-must-not-leak"], env);
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /Usage: openartifacts/);
+      assert(!result.stderr.includes("license-secret-must-not-leak"));
+    }
+    const license = await cliProcess(["link-copilot"], { ...env, OPENARTIFACTS_TOKEN: "license-secret" });
+    assert.equal(license.code, 1);
+    assert.match(license.stderr, /unset OPENARTIFACTS_TOKEN/);
+    assert.equal(remote.requests.length, 1);
+    remote.control.status = 401;
+    const rejected = await cliProcess(["account"], env);
+    assert.equal(rejected.code, 1);
+    assert.match(rejected.stderr, /openartifacts login/);
+    assert.equal(rejected.stdout, "");
+    assert(!rejected.stderr.includes("environment-secret"));
+    assert.deepEqual(remote.requests.map((r) => r.path), ["/api/v1/account", "/api/v1/account"]);
+    assert.equal(JSON.parse(await readFile(join(directory, "credentials.json"), "utf8")).hosts[remote.host].token, "oat_stored-secret");
+  } finally { remote.server.close(); }
+});
+
+test("account actions reject unsafe browser URLs without printing them", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "oa-01a08465-cli-url-"));
+  const remote = await accountServer();
+  remote.control.unsafeUrl = true;
+  try {
+    const result = await cliProcess(["upgrade"], { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host, OPENARTIFACTS_TOKEN: "oat_test-secret" });
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /invalid account action link/);
+    assert(!result.stderr.includes("javascript:"));
+  } finally { remote.server.close(); }
 });


### PR DESCRIPTION
Fixes Brevilabs/app-sites#467

## Why

The CLI can publish and manage documents, but cannot show account usage or start an authenticated browser action. Its installed skill also incorrectly says publishing requires a paid plan.

## What

Users can run `account` for plan and usage, or `upgrade`, `billing`, and `link-copilot` to open the corresponding short-lived browser flow. Account commands use an OAuth token and explain how to resolve an environment license key overriding stored sign-in. Publishing guidance now recognizes free accounts.

> **Before:** A user reaching a limit gets a routing-only upgrade URL and no account command.
>
> **After:** The CLI explains how to request a fresh authenticated upgrade link; linking directs the human to enter their key on the trusted page.

## Non goal

Browser pages, payment handling, a permanent session/dashboard, and hosted price policy are separate. License credentials do not gain account-token administration. Existing document API responses remain unchanged.

## Screenshot

Not applicable: command-line output and agent instructions only.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Child-process tests cover command routing, credentials, output, and failures; a Windows regression preserves complete URLs |
| A defect would fail CI or be obvious on first use | ✅ | CLI tests run in CI |
| A revert fully restores prior state, including persisted data | ✅ | No new credential format or persistent state |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Commands use account credentials to request browser proof |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Four additive CLI commands and client methods |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing sign-in and browser helpers are reused |
| No hot-path behavior lacks deterministic coverage | ✅ | Local HTTP tests verify account requests and malformed responses |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Browser opening and agent wording are immediately visible |

Review: inspect `main`, `presentError`, `browserProcess`, `openBrowser`, and `HELP` in `packages/openartifacts/src/cli.js`, account methods in `packages/openartifacts/src/client.js`, and Authentication/Errors in `packages/openartifacts/skill/openartifacts/SKILL.md`; run Verification 2–4 including refusal paths.

## Verification

1. Use a Worker with account handoffs configured and sign in with the CLI. Run `account` and confirm its JSON shows your plan, limits, joined usage, and link status.
2. Run each browser action. Confirm the browser opens and JSON contains only the short-lived URL and expiry. The service must receive the matching upgrade, billing, or link purpose.
3. Set an environment license credential and run an account command. Confirm it explains the OAuth requirement without printing the credential. Pass an argument to `link-copilot`; confirm rejection before any request.
4. Reach a document limit and confirm the CLI suggests `openartifacts upgrade`. Verify malformed/unsafe action URLs are refused, and confirm the installed skill permits free publishing without asking for a key in chat. On Windows, check that a URL with an existing query parameter opens with its complete handoff code.

## Note

The CLI release must follow deployment of the account API and trusted browser service. This PR does not bump the npm version.
