### PR TITLE
[Account linking] - Step 4: Order and expire entitlement updates

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -780,3 +780,39 @@ an identical retry return `200` with `{"accountId":"oa_…","externalOwner":"…
 A conflicting association returns `409 conflict`; invalid identities return
 `400`; a missing local account returns `404`. Associations are permanent and do
 not change plans, credential permissions, document IDs, or stored versions.
+
+### Ordered plan snapshots
+
+The existing service-only `PUT /admin/v1/accounts/{accountId}/plan` also accepts
+exactly `{"plan":"pro","expiresAt":1800000600000,"revision":1}`. `expiresAt` is
+null for unlimited validity or a nonnegative safe-integer epoch millisecond
+value. `revision` is a positive safe integer. Both fields must be supplied
+together; missing fields, additional fields, invalid numbers, and unconfigured
+plan names return `400`.
+
+A larger revision atomically replaces the stored snapshot. An identical retry
+of the current revision succeeds; a lower revision, or the same revision with
+different contents, returns `409 conflict`. Missing accounts return `404`.
+Success returns the stored snapshot, not its time-dependent effective plan:
+`{"owner":"oa_…","plan":"pro","expiresAt":1800000600000,"revision":1}`.
+The caller must allocate revisions durably per account and deliver reconciled
+snapshots in increasing order. A newer reconciliation can supersede a manual
+operator assignment; retries must never send changed contents under an old
+revision.
+
+At `expiresAt <= now`, account authentication and status use the configured
+default plan. This requires no remote call or database mutation. The stored
+snapshot, documents, versions, credentials, and usage remain intact. Existing
+above-limit collections remain listable, editable within the effective daily
+and byte limits, and removable; additional documents are refused at the cap.
+
+The original `{"plan":"…"}` manual operation and `{owner,plan}` response remain
+supported. It clears expiration but preserves the latest revision fence. The
+next service reconciliation must use a larger revision to replace that override.
+
+`GET /admin/v1/accounts/{accountId}/external-owner` uses the same service
+credential and returns `{accountId,externalOwner}` with null when the account
+has no association, or `404` when the account is unknown. This read supports
+recovery when association succeeds but a trusted caller's subsequent local
+write fails. It does not require retaining a raw external credential or
+replaying a consumed handoff. Responses use `cache-control: no-store`.

--- a/migrations/0008_plan_snapshots.sql
+++ b/migrations/0008_plan_snapshots.sql
@@ -1,0 +1,4 @@
+-- A service may deliver ordered plan snapshots with a bounded validity period.
+-- Existing manual assignments remain unlimited and start behind every revision.
+ALTER TABLE accounts ADD COLUMN plan_expires_at INTEGER CHECK (plan_expires_at >= 0);
+ALTER TABLE accounts ADD COLUMN plan_revision INTEGER NOT NULL DEFAULT 0 CHECK (plan_revision >= 0);

--- a/src/account.ts
+++ b/src/account.ts
@@ -3,7 +3,7 @@ import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
 import { sha256Hex } from "./hash.js";
 import { OWNER_SCOPE_SQL } from "./owners.js";
-import { planLimits } from "./plans.js";
+import { effectivePlan, planLimits } from "./plans.js";
 import { readBodyWithin, utcDay } from "./quota.js";
 
 const NO_STORE = { "cache-control": "no-store" };
@@ -39,15 +39,16 @@ export async function handleAccount(request: Request, env: Env, publisher: Publi
   const path = new URL(request.url).pathname;
   if (path === "/api/v1/account" && request.method === "GET") {
     const row = await env.DB.prepare(`${OWNER_SCOPE_SQL}
