### PR TITLE
[Account linking] - Step 5: Offer one free published document

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ comments do not exist yet.
 - **List and unshare documents.** Deleting destroys the stored files and leaves
   a `410 Gone` tombstone. Copies already in a reader's browser cache cannot be
   recalled.
-- **Bound abuse.** Hosted free accounts get three live documents, six
+- **Bound abuse.** Hosted free accounts get one live document, six
   publishes/updates per UTC day, and 1 MiB HTML per document. The paid plan and
   paid Copilot licenses allow 500 documents, 100 pushes per day, and 10 MiB.
   All credentials share their account's allowance. Unsharing frees a document
@@ -153,7 +153,7 @@ explains the boundary.
 
 Choose your own account limits with `PLAN_LIMITS` and `DEFAULT_PLAN` in Worker
 vars; the checked-in values are the hosted free/paid policy. Without an override,
-the built-in map has one free plan: 3 documents, 6 pushes/day, and 1 MiB HTML.
+the built-in map has one free plan: 1 document, 6 pushes/day, and 1 MiB HTML.
 Billing is optional: [plan configuration and the admin API](docs/http-api.md#account-plans)
 let your own service change plans. Never expose the admin secret to clients.
 

--- a/docs/cost-at-scale.md
+++ b/docs/cost-at-scale.md
@@ -10,6 +10,9 @@ status: draft
 
 # openartifacts.ai - Business Feasibility - Cost at Scale
 
+> Historical pricing context: the paid-only publishing assumptions below predate
+> standalone free accounts. Current hosted limits are in [the HTTP API](http-api.md#quotas).
+
 Companion to [[Agent-First Docs - Product Positioning]]. That doc argues *why* the product should exist. This one asks a colder question: **what does it cost to serve, and does the cost curve stay sane from 1k to 100k to 1M users?** (Pricing was revised on 2026-07-25: publishing is paid, reading is free. See §8. Sections written against the earlier free-share plan are flagged where it matters.)
 
 Scope of the launch product being costed: **one-click sharing from Copilot for Obsidian. Push a local md/html file, get a public HTML page on the internet. No accounts for readers, no permissions, no comments.** Later phases (access control, comments, agent APIs) are costed as deltas.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -55,8 +55,8 @@ accept an account id to select whose documents to access; ownership is derived
 from the credential. The separate admin API and optional account-token upgrade
 link expose account ids for routing, not as publisher credentials.
 
-**Publishing requires a paid plan.** Both current license-server paid plans are
-entitled: `PLUS` subscriptions and the lifetime `BELIEVER` plan (sold as
+**License-key publishing requires a paid plan.** Both current license-server
+paid plans are entitled: `PLUS` subscriptions and the lifetime `BELIEVER` plan (sold as
 Supporter). An unknown or otherwise ineligible plan is refused with `401
 unauthorized` like every other auth failure, so only the human-readable
 `message` distinguishes it.
@@ -88,17 +88,17 @@ ceiling, and any of them can push a new version of, or unshare, a document
 another one created. Revoking a token changes nothing about which documents the
 account holds.
 
-**The two credentials never mix.** A key resolves to the Brevilabs account that
-holds it and a token to the OpenArtifacts account it was issued to; the two id
-spaces cannot collide, so neither can ever see the other's documents. A Copilot
-subscriber who wants the documents their plugin published presents the same
-license key the plugin does — this API accepts it from a terminal like any other
-caller.
+**Credential identities stay separate until explicitly linked.** A key resolves
+to its Brevilabs account and a token to its OpenArtifacts account. A trusted
+service may permanently associate the two after proving control of both; email
+matching alone cannot authorize this. Linked credentials see the joined history
+and their publishing limits count both owners. Token administration remains tied
+to the account that issued the token. Existing document URLs do not change.
 
 **Publishing follows the account's plan.** First approval uses the deployment's
 default plan. Every token shares its account's limits, and a plan change takes
 effect on the next request without signing in again. The hosted free plan has
-three live documents, six publishes/updates per UTC day, and 1 MiB HTML per doc.
+one live document, six publishes/updates per UTC day, and 1 MiB HTML per doc.
 Listing and unsharing never require available publishing quota.
 
 **Revocation is immediate.** A revoked token fails on its very next request,
@@ -586,7 +586,7 @@ Worker var `PLAN_LIMITS` is a JSON string mapping plan names to positive integer
 ceilings. HTML is measured in UTF-8 bytes and cannot exceed the 10 MiB safety bound:
 
 ```json
-{"free":{"documents":3,"pushesPerDay":6,"htmlBytes":1048576},"pro":{"documents":500,"pushesPerDay":100,"htmlBytes":10485760}}
+{"free":{"documents":1,"pushesPerDay":6,"htmlBytes":1048576},"pro":{"documents":500,"pushesPerDay":100,"htmlBytes":10485760}}
 ```
 
 `DEFAULT_PLAN` (default `free`) selects the plan for newly created accounts.
@@ -595,7 +595,7 @@ Apply `0005_account_plans.sql` before deploying this version, following the
 `free`; their tokens and documents remain valid. Unknown plans or malformed
 configuration fail closed for publishing, but do not block listing or unsharing.
 Absent or blank `PLAN_LIMITS` uses the built-in map with one `free` entry:
-3 documents, 6 pushes/day and 1 MiB HTML. `PLAN_LIMITS` replaces that map.
+1 document, 6 pushes/day and 1 MiB HTML. `PLAN_LIMITS` replaces that map.
 
 ### Change an account's plan
 
@@ -618,13 +618,14 @@ in a CLI, skill, public link, or this repository.
 ## Quotas
 
 Publishing limits follow the authenticated account, not the token, key, agent,
-or device. License-key and account-token identities remain separate.
+or device. Explicitly linked license-key and account-token owners share their
+collection and usage; linking does not grant a second allowance.
 
 | Limit | Hosted free account | Hosted paid account / paid license |
 | --- | --- | --- |
 | HTML per doc | 1 MiB | 10 MiB |
 | Pushes per UTC day | 6 | 100 |
-| Live docs held | 3 | 500 |
+| Live docs held | 1 | 500 |
 
 Account plan refusals use `402 limit_reached`. License-key refusals are unchanged:
 `413 too_large` for HTML size, `429 quota_exceeded` for document/daily limits.
@@ -726,7 +727,7 @@ These additive routes are served on the API host. They use no browser cookies.
 cannot access it. It returns `200` with `cache-control: no-store`:
 
 ```json
-{"accountId":"oa_…","plan":"free","limits":{"documents":3,"pushesPerDay":6,"htmlBytes":1048576},"usage":{"documents":1,"pushesToday":2},"externalLinked":false}
+{"accountId":"oa_…","plan":"free","limits":{"documents":1,"pushesPerDay":6,"htmlBytes":1048576},"usage":{"documents":1,"pushesToday":2},"externalLinked":false}
 ```
 
 Limits reflect the deployment configuration. Usage counts live documents and

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -55,9 +55,9 @@ accept an account id to select whose documents to access; ownership is derived
 from the credential. The separate admin API and optional account-token upgrade
 link expose account ids for routing, not as publisher credentials.
 
-**License-key publishing requires a paid plan.** Both current license-server
-paid plans are entitled: `PLUS` subscriptions and the lifetime `BELIEVER` plan (sold as
-Supporter). An unknown or otherwise ineligible plan is refused with `401
+**License-key publishing requires a paid plan.** Eligible `PLUS` subscriptions
+and `BELIEVER` accounts (sold as Supporter) can publish with a license key,
+subject to their hosted-access period. An unknown or otherwise ineligible plan is refused with `401
 unauthorized` like every other auth failure, so only the human-readable
 `message` distinguishes it.
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -13,7 +13,7 @@ having never made one — and see the same documents throughout.
 
 `docs.owner` is an opaque string. Nothing parses it, and every query only ever
 compares it for equality. Two things put a value there, and they are deliberately
-never mixed:
+stored with their original provenance:
 
 | Credential | Owner id | Where it comes from |
 | --- | --- | --- |
@@ -27,8 +27,8 @@ to the license server to be identified, handing this deployment's own secret to
 another service on every request.
 
 An account here holds an id, one verified email address, and the time it was
-created. That is the whole `accounts` table. One further thing about a person is
-stored, and it lives in `identities`: the provider's own permanent id for them,
+created, alongside its configured plan, expiry and revision. One further thing
+about a person is stored, and it lives in `identities`: the provider's own permanent id for them,
 which is what returns a later sign-in to the right account. Beyond those,
 nothing is read, requested or stored, so no name and no avatar.
 
@@ -269,6 +269,6 @@ and that is only acceptable while there is nothing on it for them to steal.
   documents would simply stop being reachable by anyone. Worth solving before
   there are accounts worth deleting.
 - **It does not decide what an account may do.** Entitlement is a separate
-  question, answered per operation — today by the license key's plan, next by
-  [#60](https://github.com/Brevilabs/OpenArtifacts/issues/60)'s plan config. An
-  account exists before it is allowed to do anything.
+  question, answered per operation by the license key's entitlement or the
+  local account's configured plan. Hosted OAuth accounts start with one free
+  published document; listing and unsharing remain available over the limit.

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -251,7 +251,7 @@ export async function createDoc(
     if (limits) {
       return limitReached(
         env, publisher, "documents",
-        `Your account can hold ${maxDocs} published documents. Unshare one to publish another.`,
+        `Your account can hold ${maxDocs} published ${maxDocs === 1 ? "document" : "documents"}. Unshare enough documents to get below this limit before publishing another.`,
       );
     }
     return errorResponse(

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -9,7 +9,7 @@ export interface PlanLimits {
 }
 
 const DEFAULT_PLANS: Record<string, PlanLimits> = {
-  free: { documents: 3, pushesPerDay: 6, htmlBytes: 1024 * 1024 },
+  free: { documents: 1, pushesPerDay: 6, htmlBytes: 1024 * 1024 },
 };
 
 /** Finite positive ceilings only; the HTML memory safety bound is never configurable. */

--- a/test/account-actions.test.ts
+++ b/test/account-actions.test.ts
@@ -53,7 +53,7 @@ it("reports account plan, limits, combined usage and association without reveali
   }
   const response = await send("GET", "/api/v1/account", token);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ accountId: ACCOUNT, plan: "free", limits: { documents: 3, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 2, pushesToday: 4 }, externalLinked: true });
+  expect(await response.json()).toEqual({ accountId: ACCOUNT, plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 2, pushesToday: 4 }, externalLinked: true });
   const other = await (await send("GET", "/api/v1/account", otherToken)).json();
   expect(other).toMatchObject({ accountId: OTHER, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
 });

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -55,7 +55,7 @@ describe("configured account plans", () => {
   });
 
   it("loads the agreed hosted values from wrangler, not a separate test copy", () => {
-    expect(planLimits(local(), "free")).toEqual({ documents: 3, pushesPerDay: 6, htmlBytes: 1048576 });
+    expect(planLimits(local(), "free")).toEqual({ documents: 1, pushesPerDay: 6, htmlBytes: 1048576 });
     expect(planLimits(local(), "pro")).toEqual({ documents: 500, pushesPerDay: 100, htmlBytes: 10485760 });
     for (const PLAN_LIMITS of [undefined, ""]) {
       expect(planLimits(local({ PLAN_LIMITS }), "free")).toEqual(planLimits(local(), "free"));
@@ -75,7 +75,7 @@ describe("configured account plans", () => {
     const other = await issue();
     const doc = await (await create()).json<{ docId: string }>();
     for (let i = 0; i < 5; i++) expect((await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "updated" }, {}, other)).status).toBe(200);
-    const rejected = await create();
+    const rejected = await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "one too many" });
     expect(rejected.status).toBe(402);
     expect(await error(rejected)).toMatchObject({ error: { limit: "pushesPerDay", plan: "free" } });
     expect(await usage()).toBe(6);

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -237,12 +237,10 @@ describe("free account document limit", () => {
     objects: (await env.DOCS.list()).objects.map((object) => object.key),
   });
 
-  it("allows three across tokens, rejects the fourth without writes, and isolates other accounts", async () => {
+  it("allows one across tokens, rejects the second without writes, and isolates other accounts", async () => {
     const first = await issueToken(ACCOUNT_A);
     const second = await issueToken(ACCOUNT_A);
-    for (const token of [first.token, second.token, first.token]) {
-      expect((await create(token)).status).toBe(201);
-    }
+    expect((await create(first.token)).status).toBe(201);
 
     const before = await storage();
     const refused = await create(second.token);
@@ -250,7 +248,7 @@ describe("free account document limit", () => {
     expect(await refused.json()).toEqual({
       error: {
         code: "limit_reached",
-        message: "Your account can hold 3 published documents. Unshare one to publish another.",
+        message: "Your account can hold 1 published document. Unshare enough documents to get below this limit before publishing another.",
         limit: "documents",
         plan: "free",
       },
@@ -263,7 +261,7 @@ describe("free account document limit", () => {
 
   it("does not reset document capacity when yesterday's push allowance rolls over", async () => {
     const { token } = await issueToken(ACCOUNT_A);
-    for (let i = 0; i < 3; i++) await publish(token, `Doc ${i}`);
+    await publish(token, "First");
     await env.DB.prepare("UPDATE push_quota SET day = '2000-01-01'").run();
     const before = await storage();
     expect((await create(token)).status).toBe(402);
@@ -273,8 +271,6 @@ describe("free account document limit", () => {
   it("keeps updates and public reads working at the limit, and unshare frees one slot", async () => {
     const { token } = await issueToken(ACCOUNT_A);
     const first = await publish(token, "First");
-    await publish(token, "Second");
-    await publish(token, "Third");
     expect((await send("PUT", `/api/v1/docs/${first.docId}`, token, { html: page("v2") })).status)
       .toBe(200);
     expect((await send("GET", `/d/${first.docId}`, null)).status).toBe(200);
@@ -285,28 +281,26 @@ describe("free account document limit", () => {
     expect((await create(token)).status).toBe(402);
   });
 
-  it("atomically gives concurrent tokens only the remaining slot", async () => {
+  it("atomically gives concurrent first creates from two tokens only one slot", async () => {
     const first = await issueToken(ACCOUNT_A);
     const second = await issueToken(ACCOUNT_A);
-    await publish(first.token, "First");
-    await publish(first.token, "Second");
     const replies = await Promise.all([create(first.token), create(second.token)]);
     expect(replies.map((response) => response.status).sort()).toEqual([201, 402]);
-    expect(await tokensSeeDoc(first.token)).toHaveLength(3);
-    expect((await env.DOCS.list()).objects).toHaveLength(3);
-    expect((await storage()).pushes).toMatchObject([{ pushes: 3 }]);
+    expect(await tokensSeeDoc(first.token)).toHaveLength(1);
+    expect((await env.DOCS.list()).objects).toHaveLength(1);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 1 }]);
   });
 
-  it("preserves existing over-cap documents and blocks creates until below the cap", async () => {
+  it("preserves three preexisting documents and requires all withdrawn before a new create", async () => {
     const { token } = await issueToken(ACCOUNT_A);
     const docs: PushResponse[] = [];
-    for (let i = 0; i < 4; i++) {
-      const response = await create(token, cap(4));
+    for (let i = 0; i < 3; i++) {
+      const response = await create(token, cap(3));
       expect(response.status).toBe(201);
       docs.push(await response.json<PushResponse>());
     }
     expect((await create(token)).status).toBe(402);
-    expect(await tokensSeeDoc(token)).toHaveLength(4);
+    expect(await tokensSeeDoc(token)).toHaveLength(3);
     for (const doc of docs) {
       expect((await send("GET", `/d/${doc.docId}`, null)).status).toBe(200);
     }
@@ -315,13 +309,19 @@ describe("free account document limit", () => {
     await send("DELETE", `/api/v1/docs/${docs[0]!.docId}`, token);
     expect((await create(token)).status).toBe(402);
     await send("DELETE", `/api/v1/docs/${docs[1]!.docId}`, token);
+    expect((await create(token)).status).toBe(402);
+    await send("DELETE", `/api/v1/docs/${docs[2]!.docId}`, token);
+    expect(await tokensSeeDoc(token)).toHaveLength(0);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 4 }]);
     expect((await create(token)).status).toBe(201);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 5 }]);
   });
 
   it("honors a self-hosted account cap without changing paid license limits", async () => {
     const { token } = await issueToken(ACCOUNT_A);
-    expect((await create(token, cap(1))).status).toBe(201);
-    expect((await create(token, cap(1))).status).toBe(402);
+    expect((await create(token, cap(2))).status).toBe(201);
+    expect((await create(token, cap(2))).status).toBe(201);
+    expect((await create(token, cap(2))).status).toBe(402);
     for (let i = 0; i < 4; i++) {
       expect((await create(LICENSE_KEY, cap(1))).status).toBe(201);
     }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -114,6 +114,6 @@
     "LEGACY_SERVING_HOST": "symposium.site",
     "RETIRED_API_HOST": "api.symposium.md",
     "DEFAULT_PLAN": "free",
-    "PLAN_LIMITS": "{\"free\":{\"documents\":3,\"pushesPerDay\":6,\"htmlBytes\":1048576},\"pro\":{\"documents\":500,\"pushesPerDay\":100,\"htmlBytes\":10485760}}"
+    "PLAN_LIMITS": "{\"free\":{\"documents\":1,\"pushesPerDay\":6,\"htmlBytes\":1048576},\"pro\":{\"documents\":500,\"pushesPerDay\":100,\"htmlBytes\":10485760}}"
   }
 }


### PR DESCRIPTION
Fixes Brevilabs/app-sites#468

## Why

The launch offers one free published document, but hosted configuration and the fallback plan still allow three. Existing accounts above the new limit must keep their documents and remain able to update or unshare them.

## What

Set the free document limit to one and align account examples and publishing guidance. Keep six daily publishes or updates and 1 MiB files, paid limits, and custom self-hosted plans unchanged. A new publication is refused until the account has room; unsharing frees a document slot without resetting daily usage.

## Non goal

Checkout, prices, deleting existing documents, a new preview implementation, or publishing the versioned CLI release.

## Screenshot

No visual interface changes. The document-limit error now says “Unshare enough documents to get below this limit before publishing another,” so accounts already above the limit are not told that removing one document is sufficient.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real D1/R2 tests cover first publication, concurrency, and preserved over-limit documents |
| A defect would fail CI or be obvious on first use | ✅ | Default and hosted limits are checked by account and publishing tests |
| A revert fully restores prior state, including persisted data | ✅ | No migration or document deletion |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing account and quota authorization is reused |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The advertised free publishing allowance changes from three to one |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing atomic quota reservation remains unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Multiple tokens, concurrent creates, updates, and unsharing are covered |
| No new dependency | ✅ | Dependencies are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A refused second publication gives the account limit |

Review: inspect `DEFAULT_PLANS` in `src/plans.ts`, `PLAN_LIMITS` in `wrangler.jsonc`, and the document-limit response in `createDoc` in `src/api/push.ts`. Exercise Verification 2–3.

## Verification

1. Use a fresh free account and publish one HTML file. Confirm the account reports one available document and the first publication succeeds.
2. Try a second publication, including concurrent requests and another token for the same account. Confirm only one live document is permitted. Update the existing document successfully.
3. Load an existing free account with three publications. List and update them, then unshare all three before creating another. Confirm previous URLs answer 410 and daily usage was not reset.
4. Use a custom self-hosted plan and a paid account. Confirm their configured limits still apply.
