### PR TITLE
[Account linking] - Step 6: Suspend publishers and withdraw documents

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -817,3 +817,22 @@ has no association, or `404` when the account is unknown. This read supports
 recovery when association succeeds but a trusted caller's subsequent local
 write fails. It does not require retaining a raw external credential or
 replaying a consumed handoff. Responses use `cache-control: no-store`.
+
+### Operator controls (trusted service only)
+
+On the configured API host, `PUT /admin/v1/publishers/:owner/suspension`
+accepts exactly `{"suspended":true}` or `{"suspended":false}` and returns
+`{owner,suspended}`. It uses the same service bearer credential as the account
+admin routes; an unset credential disables the route. A suspension covers the
+owner's joined identities, including later links; restoration clears the current
+joined scope. Suspended publishers retain read, list, token and unshare access.
+Publishing returns `403` with error code `publisher_suspended`. Foreign or
+withdrawn documents retain the existing `404` response. Writes rejected before
+version commit refund their daily reservation; earlier committed versions remain.
+
+`DELETE /admin/v1/docs/:docId` permanently withdraws a document and returns `204`
+after paginated object cleanup. Unknown IDs return `404`. Cleanup failure returns
+`500 internal`; the current and pinned URLs already return `410`, and repeating
+the DELETE retries cleanup. Tombstones are never erased. Publisher-facing DELETE
+behavior is unchanged. See [the operator runbook](operator-runbook.md) for target
+verification and secret handling.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,0 +1,48 @@
+# Publisher suspension and document removal
+
+Use the trusted service API on the configured API host. These operations require
+`ADMIN_API_KEY`; publisher tokens and license keys cannot call them. Never put a
+credential in a report, URL, issue, transcript, or committed script.
+
+1. Record the reported URL and reason privately. Verify the exact serving host,
+   document ID and any pinned version. Inspect suspicious content in an isolated
+   browser without signing in or following its links.
+2. Identify the publisher from the document's D1 `docs.owner` row using authorized
+   database access. Inspect `owner_links` for its joined identity. Do not infer
+   identity from email, page content, or the person submitting the report.
+3. Verify the deployment, document ID, owner and intended action before changing
+   anything. Suspension blocks future publishing; removal permanently withdraws
+   one document. Neither refunds a payment or changes a plan.
+
+Load the service secret into `ADMIN_API_KEY` through your normal secret manager.
+Set `API_ORIGIN` to the verified API origin and `OWNER` / `DOC_ID` to the exact
+verified targets. Disable shell tracing. The examples pass authorization through
+stdin rather than a process argument; do not capture curl input in logs.
+
+```sh
+printf 'header = "Authorization: Bearer %s"\n' "$ADMIN_API_KEY" |
+  curl --config - --fail-with-body -X PUT \
+    -H 'Content-Type: application/json' --data '{"suspended":true}' \
+    "$API_ORIGIN/admin/v1/publishers/$OWNER/suspension"
+
+printf 'header = "Authorization: Bearer %s"\n' "$ADMIN_API_KEY" |
+  curl --config - --fail-with-body -X DELETE \
+    "$API_ORIGIN/admin/v1/docs/$DOC_ID"
+```
+
+Suspension returns `{owner,suspended:true}`. It applies to both joined identities,
+including an identity linked later. Existing pages remain readable; publishers
+can still list and unshare, manage tokens, and inspect their account. New creates
+and updates return `403 publisher_suspended`; another owner's or withdrawn doc
+still returns `404`. A version committed before suspension remains published.
+To restore publishing after review, repeat the PUT with `{"suspended":false}`.
+This removes suspension records across the whole current joined identity.
+
+Removal returns `204` only after the document's R2 prefix is cleared. D1 is
+marked deleted first and its tombstone is permanent. If cleanup returns `500`,
+retry the same DELETE: the document is already withdrawn and the retry finishes
+removing leftover objects. An unknown ID returns `404`. Verify both the current
+URL and a previously published pinned URL return `410`, and verify the R2 prefix
+is empty after success. Record the target, outcome and verification privately.
+Removal cannot recall copies readers already saved. No shared edge cache is
+currently enabled; enabling one requires cache purge support before rollout.

--- a/migrations/0009_publisher_suspensions.sql
+++ b/migrations/0009_publisher_suspensions.sql
@@ -1,0 +1,4 @@
+CREATE TABLE publisher_suspensions (
+  owner TEXT PRIMARY KEY,
+  suspended_at INTEGER NOT NULL
+);

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,3 +1,4 @@
+import { operatorAction } from "./operator.js";
 import { consumeHandoff, stringField } from "./account.js";
 import { linkExternalOwner } from "./owners.js";
 import { parseBearerToken } from "./auth.js";