-      SELECT a.id AS accountId, a.plan,
+      SELECT a.id AS accountId, a.plan, a.plan_expires_at,
         (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) AS documents,
         (SELECT COALESCE(SUM(pushes), 0) FROM push_quota WHERE owner IN (SELECT owner FROM owner_scope) AND day = ?) AS pushesToday,
         EXISTS(SELECT 1 FROM owner_links WHERE account_id = a.id) AS externalLinked
       FROM accounts a WHERE a.id = ?`)
       .bind(publisher.owner, publisher.owner, utcDay(Date.now()), publisher.owner)
-      .first<{ accountId: string; plan: string; documents: number; pushesToday: number; externalLinked: number }>();
+      .first<{ accountId: string; plan: string; plan_expires_at: number | null; documents: number; pushesToday: number; externalLinked: number }>();
     if (!row) return errorResponse("unauthorized", "Sign in again.");
-    return Response.json({ accountId: row.accountId, plan: row.plan, limits: planLimits(env, row.plan),
+    const plan = effectivePlan(env, row.plan, row.plan_expires_at);
+    return Response.json({ accountId: row.accountId, plan, limits: planLimits(env, plan),
       usage: { documents: row.documents, pushesToday: row.pushesToday }, externalLinked: !!row.externalLinked }, { headers: NO_STORE });
   }
   if (path !== "/api/v1/account/handoffs" || request.method !== "POST") return errorResponse("not_found", "No account route.");

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -12,7 +12,8 @@ export const ADMIN_PREFIX = "/admin/v1";
 export async function handleAdmin(request: Request, url: URL, env: Env): Promise<Response> {
   const match = /^\/admin\/v1\/accounts\/([^/]+)\/(plan|external-owner)$/.exec(url.pathname);
   const consume = request.method === "POST" && url.pathname === "/admin/v1/handoffs/consume";
-  if (!env.ADMIN_API_KEY?.trim() || (!consume && (request.method !== "PUT" || !match))) {
+  const readOwner = request.method === "GET" && match?.[2] === "external-owner";
+  if (!env.ADMIN_API_KEY?.trim() || (!consume && !readOwner && (request.method !== "PUT" || !match))) {
     return errorResponse("not_found", "No admin route.");
   }
   const token = parseBearerToken(request.headers.get("authorization"));
@@ -25,6 +26,12 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   let owner: string;
   try { owner = decodeURIComponent(match![1]!); } catch {
     return errorResponse("not_found", "No account with that id.");
+  }
+  if (readOwner) {
+    const association = await env.DB.prepare(`SELECT a.id AS accountId, l.external_owner AS externalOwner
+      FROM accounts a LEFT JOIN owner_links l ON l.account_id = a.id WHERE a.id = ?`).bind(owner).first();
+    if (!association) return errorResponse("not_found", "No account with that id.");
+    return Response.json(association, { headers: { "cache-control": "no-store" } });
   }
   if (match![2] === "external-owner") {
     const externalOwner = await stringField(request, "externalOwner");
@@ -42,14 +49,35 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
     return errorResponse("bad_request", "Body must be JSON.");
   }
   if (!body || typeof body !== "object" || Array.isArray(body) || !("plan" in body) ||
-    typeof body.plan !== "string" || Object.keys(body).length !== 1) {
-    return errorResponse("bad_request", "Expected only a plan name.");
+    typeof body.plan !== "string") return errorResponse("bad_request", "Expected a plan name.");
+  const snapshot = Object.hasOwn(body, "revision") || Object.hasOwn(body, "expiresAt");
+  const value = body as { plan: string; revision?: unknown; expiresAt?: unknown };
+  if (snapshot ? Object.keys(body).length !== 3 || !Number.isSafeInteger(value.revision) ||
+      typeof value.revision !== "number" || value.revision <= 0 ||
+      (value.expiresAt !== null && (typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt < 0))
+    : Object.keys(body).length !== 1) {
+    return errorResponse("bad_request", "Expected only plan, or plan with expiresAt and a positive revision.");
   }
   // A malformed deployment is a 500, while a caller naming no configured plan is a 400.
   if (!Object.hasOwn(configuredPlans(env), body.plan)) {
     return errorResponse("bad_request", "Unknown plan.");
   }
-  const updated = await env.DB.prepare("UPDATE accounts SET plan = ? WHERE id = ? RETURNING id, plan")
+  if (snapshot) {
+    const revision = value.revision as number;
+    const expiresAt = value.expiresAt as number | null;
+    const updated = await env.DB.prepare(`UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_revision = ?
+      WHERE id = ? AND plan_revision < ? RETURNING id AS owner, plan, plan_expires_at AS expiresAt, plan_revision AS revision`)
+      .bind(value.plan, expiresAt, revision, owner, revision).first();
+    if (updated) return Response.json(updated, { headers: { "cache-control": "no-store" } });
+    const current = await env.DB.prepare("SELECT id AS owner, plan, plan_expires_at AS expiresAt, plan_revision AS revision FROM accounts WHERE id = ?")
+      .bind(owner).first<{ owner: string; plan: string; expiresAt: number | null; revision: number }>();
+    if (!current) return errorResponse("not_found", "No account with that id.");
+    if (current.revision !== revision || current.plan !== value.plan || current.expiresAt !== expiresAt) {
+      return errorResponse("conflict", "Plan snapshot revision is stale or has different content.");
+    }
+    return Response.json(current, { headers: { "cache-control": "no-store" } });
+  }
+  const updated = await env.DB.prepare("UPDATE accounts SET plan = ?, plan_expires_at = NULL WHERE id = ? RETURNING id, plan")
     .bind(body.plan, owner).first<{ id: string; plan: string }>();
   if (!updated) return errorResponse("not_found", "No account with that id.");
   return Response.json({ owner: updated.id, plan: updated.plan }, { headers: { "cache-control": "no-store" } });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,6 +42,7 @@ import { LICENSE_CACHE_TTL_MS, TOKEN_LAST_USED_RESOLUTION_MS, type Env } from ".
 import { d1PublisherStore, findLiveToken, touchTokenUse, type PublisherStore } from "./db.js";
 import { errorResponse, type ErrorCode } from "./errors.js";
 import { sha256Hex } from "./hash.js";
+import { effectivePlan } from "./plans.js";
 import { TOKEN_PREFIX } from "./ids.js";
 
 /** tRPC endpoint on the license server, appended to `LICENSE_API_URL`. */
@@ -260,7 +261,7 @@ async function resolveAccountToken(
     await touchTokenUse(env.DB, live.id, at, at - TOKEN_LAST_USED_RESOLUTION_MS);
   }
 
-  return { ok: true, publisher: { owner: live.account_id, plan: live.plan, authKind: "account" } };
+  return { ok: true, publisher: { owner: live.account_id, plan: effectivePlan(env, live.plan, live.plan_expires_at, at), authKind: "account" } };
 }
 
 const FAILURE_STATUS: Record<PublisherFailure, ErrorCode> = {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1145,15 +1145,15 @@ export async function collectDeviceToken(
 export async function findLiveToken(
   db: D1Database,
   tokenHash: string,
-): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string }) | null> {
+): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string; plan_expires_at: number | null }) | null> {
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT t.id, t.account_id, t.last_used_at, a.plan
+      `SELECT t.id, t.account_id, t.last_used_at, a.plan, a.plan_expires_at
          FROM tokens t JOIN accounts a ON a.id = t.account_id WHERE t.token_hash = ?`,
     )
     .bind(tokenHash)
-    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string }>();
+    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string; plan_expires_at: number | null }>();
 }
 
 /**

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -44,6 +44,11 @@ export function defaultPlan(env: Env): string {
   return plan;
 }
 
+/** Expiration changes access on the next request, never ownership or stored history. */
+export function effectivePlan(env: Env, plan: string, expiresAt: number | null, now = Date.now()): string {
+  return expiresAt !== null && expiresAt <= now ? defaultPlan(env) : plan;
+}
+
 export function limitReached(env: Env, publisher: Publisher, limit: string, message: string): Response {
   let upgradeUrl: string | undefined;
   if (env.UPGRADE_URL?.trim()) {

--- a/test/account-actions.test.ts
+++ b/test/account-actions.test.ts
@@ -143,3 +143,14 @@ it("associates only through service authorization, repeats safely, rejects confl
   expect((await send("PUT", path, SERVICE, { externalOwner: ACCOUNT })).status).toBe(400);
   expect((await send("PUT", path, SERVICE, { externalOwner: EXTERNAL, plan: "pro" })).status).toBe(400);
 });
+
+it("lets only the trusted service recover the current owner association", async () => {
+  const path = `/admin/v1/accounts/${ACCOUNT}/external-owner`;
+  expect((await send("GET", path, token)).status).toBe(401);
+  expect((await send("GET", "/admin/v1/accounts/missing/external-owner", SERVICE)).status).toBe(404);
+  const empty = await send("GET", path, SERVICE);
+  expect(empty.headers.get("cache-control")).toBe("no-store");
+  expect(await empty.json()).toEqual({ accountId: ACCOUNT, externalOwner: null });
+  await send("PUT", path, SERVICE, { externalOwner: EXTERNAL });
+  expect(await (await send("GET", path, SERVICE)).json()).toEqual({ accountId: ACCOUNT, externalOwner: EXTERNAL });
+});

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -1,5 +1,6 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePublisher } from "../src/auth.js";
 import type { Env } from "../src/config.js";
 import { MAX_DOC_BYTES } from "../src/config.js";
 import { findOrCreateAccount, resolveAccountForIdentity } from "../src/db.js";
@@ -196,5 +197,80 @@ describe("service-only plan changes", () => {
     }
     expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan: "free" });
     expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "pro" }, hosts, ADMIN, "https://api.test")).status).toBe(200);
+  });
+});
+
+const snapshot = (plan: string, expiresAt: number | null, revision: number) =>
+  send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan, expiresAt, revision }, {}, ADMIN);
+const storedSnapshot = () => env.DB.prepare("SELECT plan, plan_expires_at AS expiresAt, plan_revision AS revision FROM accounts WHERE id = ?")
+  .bind(OWNER).first();
+
+describe("ordered and expiring account plans", () => {
+  it("applies newer snapshots, accepts identical retries, and refuses old or changed revisions", async () => {
+    const state = { plan: "pro", expiresAt: 123456789, revision: 2 };
+    expect(await (await snapshot(state.plan, state.expiresAt, state.revision)).json()).toEqual({ owner: OWNER, ...state });
+    expect(await (await snapshot(state.plan, state.expiresAt, state.revision)).json()).toEqual({ owner: OWNER, ...state });
+    expect((await snapshot("free", null, 1)).status).toBe(409);
+    expect((await snapshot("free", state.expiresAt, 2)).status).toBe(409);
+    expect((await snapshot("pro", null, 2)).status).toBe(409);
+    expect(await storedSnapshot()).toEqual(state);
+    expect((await snapshot("free", null, 3)).status).toBe(200);
+    expect((await send("PUT", "/admin/v1/accounts/missing/plan", { plan: "pro", expiresAt: null, revision: 1 }, {}, ADMIN)).status).toBe(404);
+  });
+
+  it("keeps the highest revision when two snapshots arrive concurrently", async () => {
+    const results = await Promise.all([snapshot("pro", null, 10), snapshot("free", 0, 11)]);
+    expect([200, 409]).toContain(results[0]!.status);
+    expect(results[1]!.status).toBe(200);
+    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: 0, revision: 11 });
+  });
+
+  it("rejects partial, extra, noninteger and unsafe snapshot fields without modifying the account", async () => {
+    for (const body of [
+      { plan: "pro", revision: 1 }, { plan: "pro", expiresAt: null },
+      ...[0, -1, 1.5, "2", Number.MAX_SAFE_INTEGER + 1, null].map((revision) => ({ plan: "pro", expiresAt: null, revision })),
+      ...[-1, 1.5, "2", Number.MAX_SAFE_INTEGER + 1].map((expiresAt) => ({ plan: "pro", expiresAt, revision: 1 })),
+      { plan: "pro", expiresAt: null, revision: 1, owner: OWNER },
+    ]) expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, body, {}, ADMIN)).status).toBe(400);
+    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: null, revision: 0 });
+  });
+
+  it("expires at the exact boundary in authentication and account status without changing the snapshot", async () => {
+    await snapshot("pro", 1000, 1);
+    for (const [at, plan] of [[999, "pro"], [1000, "free"], [1001, "free"]] as const) {
+      expect(await resolvePublisher(token, local(), { now: () => at })).toMatchObject({ ok: true, publisher: { plan } });
+      const clock = vi.spyOn(Date, "now").mockReturnValue(at);
+      try {
+        const status = await send("GET", "/api/v1/account");
+        expect(await status.json()).toMatchObject({ plan, limits: planLimits(local(), plan) });
+      } finally { clock.mockRestore(); }
+    }
+    expect(await storedSnapshot()).toEqual({ plan: "pro", expiresAt: 1000, revision: 1 });
+    await snapshot("pro", null, 2);
+    expect(await resolvePublisher(token, local(), { now: () => Number.MAX_SAFE_INTEGER })).toMatchObject({ ok: true, publisher: { plan: "pro" } });
+    await snapshot("pro", 0, 3);
+    expect(await resolvePublisher(token, local({ DEFAULT_PLAN: "trial", PLAN_LIMITS: JSON.stringify({ trial: { documents: 2, pushesPerDay: 3, htmlBytes: 1024 } }) }), { now: () => 1 }))
+      .toMatchObject({ ok: true, publisher: { plan: "trial" } });
+  });
+
+  it("preserves manual response shape and revision fence while clearing expiry", async () => {
+    await snapshot("pro", 0, 4);
+    expect(await (await setPlan("free")).json()).toEqual({ owner: OWNER, plan: "free" });
+    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: null, revision: 4 });
+    expect((await snapshot("pro", 0, 4)).status).toBe(409);
+    expect((await snapshot("pro", null, 5)).status).toBe(200);
+  });
+
+  it("preserves over-limit history, updating and unsharing when a snapshot expires", async () => {
+    await snapshot("pro", null, 1);
+    const docs: string[] = [];
+    for (let n = 0; n < 4; n++) docs.push((await (await create()).json<{ docId: string }>()).docId);
+    await snapshot("pro", 0, 2);
+    const listing = await send("GET", "/api/v1/docs");
+    expect(await listing.json()).toMatchObject({ docs: expect.arrayContaining(docs.map((docId) => expect.objectContaining({ docId }))) });
+    expect((await create()).status).toBe(402);
+    expect((await send("PUT", `/api/v1/docs/${docs[0]}`, { html: "still editable" })).status).toBe(200);
+    expect((await send("DELETE", `/api/v1/docs/${docs[1]}`)).status).toBe(204);
+    expect(await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(docs[1]).first()).toMatchObject({ deleted_at: expect.any(Number) });
   });
 });


### PR DESCRIPTION
Relates to Brevilabs/app-sites#447

## Why

A plan change currently lasts forever and a delayed service update can overwrite a newer decision. Trusted integrations also cannot recover a completed association after their own persistence fails.

## What

The service may attach an expiry and increasing revision to a plan update. Expiry applies on the next request while preserving account history. A service-authenticated association lookup lets a failed integration resume without retaining an external credential.

| Update | Result |
| --- | --- |
| Newer revision | Applies |
| Same revision and content | Safe retry |
| Older revision or conflicting content | Refused |
| Expired plan | Configured default limits; history remains |
| Existing manual plan request | Same response; clears expiry and preserves the revision fence |

## Non goal

Pricing, payment providers, external subscription policy, browser sessions, and plugin changes remain outside this generic API. No remote entitlement lookup is added to publishing requests.

## Screenshot

Not applicable: API and entitlement behavior only.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | D1 tests cover revision ordering, expiry, recovery, and retained document operations |
| A defect would fail CI or be obvious on first use | ✅ | Plan and account API tests run in CI |
| A revert fully restores prior state, including persisted data | ❌ | Old code ignores persisted expiry and revision fields |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Effective account limits and trusted service inputs change |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Additive plan fields, account columns, and association lookup |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Concurrent updates obey a persisted revision fence |
| No hot-path behavior lacks deterministic coverage | ✅ | Exact-boundary expiry and concurrent revision cases have D1 coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Account status and request limits expose the result immediately |

Review: inspect `handleAdmin` in `src/admin.ts`, `effectivePlan` in `src/plans.ts`, `resolveAccountToken` in `src/auth.ts`, `findLiveToken` in `src/db.ts`, `handleAccount` in `src/account.ts`, and migration `migrations/0008_plan_snapshots.sql` line by line; exercise Verification 2–4.

## Verification

1. Apply migration 0008 locally, configure distinct default/paid limits, and obtain an account token plus the service credential.
2. Send a future-expiring plan snapshot. Retry identical content successfully; send an older revision and conflicting equal revision and expect 409. Concurrent newer revisions must leave the highest revision effective.
3. At expiry, confirm account status and publishing use default limits. Existing documents remain listable, editable within effective byte/day limits, and removable. Try a manual plan update and confirm its old response shape; an older snapshot must still fail.
4. Read an account association using the service credential and confirm null before linking and the proven owner afterward. Confirm unknown accounts return 404 and publisher credentials cannot use this route. Malformed snapshot fields must fail without changing access.

## Note

Deploy migration 0008 before this Worker. Once timed snapshots are used, rollback must preserve expiry and revision enforcement; older code could otherwise restore expired access. The private service must commit its next revision before delivery.