@@ -10,10 +11,12 @@ export const ADMIN_PREFIX = "/admin/v1";
 
 /** Trusted service API: account plans, ownership associations, and one-use account proofs. */
 export async function handleAdmin(request: Request, url: URL, env: Env): Promise<Response> {
+  const operator = request.method === "PUT" ? /^\/admin\/v1\/publishers\/([^/]+)\/suspension$/.exec(url.pathname)
+    : request.method === "DELETE" ? /^\/admin\/v1\/docs\/([^/]+)$/.exec(url.pathname) : null;
   const match = /^\/admin\/v1\/accounts\/([^/]+)\/(plan|external-owner)$/.exec(url.pathname);
   const consume = request.method === "POST" && url.pathname === "/admin/v1/handoffs/consume";
   const readOwner = request.method === "GET" && match?.[2] === "external-owner";
-  if (!env.ADMIN_API_KEY?.trim() || (!consume && !readOwner && (request.method !== "PUT" || !match))) {
+  if (!env.ADMIN_API_KEY?.trim() || (!operator && !consume && !readOwner && (request.method !== "PUT" || !match))) {
     return errorResponse("not_found", "No admin route.");
   }
   const token = parseBearerToken(request.headers.get("authorization"));
@@ -21,6 +24,11 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   const digest = (value: string) => crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   if (!token || !crypto.subtle.timingSafeEqual(await digest(token), await digest(env.ADMIN_API_KEY))) {
     return errorResponse("unauthorized", "Expected the admin bearer credential.", { "www-authenticate": "Bearer" });
+  }
+  if (operator) {
+    let target: string;
+    try { target = decodeURIComponent(operator[1]!); } catch { return errorResponse("bad_request", "Invalid target."); }
+    return await operatorAction(request, env, target, request.method === "PUT");
   }
   if (consume) return await consumeHandoff(request, env);
   let owner: string;

--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -55,7 +55,7 @@ export interface DeleteDeps {
  * can hold more than a page of versions — 100 pushes a day compounds — so this
  * pages rather than assuming one listing covers it.
  */
-async function deleteDocObjects(env: Env, docId: string, objectBatch: number): Promise<void> {
+export async function deleteDocObjects(env: Env, docId: string, objectBatch = OBJECT_BATCH): Promise<void> {
   const prefix = docObjectPrefix(docId);
   let cursor: string | undefined;
 

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -25,6 +25,7 @@ import { limitReached, planLimits, type PlanLimits } from "../plans.js";
 import type { Env } from "../config.js";
 import {
   deleteDocRow,
+  tombstoneEmptyDoc,
   deleteVersionRow,
   commitVersionMetadata,
   docIsDeleted,
@@ -190,7 +191,10 @@ async function storeVersion(
   }, owner);
 
   if (!committed) {
-    await env.DOCS.delete(key);
+    try { await env.DOCS.delete(key); } catch {
+      // Noncommit is known: cleanup failure must not spend quota or capacity.
+      console.error("Rejected version cleanup failed", { docId, version });
+    }
     return "rejected";
   }
 
@@ -293,7 +297,7 @@ export async function createDoc(
   if (await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now, publisher.owner) !== "stored") {
     const response = await rejectedPush(env, publisher.owner, docId);
     await refundDailyPush(env.DB, publisher.owner, day);
-    await deleteDocRow(env.DB, docId);
+    await tombstoneEmptyDoc(env.DB, docId, now);
     return response;
   }
   return pushed(env, requestUrl, docId, FIRST_VERSION, 201);

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -18,6 +18,7 @@
  * the failure may equally be the version insert *after* a successful write, and
  * a rollback there would strand the object it names.
  */
+import { publisherSuspended } from "../owners.js";
 import type { Publisher } from "../auth.js";
 import { MAX_DOCS_PER_PUBLISHER, MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "../config.js";
 import { limitReached, planLimits, type PlanLimits } from "../plans.js";
@@ -155,8 +156,8 @@ function planHtmlExceeded(env: Env, publisher: Publisher, limits: PlanLimits): R
  * writes cannot collide with another push and the object it writes is never
  * read back or rewritten.
  *
- * Returns false when a concurrent delete won the race and this version was
- * rolled back; see below.
+ * Rejects when deletion or suspension wins before insertion; a later deletion
+ * is compensated below. Suspension after insertion keeps the committed version.
  */
 async function storeVersion(
   env: Env,
@@ -165,7 +166,8 @@ async function storeVersion(
   html: string,
   title: string | null,
   atMs: number,
-): Promise<boolean> {
+  owner: string,
+): Promise<"stored" | "rejected"> {
   // The publisher's own bytes, unmodified. OpenArtifacts' additions go in when the
   // document is served, so a byline change — or a plan that removes one —
   // reaches documents already published. `size` is therefore the size of what
@@ -177,7 +179,7 @@ async function storeVersion(
     httpMetadata: { contentType: STORED_CONTENT_TYPE },
   });
 
-  await insertVersion(env.DB, {
+  const committed = await insertVersion(env.DB, {
     doc_id: docId,
     n: version,
     size: bytes.byteLength,
@@ -185,7 +187,12 @@ async function storeVersion(
     // nothing, which is how the doc's title survives a push that omits one.
     title,
     created_at: atMs,
-  });
+  }, owner);
+
+  if (!committed) {
+    await env.DOCS.delete(key);
+    return "rejected";
+  }
 
   // A delete that lands between the version reservation and this write has
   // already finished its prefix scan, so it never saw these bytes: unshare
@@ -198,10 +205,19 @@ async function storeVersion(
   if (await docIsDeleted(env.DB, docId)) {
     await env.DOCS.delete(key);
     await deleteVersionRow(env.DB, docId, version);
-    return false;
+    return "rejected";
   }
 
-  return true;
+  return "stored";
+}
+
+function suspended(): Response {
+  return errorResponse("publisher_suspended", "Publishing is suspended. Contact support.");
+}
+
+async function rejectedPush(env: Env, owner: string, docId: string): Promise<Response> {
+  if (!(await ownsLiveDoc(env.DB, docId, owner))) return docNotFound(docId);
+  return await publisherSuspended(env.DB, owner) ? suspended() : docNotFound(docId);
 }
 
 function pushed(env: Env, requestUrl: URL, docId: string, version: number, status: number) {
@@ -223,6 +239,8 @@ export async function createDoc(
   if (limits && parsed.body.htmlBytes > limits.htmlBytes) {
     return planHtmlExceeded(env, publisher, limits);
   }
+
+  if (await publisherSuspended(env.DB, publisher.owner)) return suspended();
 
   const maxDocs = limits?.documents ?? MAX_DOCS_PER_PUBLISHER;
   const now = Date.now();
@@ -248,6 +266,7 @@ export async function createDoc(
     maxDocs,
   );
   if (!inserted) {
+    if (await publisherSuspended(env.DB, publisher.owner)) return suspended();
     if (limits) {
       return limitReached(
         env, publisher, "documents",
@@ -271,9 +290,11 @@ export async function createDoc(
   // while its first version is still being written. Same answer as an update
   // that loses that race — the doc is gone, and the push is given back rather
   // than spent on a url that would serve 410.
-  if (!(await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now))) {
+  if (await storeVersion(env, docId, FIRST_VERSION, parsed.body.html, title, now, publisher.owner) !== "stored") {
+    const response = await rejectedPush(env, publisher.owner, docId);
     await refundDailyPush(env.DB, publisher.owner, day);
-    return docNotFound(docId);
+    await deleteDocRow(env.DB, docId);
+    return response;
   }
   return pushed(env, requestUrl, docId, FIRST_VERSION, 201);
 }
@@ -299,6 +320,7 @@ export async function updateDoc(
   if (!(await ownsLiveDoc(env.DB, docId, publisher.owner))) {
     return docNotFound(docId);
   }
+  if (await publisherSuspended(env.DB, publisher.owner)) return suspended();
   if (limits && parsed.body.htmlBytes > limits.htmlBytes) {
     return planHtmlExceeded(env, publisher, limits);
   }
@@ -315,7 +337,7 @@ export async function updateDoc(
   const version = await reserveNextVersion(env.DB, docId, publisher.owner);
   if (version === null) {
     await refundDailyPush(env.DB, publisher.owner, day);
-    return docNotFound(docId);
+    return await rejectedPush(env, publisher.owner, docId);
   }
 
   // Absent title keeps the doc's current one; a blank one resets it, same as on
@@ -326,9 +348,9 @@ export async function updateDoc(
   // The doc can still be deleted while this version is being written. Answering
   // 200 would hand back a url that serves 410, so a lost race reads as what it
   // is from the caller's side: the doc is gone.
-  if (!(await storeVersion(env, docId, version, parsed.body.html, title, now))) {
+  if (await storeVersion(env, docId, version, parsed.body.html, title, now, publisher.owner) !== "stored") {
     await refundDailyPush(env.DB, publisher.owner, day);
-    return docNotFound(docId);
+    return await rejectedPush(env, publisher.owner, docId);
   }
 
   // Only now: the title and timestamp in "my docs" describe what the public url

--- a/src/db.ts
+++ b/src/db.ts
@@ -257,6 +257,12 @@ export async function deleteDocRow(db: D1Database, docId: string): Promise<void>
   await db.prepare("DELETE FROM docs WHERE id = ? AND deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM versions WHERE doc_id = docs.id)").bind(docId).run();
 }
 
+/** Keep a cleanup target for a rejected create without occupying live capacity. */
+export async function tombstoneEmptyDoc(db: D1Database, docId: string, atMs: number): Promise<void> {
+  await db.prepare(`UPDATE docs SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL
+    AND NOT EXISTS (SELECT 1 FROM versions WHERE doc_id = docs.id)`).bind(atMs, docId).run();
+}
+
 /** Whether a doc has been soft-deleted since a push started writing to it. */
 export async function docIsDeleted(db: D1Database, docId: string): Promise<boolean> {
   const row = await db

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,7 +5,7 @@
  * every row here is reconstructible from it, so a lost D1 is a rebuild rather
  * than a data loss. Queries land here as the phase that needs them arrives.
  */
-import { OWNER_SCOPE_SQL } from "./owners.js";
+import { OWNER_SCOPE_SQL, UNSUSPENDED_SQL } from "./owners.js";
 
 /** Publisher row, which doubles as the license-validation cache (phase 2). */
 export interface PublisherRow {
@@ -227,7 +227,7 @@ export async function insertDocWithinQuota(
       `${OWNER_SCOPE_SQL}
        INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
        SELECT ?, ?, ?, ?, ?, ?
-        WHERE (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) < ?`,
+        WHERE (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) < ? AND ${UNSUSPENDED_SQL}`,
     )
     .bind(
       doc.owner,
@@ -247,14 +247,14 @@ export async function insertDocWithinQuota(
 
 /**
  * Hard-delete a `docs` row. Only for rolling back a create that failed after the
- * row existed: the id was minted this request and nothing else can have seen it,
- * so there are no versions, no objects, and no url to leave behind.
+ * row existed. Only an empty live placeholder can be removed: a concurrent
+ * writer or takedown may already have made the row permanent.
  *
  * Unsharing a *published* doc is a soft delete (`softDeleteDoc`) — that row has
  * to survive so its url keeps answering 410 rather than pretending it never was.
  */
 export async function deleteDocRow(db: D1Database, docId: string): Promise<void> {
-  await db.prepare("DELETE FROM docs WHERE id = ?").bind(docId).run();
+  await db.prepare("DELETE FROM docs WHERE id = ? AND deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM versions WHERE doc_id = docs.id)").bind(docId).run();
 }
 
 /** Whether a doc has been soft-deleted since a push started writing to it. */
@@ -311,6 +311,7 @@ export async function reserveNextVersion(
        UPDATE docs
           SET latest_version = latest_version + 1
         WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL
+          AND ${UNSUSPENDED_SQL}
         RETURNING latest_version`,
     )
     .bind(owner, owner, docId)
@@ -382,11 +383,14 @@ export async function commitVersionMetadata(
  * ordering chooses to allow: it costs storage, where a row with no object would
  * be a doc that 500s.
  */
-export async function insertVersion(db: D1Database, version: VersionRow): Promise<void> {
-  await db
-    .prepare("INSERT INTO versions (doc_id, n, size, title, created_at) VALUES (?, ?, ?, ?, ?)")
-    .bind(version.doc_id, version.n, version.size, version.title, version.created_at)
-    .run();
+export async function insertVersion(db: D1Database, version: VersionRow, owner: string): Promise<boolean> {
+  const result = await db.prepare(`${OWNER_SCOPE_SQL}
+    INSERT INTO versions (doc_id, n, size, title, created_at)
+    SELECT ?, ?, ?, ?, ? FROM docs WHERE id = ? AND owner IN (SELECT owner FROM owner_scope)
+      AND deleted_at IS NULL AND ${UNSUSPENDED_SQL}`)
+    .bind(owner, owner, version.doc_id, version.n, version.size,
+      version.title, version.created_at, version.doc_id).run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 /** What the serving path needs to know about a doc, in one read. */

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@
  * The code is stable for clients to match; the message stays free to change.
  */
 export type ErrorCode =
+  | "publisher_suspended"
   | "conflict"
   | "bad_request"
   | "unauthorized"
@@ -23,6 +24,7 @@ export type ErrorCode =
   | "access_denied";
 
 const ERROR_STATUS: Record<ErrorCode, number> = {
+  publisher_suspended: 403,
   conflict: 409,
   bad_request: 400,
   unauthorized: 401,

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -1,0 +1,42 @@
+import type { Env } from "./config.js";
+import { deleteDocObjects } from "./api/manage.js";
+import { docNotFound, errorResponse } from "./errors.js";
+import { isDocId } from "./ids.js";
+import { OWNER_SCOPE_SQL } from "./owners.js";
+import { readBodyWithin } from "./quota.js";
+
+/** Caller must authenticate the service credential before dispatching here. */
+export async function operatorAction(request: Request, env: Env, target: string, suspension: boolean): Promise<Response> {
+  if (!suspension) return await removeDocument(env, target);
+  if (!target || target.length > 256 || /[\u0000-\u0020\u007f]/.test(target) ||
+    (target.startsWith("oa_") && !/^oa_[0-9abcdefghjkmnpqrstvwxyz]{26}$/.test(target))) {
+    return errorResponse("bad_request", "Invalid publisher identity.");
+  }
+  const raw = await readBodyWithin(request, 1024);
+  let body: unknown;
+  try { body = raw && JSON.parse(new TextDecoder().decode(raw)); } catch { body = null; }
+  if (!body || typeof body !== "object" || Array.isArray(body) ||
+    Object.keys(body).length !== 1 || !("suspended" in body) || typeof body.suspended !== "boolean") {
+    return errorResponse("bad_request", "Expected only suspended, a boolean.");
+  }
+  if (body.suspended) {
+    await env.DB.prepare(`INSERT INTO publisher_suspensions (owner, suspended_at) VALUES (?, ?)
+      ON CONFLICT(owner) DO NOTHING`).bind(target, Date.now()).run();
+  } else {
+    await env.DB.prepare(`${OWNER_SCOPE_SQL} DELETE FROM publisher_suspensions
+      WHERE owner IN (SELECT owner FROM owner_scope)`).bind(target, target).run();
+  }
+  return Response.json({ owner: target, suspended: body.suspended }, { headers: { "cache-control": "no-store" } });
+}
+
+/** Tombstones are permanent; retries finish any interrupted prefix cleanup. */
+export async function removeDocument(env: Env, docId: string, objectBatch?: number): Promise<Response> {
+  if (!isDocId(docId)) return docNotFound(docId);
+  const row = await env.DB.prepare(`UPDATE docs SET deleted_at = COALESCE(deleted_at, ?)
+    WHERE id = ? RETURNING id`).bind(Date.now(), docId).first();
+  if (!row) return docNotFound(docId);
+  try { await deleteDocObjects(env, docId, objectBatch); } catch {
+    return errorResponse("internal", "Document withdrawn; object cleanup failed. Retry this removal.");
+  }
+  return new Response(null, { status: 204 });
+}

--- a/src/owners.ts
+++ b/src/owners.ts
@@ -17,6 +17,15 @@ export const OWNER_SCOPE_SQL = `WITH canonical AS (
   SELECT external_owner FROM owner_links JOIN canonical ON account_id = id
 )`;
 
+export const UNSUSPENDED_SQL = `NOT EXISTS (
+  SELECT 1 FROM publisher_suspensions WHERE owner IN (SELECT owner FROM owner_scope)
+)`;
+
+export async function publisherSuspended(db: D1Database, owner: string): Promise<boolean> {
+  return await db.prepare(`${OWNER_SCOPE_SQL} SELECT 1 WHERE NOT (${UNSUSPENDED_SQL})`)
+    .bind(owner, owner).first() !== null;
+}
+
 export type OwnerLinkResult = "linked" | "conflict" | "invalid" | "account_not_found";
 
 /**

--- a/test/operator.test.ts
+++ b/test/operator.test.ts
@@ -1,7 +1,7 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, expect, it } from "vitest";
 import type { Env } from "../src/config.js";
-import { deleteDocRow, insertDocWithinQuota, insertVersion, reserveNextVersion } from "../src/db.js";
+import { deleteDocRow, insertDocWithinQuota, insertVersion, reserveNextVersion, tombstoneEmptyDoc } from "../src/db.js";
 import { sha256Hex } from "../src/hash.js";
 import { newApiToken, newDocId, newTokenId } from "../src/ids.js";
 import { linkExternalOwner, publisherSuspended } from "../src/owners.js";
@@ -90,7 +90,7 @@ it("rolls back an empty create and refunds its exact daily reservation when susp
   await env.DB.exec(`CREATE TRIGGER suspend_create AFTER INSERT ON docs BEGIN INSERT INTO publisher_suspensions VALUES (NEW.owner, 1); END`);
   const result = await push(); expect(result.status).toBe(403);
   expect(await result.json()).toMatchObject({ error: { code: "publisher_suspended" } });
-  expect(await env.DB.prepare("SELECT id FROM docs").first()).toBeNull();
+  expect(await env.DB.prepare("SELECT deleted_at FROM docs").first()).toMatchObject({ deleted_at: expect.any(Number) });
   expect(await quota()).toBe(0);
   expect((await env.DOCS.list()).objects).toHaveLength(0);
 });
@@ -141,6 +141,7 @@ it("compensates for a takedown after version insertion without deleting the tomb
 
 it("never rolls back a live placeholder that another writer has populated", async () => {
   const id = await published(); await deleteDocRow(env.DB, id);
+  await tombstoneEmptyDoc(env.DB, id, Date.now());
   expect((await send("GET", `/d/${id}`)).status).toBe(200);
 });
 
@@ -149,7 +150,8 @@ it("withdraws before cleanup failure, returns retryable 500, and removes all R2 
   for (let n = 2; n <= 5; n++) await env.DOCS.put(`docs/${id}/v${n}.html`, "orphan or old version");
   const broken = new Proxy(env.DOCS, { get(target, prop, receiver) {
     if (prop === "delete") return () => Promise.reject(new Error("synthetic R2 failure"));
-    return Reflect.get(target, prop, receiver);
+    const value: unknown = Reflect.get(target, prop, receiver);
+    return typeof value === "function" ? value.bind(target) : value;
   } });
   expect((await send("DELETE", `/admin/v1/docs/${id}`, token)).status).toBe(401);
   expect((await send("DELETE", `/admin/v1/docs/${id}`, SERVICE, undefined, { DOCS: broken })).status).toBe(500);
@@ -161,4 +163,47 @@ it("withdraws before cleanup failure, returns retryable 500, and removes all R2 
   expect(await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(id).first()).toEqual(tombstone);
   expect((await send("DELETE", `/admin/v1/docs/${newDocId()}`)).status).toBe(404);
   expect((await send("DELETE", "/admin/v1/docs/invalid")).status).toBe(404);
+});
+
+it("releases free capacity and quota after rejected-create cleanup fails, retaining a cleanup tombstone", async () => {
+  await env.DB.prepare("UPDATE accounts SET plan = 'free' WHERE id = ?").bind(ACCOUNT).run();
+  await env.DB.exec(`CREATE TRIGGER suspend_create AFTER INSERT ON docs BEGIN INSERT INTO publisher_suspensions VALUES (NEW.owner, 1); END`);
+  const broken = new Proxy(env.DOCS, { get(target, prop, receiver) {
+    if (prop === "delete") return () => Promise.reject(new Error("synthetic R2 failure"));
+    const value: unknown = Reflect.get(target, prop, receiver);
+    return typeof value === "function" ? value.bind(target) : value;
+  } });
+  const result = await send("POST", "/api/v1/docs", token, { html: "<html>Rejected</html>" }, { DOCS: broken });
+  expect(result.status).toBe(403);
+  expect(await quota()).toBe(0);
+  const row = await env.DB.prepare("SELECT id, deleted_at FROM docs").first<{ id: string; deleted_at: number }>();
+  expect(row?.deleted_at).toEqual(expect.any(Number));
+  expect((await env.DOCS.list()).objects).toHaveLength(1);
+  expect((await send("GET", `/d/${row!.id}`)).status).toBe(410);
+  await env.DB.exec("DROP TRIGGER suspend_create");
+  await suspend(ACCOUNT, false);
+  const replacement = await published();
+  expect(replacement).not.toBe(row!.id);
+  expect(await quota()).toBe(1);
+  expect((await send("DELETE", `/admin/v1/docs/${row!.id}`)).status).toBe(204);
+  expect((await env.DOCS.list({ prefix: `docs/${row!.id}/` })).objects).toHaveLength(0);
+  expect(await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(row!.id).first()).toEqual({ deleted_at: row!.deleted_at });
+});
+
+it("refunds a rejected update despite cleanup failure and continues serving its previous version", async () => {
+  const id = await published();
+  await env.DB.exec(`CREATE TRIGGER suspend_update AFTER UPDATE OF latest_version ON docs BEGIN INSERT INTO publisher_suspensions VALUES (NEW.owner, 1); END`);
+  const broken = new Proxy(env.DOCS, { get(target, prop, receiver) {
+    if (prop === "delete") return () => Promise.reject(new Error("synthetic R2 failure"));
+    const value: unknown = Reflect.get(target, prop, receiver);
+    return typeof value === "function" ? value.bind(target) : value;
+  } });
+  expect((await send("PUT", `/api/v1/docs/${id}`, token, { html: "<html>Rejected</html>" }, { DOCS: broken })).status).toBe(403);
+  expect(await quota()).toBe(1);
+  expect((await env.DOCS.list({ prefix: `docs/${id}/` })).objects).toHaveLength(2);
+  expect((await send("GET", `/d/${id}`)).status).toBe(200);
+  expect((await send("GET", `/d/${id}/v2`)).status).toBe(404);
+  expect(await env.DB.prepare("SELECT n FROM versions WHERE doc_id = ?").bind(id).all()).toMatchObject({ results: [{ n: 1 }] });
+  expect((await send("DELETE", `/admin/v1/docs/${id}`)).status).toBe(204);
+  expect((await env.DOCS.list({ prefix: `docs/${id}/` })).objects).toHaveLength(0);
 });

--- a/test/operator.test.ts
+++ b/test/operator.test.ts
@@ -1,0 +1,164 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import { deleteDocRow, insertDocWithinQuota, insertVersion, reserveNextVersion } from "../src/db.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newDocId, newTokenId } from "../src/ids.js";
+import { linkExternalOwner, publisherSuspended } from "../src/owners.js";
+import { removeDocument } from "../src/operator.js";
+import worker from "../src/index.js";
+const ACCOUNT = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const EXTERNAL = "external-a";
+const SERVICE = "operator-service-fixture";
+let token: string;
+beforeEach(async () => {
+  await env.DB.prepare("INSERT INTO accounts (id, email, created_at, plan) VALUES (?, 'a@example.test', 0, 'pro')").bind(ACCOUNT).run();
+  token = newApiToken();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+    .bind(newTokenId(), await sha256Hex(token), ACCOUNT).run();
+  await env.DB.prepare("INSERT INTO publishers (key_hash, plan, owner, validated_at) VALUES (?, 'plus', ?, ?)")
+    .bind(await sha256Hex("license-fixture"), EXTERNAL, Date.now()).run();
+});
+async function send(method: string, path: string, credential = SERVICE, body?: unknown, overrides: Partial<Env> = {}) {
+  const ctx = createExecutionContext();
+  const result = await worker.fetch(new Request(`https://api.local.test${path}`, {
+    method, headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), { ...env, ADMIN_API_KEY: SERVICE, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "", ...overrides }, ctx);
+  await waitOnExecutionContext(ctx);
+  const bytes = await result.arrayBuffer();
+  return new Response(result.status === 204 ? null : bytes, { status: result.status, headers: result.headers });
+}
+const suspend = (owner = ACCOUNT, suspended = true) => send("PUT", `/admin/v1/publishers/${owner}/suspension`, SERVICE, { suspended });
+const push = (id?: string, credential = token) => send(id ? "PUT" : "POST", `/api/v1/docs${id ? `/${id}` : ""}`, credential, { title: "Kept", html: "<html><body>Kept</body></html>" });
+async function published(credential = token) {
+  const result = await push(undefined, credential); expect(result.status).toBe(201);
+  return (await result.json() as { docId: string }).docId;
+}
+const quota = async () => (await env.DB.prepare("SELECT COALESCE(SUM(pushes), 0) AS n FROM push_quota").first<{ n: number }>())!.n;
+const doc = (id = newDocId()) => ({ id, owner: ACCOUNT, title: "Kept", created_at: 0, updated_at: 0 });
+
+it("requires the service credential on the API host and validates exact inputs", async () => {
+  const path = `/admin/v1/publishers/${ACCOUNT}/suspension`;
+  for (const credential of [token, "license-fixture", "bad"]) expect((await send("PUT", path, credential, { suspended: true })).status).toBe(401);
+  expect((await send("PUT", path, SERVICE, { suspended: true }, { ADMIN_API_KEY: "" })).status).toBe(404);
+  expect((await send("PUT", path, SERVICE, { suspended: true }, { API_HOST: "different.test" })).status).toBe(404);
+  expect((await send("PUT", path, SERVICE, { suspended: true }, { SERVING_HOST: "api.local.test" })).status).toBe(404);
+  expect((await send("PUT", path, SERVICE, { suspended: true }, { RETIRED_API_HOST: "api.local.test" })).status).toBe(410);
+  for (const body of [null, [], {}, { suspended: "true" }, { suspended: true, owner: ACCOUNT }, { suspended: "x".repeat(1025) }]) {
+    expect((await send("PUT", path, SERVICE, body)).status).toBe(400);
+  }
+  for (const owner of ["%00", "%20x", "oa_bad", "%E0%A4%A", "x".repeat(257)]) expect((await suspend(owner)).status).toBe(400);
+  expect((await send("POST", path, SERVICE, { suspended: true })).status).toBe(404);
+  expect(await publisherSuspended(env.DB, ACCOUNT)).toBe(false);
+});
+
+it("inherits suspensions across future links and clears the whole joined scope without changing credentials or plan", async () => {
+  const id = await published();
+  const externalId = await published("license-fixture");
+  expect((await suspend(EXTERNAL)).status).toBe(200);
+  expect(await publisherSuspended(env.DB, ACCOUNT)).toBe(false);
+  expect(await linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 1)).toBe("linked");
+  await suspend(ACCOUNT);
+  for (const credential of [token, "license-fixture"]) {
+    expect((await push(undefined, credential)).status).toBe(403);
+    expect((await push(id, credential)).status).toBe(403);
+    expect((await push(newDocId(), credential)).status).toBe(404);
+    expect((await send("GET", "/api/v1/docs", credential)).status).toBe(200);
+  }
+  expect(await quota()).toBe(2);
+  expect((await send("GET", "/api/v1/account", token)).status).toBe(200);
+  expect((await send("GET", "/api/v1/tokens", token)).status).toBe(200);
+  expect((await send("DELETE", `/api/v1/docs/${externalId}`, token)).status).toBe(204);
+  expect((await push(externalId)).status).toBe(404);
+  expect((await suspend(EXTERNAL, false)).status).toBe(200);
+  expect(await publisherSuspended(env.DB, ACCOUNT)).toBe(false);
+  expect(await publisherSuspended(env.DB, EXTERNAL)).toBe(false);
+  expect((await push(id, "license-fixture")).status).toBe(200);
+  expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(ACCOUNT).first()).toEqual({ plan: "pro" });
+});
+
+it("rejects create and version reservations atomically without consuming a slot or version", async () => {
+  const row = doc(); expect(await insertDocWithinQuota(env.DB, row, 500)).toBe(true);
+  await suspend();
+  expect(await insertDocWithinQuota(env.DB, doc(), 500)).toBe(false);
+  expect(await reserveNextVersion(env.DB, row.id, ACCOUNT)).toBeNull();
+  expect(await env.DB.prepare("SELECT latest_version FROM docs WHERE id = ?").bind(row.id).first()).toEqual({ latest_version: 1 });
+});
+
+it("rolls back an empty create and refunds its exact daily reservation when suspension follows reservation", async () => {
+  await env.DB.exec(`CREATE TRIGGER suspend_create AFTER INSERT ON docs BEGIN INSERT INTO publisher_suspensions VALUES (NEW.owner, 1); END`);
+  const result = await push(); expect(result.status).toBe(403);
+  expect(await result.json()).toMatchObject({ error: { code: "publisher_suspended" } });
+  expect(await env.DB.prepare("SELECT id FROM docs").first()).toBeNull();
+  expect(await quota()).toBe(0);
+  expect((await env.DOCS.list()).objects).toHaveLength(0);
+});
+
+it("preserves the previous bytes and metadata when suspension follows an update reservation", async () => {
+  const id = await published();
+  await env.DB.exec(`CREATE TRIGGER suspend_update AFTER UPDATE OF latest_version ON docs BEGIN INSERT INTO publisher_suspensions VALUES (NEW.owner, 1); END`);
+  expect((await push(id)).status).toBe(403);
+  expect(await quota()).toBe(1);
+  expect((await env.DOCS.list({ prefix: `docs/${id}/` })).objects.map(o => o.key)).toEqual([`docs/${id}/v1.html`]);
+  expect(await env.DB.prepare("SELECT n, title FROM versions WHERE doc_id = ?").bind(id).all()).toMatchObject({ results: [{ n: 1, title: "Kept" }] });
+  expect((await send("GET", `/d/${id}`)).status).toBe(200);
+});
+
+it("checks the current joined scope at version commit, including a link after reservation", async () => {
+  const row = doc(); await insertDocWithinQuota(env.DB, row, 500);
+  await suspend(EXTERNAL);
+  await linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 1);
+  expect(await insertVersion(env.DB, { doc_id: row.id, n: 1, size: 1, title: null, created_at: 0 }, ACCOUNT)).toBe(false);
+  expect(await env.DB.prepare("SELECT n FROM versions").first()).toBeNull();
+});
+
+it("keeps a version committed before suspension rather than deleting it afterwards", async () => {
+  await env.DB.exec(`CREATE TRIGGER suspend_committed AFTER INSERT ON versions BEGIN INSERT INTO publisher_suspensions SELECT owner, 1 FROM docs WHERE id = NEW.doc_id; END`);
+  const id = await published();
+  expect(await publisherSuspended(env.DB, ACCOUNT)).toBe(true);
+  expect((await send("GET", `/d/${id}/v1`)).status).toBe(200);
+});
+
+it("preserves a tombstone created before the first version commit and cleans its late object", async () => {
+  await env.DB.exec(`CREATE TRIGGER remove_reserved AFTER INSERT ON docs BEGIN UPDATE docs SET deleted_at = 1 WHERE id = NEW.id; END`);
+  expect((await push()).status).toBe(404);
+  const row = await env.DB.prepare("SELECT id, deleted_at FROM docs").first<{ id: string; deleted_at: number }>();
+  expect(row?.deleted_at).toBe(1);
+  expect((await send("GET", `/d/${row!.id}`)).status).toBe(410);
+  expect(await quota()).toBe(0);
+  expect((await env.DOCS.list()).objects).toHaveLength(0);
+});
+
+it("compensates for a takedown after version insertion without deleting the tombstone", async () => {
+  await env.DB.exec(`CREATE TRIGGER remove_committed AFTER INSERT ON versions BEGIN UPDATE docs SET deleted_at = 1 WHERE id = NEW.doc_id; END`);
+  expect((await push()).status).toBe(404);
+  expect(await quota()).toBe(0);
+  expect((await env.DOCS.list()).objects).toHaveLength(0);
+  expect(await env.DB.prepare("SELECT n FROM versions").first()).toBeNull();
+  expect(await env.DB.prepare("SELECT deleted_at FROM docs").first()).toEqual({ deleted_at: 1 });
+});
+
+it("never rolls back a live placeholder that another writer has populated", async () => {
+  const id = await published(); await deleteDocRow(env.DB, id);
+  expect((await send("GET", `/d/${id}`)).status).toBe(200);
+});
+
+it("withdraws before cleanup failure, returns retryable 500, and removes all R2 pages on retry", async () => {
+  const id = await published();
+  for (let n = 2; n <= 5; n++) await env.DOCS.put(`docs/${id}/v${n}.html`, "orphan or old version");
+  const broken = new Proxy(env.DOCS, { get(target, prop, receiver) {
+    if (prop === "delete") return () => Promise.reject(new Error("synthetic R2 failure"));
+    return Reflect.get(target, prop, receiver);
+  } });
+  expect((await send("DELETE", `/admin/v1/docs/${id}`, token)).status).toBe(401);
+  expect((await send("DELETE", `/admin/v1/docs/${id}`, SERVICE, undefined, { DOCS: broken })).status).toBe(500);
+  const tombstone = await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(id).first();
+  for (const suffix of ["", "/v1"]) expect((await send("GET", `/d/${id}${suffix}`)).status).toBe(410);
+  expect((await removeDocument(env, id, 2)).status).toBe(204);
+  expect((await env.DOCS.list({ prefix: `docs/${id}/` })).objects).toHaveLength(0);
+  expect((await send("DELETE", `/admin/v1/docs/${id}`)).status).toBe(204);
+  expect(await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(id).first()).toEqual(tombstone);
+  expect((await send("DELETE", `/admin/v1/docs/${newDocId()}`)).status).toBe(404);
+  expect((await send("DELETE", "/admin/v1/docs/invalid")).status).toBe(404);
+});

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -845,7 +845,8 @@ describe("races the review found", () => {
                       const result = await bt.run();
                       if (!raced) {
                         raced = true;
-                        const docId = String(args[0]);
+                        // The first two bindings resolve the joined publisher scope.
+                        const docId = String(args[2]);
                         await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?")
                           .bind(Date.now(), docId)
                           .run();


### PR DESCRIPTION
Fixes Brevilabs/app-sites#470

## Why

Operators need to stop abusive publication and remove a reported document before free publishing is promoted. Setting an account to the free plan does not stop updates, and withdrawing a document must keep its URL permanently unavailable.

## What

Add service-authenticated publisher suspension and document takedown. Suspension applies across linked publishing identities while preserving listing and unsharing. Resuming restores the account's normal plan limits. A takedown marks the document withdrawn before removing its stored versions; cleanup can be retried without making the document readable again.

## Non goal

A moderation dashboard, automated scanning, bulk deletion, reader identity changes, or enabling edge caching.

## Screenshot

Not applicable: operator API and runbook only.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real D1/R2 tests cover joined identities, publication races, and cleanup retries |
| A defect would fail CI or be obvious on first use | ✅ | Operator and publishing regressions exercise allowed and denied outcomes |
| A revert fully restores prior state, including persisted data | ❌ | Takedown permanently removes stored document versions |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Service credentials authorize suspension and takedown |
| No public API, plugin API, message, or on-disk contract changes | ❌ | New operator endpoints and persisted suspension state |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Suspension and deletion must remain effective during in-flight uploads |
| No hot-path behavior lacks deterministic coverage | ✅ | Reservation, version commit, and R2 cleanup races are covered |
| No new dependency | ✅ | Existing service authentication, D1, and R2 |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The operator runbook requires verifying the exact target before action |

Review: inspect `handleAdmin` in `src/admin.ts`, `operatorAction`/`removeDocument` in `src/operator.ts`, and `publisherSuspended` in `src/owners.ts`. Check `insertDocWithinQuota`, `reserveNextVersion`, `insertVersion`, `deleteDocRow`, and `tombstoneEmptyDoc` in `src/db.ts`, plus `storeVersion`/`createDoc`/`updateDoc` in `src/api/push.ts`. Exercise Verification 2–4, including failed cleanup after suspension.

## Verification

1. Apply the additive migration in a disposable Worker environment and configure a local service-admin credential. Create linked publishers with existing documents.
2. Suspend either identity and attempt create/update through both credentials. Confirm listing and unsharing remain usable, unrelated documents stay indistinguishable from missing documents, and resuming restores normal limits.
3. Suspend or take down a document during an upload. Confirm no forbidden new version is committed, failed creates release their reservation, and a withdrawn URL remains 410.
4. Take down a document with multiple stored versions, including enough objects to require pagination. Inject cleanup failure, retry the same takedown, and verify both latest and pinned URLs remain 410 while every stored version is removed.
