### PR TITLE
[Account linking] - Step 7: Report publishing and linking outcomes

### DIFF
--- a/docs/launch-reporting.md
+++ b/docs/launch-reporting.md
@@ -1,0 +1,58 @@
+# Launch reporting
+
+These signals describe publishing and account linking. They do not attribute
+website visits to installs, CLI use, payment, or publication.
+
+## Observed publishing refusals
+
+The existing Worker console emits `publishing_limit_reached` with exactly two
+fields: `limit` (`documents`, `pushesPerDay`, or `htmlBytes`) and `authKind`
+(`account` or `license`). No owner, document ID, URL, content, title, email, token,
+plan name, upgrade URL, or error message is included in this event.
+
+The event is emitted when `limitReached` returns an account-plan refusal. Current
+legacy license quota/size errors use their existing response paths and do not
+emit it. Repeated attempts count repeatedly; this is not a unique-user count.
+Successful pushes, suspension, authentication failures and foreign-document
+errors do not emit this event. Its response contract is unchanged.
+
+`wrangler.jsonc` enables observability. The repository does not explicitly set
+sampling or retention; deployed capture settings and retention have not been
+verified here. Label any log-derived totals **observed refusals**, with the query
+interval and available log coverage. Do not present them as exhaustive totals.
+Use the event name and enum fields in existing Worker logs; no new analytics
+service or per-refusal database write is required.
+
+## Persisted publication and account-link aggregates
+
+[scripts/launch-report.sql](../scripts/launch-report.sql) is a read-only report over
+existing D1 rows. Make a local copy, edit its two UTC dates, and verify the target
+database and half-open interval before running it with authorized database access.
+For a disposable local database, the command is:
+
+```sh
+npx wrangler d1 execute DB --local --file /absolute/path/launch-report.sql
+```
+
+For a deployment, use its normal approved read-only database access. This change
+does not execute production queries or alter Cloudflare configuration. Retain the
+query, interval, execution time and aggregate output together for comparison.
+An absent day/metric row means zero matching records in the current database.
+
+- `first_persisted_publication` counts each currently joined publisher once, on
+  the earliest retained `versions.created_at`, across all their documents.
+  Withdrawn documents still count; failed empty reservations do not. It counts
+  persisted version evidence, not proof that an HTTP success reached the client.
+  The timestamp is the push's recorded time, not a database commit timestamp.
+- `immutable_account_link` counts `owner_links.created_at`, independently of
+  publication. It proves an association was stored, not entitlement delivery,
+  paid eligibility, or completion of a private service's synchronization.
+
+The report groups external owners through their current immutable association.
+Linking two histories can move or merge a first-publication cohort, including
+moving it outside an earlier report's interval. Historical cohorts can therefore
+restate after a link. The report deliberately considers all retained version
+history before filtering dates; filtering versions first would count returning
+publishers as new. Deleted version records cannot be reconstructed by this query.
+No identifiers or document content appear in its output. Billing acquisition and
+renewal reporting belongs to the private billing service, not this Worker.

--- a/scripts/launch-report.sql
+++ b/scripts/launch-report.sql
@@ -1,0 +1,19 @@
+-- Read-only. Edit only the two UTC dates for the desired half-open interval.
+WITH reporting_window AS (
+  SELECT unixepoch('2026-09-09') * 1000 AS start_ms,
+         unixepoch('2026-09-10') * 1000 AS end_ms
+), first_publications AS (
+  SELECT COALESCE(l.account_id, d.owner) AS publisher, MIN(v.created_at) AS first_at
+  FROM versions v JOIN docs d ON d.id = v.doc_id
+  LEFT JOIN owner_links l ON l.external_owner = d.owner
+  GROUP BY COALESCE(l.account_id, d.owner)
+), events AS (
+  SELECT 'first_persisted_publication' AS metric, first_at AS at_ms FROM first_publications
+  UNION ALL
+  SELECT 'immutable_account_link', created_at FROM owner_links
+)
+SELECT date(at_ms / 1000, 'unixepoch') AS utc_day, metric, COUNT(*) AS count
+FROM events CROSS JOIN reporting_window
+WHERE at_ms >= start_ms AND at_ms < end_ms
+GROUP BY utc_day, metric
+ORDER BY utc_day, metric;

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -49,7 +49,7 @@ export function effectivePlan(env: Env, plan: string, expiresAt: number | null, 
   return expiresAt !== null && expiresAt <= now ? defaultPlan(env) : plan;
 }
 
-export function limitReached(env: Env, publisher: Publisher, limit: string, message: string): Response {
+export function limitReached(env: Env, publisher: Publisher, limit: keyof PlanLimits, message: string): Response {
   let upgradeUrl: string | undefined;
   if (env.UPGRADE_URL?.trim()) {
     const url = new URL(env.UPGRADE_URL);
@@ -60,6 +60,10 @@ export function limitReached(env: Env, publisher: Publisher, limit: string, mess
     url.searchParams.set("owner", publisher.owner);
     upgradeUrl = url.toString();
   }
+  // Fixed non-identifying fields only; messages and upgrade URLs can contain identity.
+  console.info("publishing_limit_reached", {
+    limit, authKind: publisher.authKind === "account" ? "account" : "license",
+  });
   return errorResponse("limit_reached", message, undefined, {
     plan: publisher.plan, limit, ...(upgradeUrl ? { upgrade_url: upgradeUrl } : {}),
   });

--- a/test/launch-reporting.test.ts
+++ b/test/launch-reporting.test.ts
@@ -1,0 +1,71 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+import report from "../scripts/launch-report.sql?raw";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId, newDocId } from "../src/ids.js";
+import worker from "../src/index.js";
+import { linkExternalOwner } from "../src/owners.js";
+const OWNER = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DAY = Date.UTC(2026, 8, 9);
+
+it("reports first persisted publications and immutable links with post-link cohort restatement", async () => {
+  await env.DB.prepare("INSERT INTO accounts (id, email, created_at) VALUES (?, 'private@example.test', 0)").bind(OWNER).run();
+  async function publication(owner: string, times: number[], deleted = false) {
+    const id = newDocId();
+    await env.DB.prepare("INSERT INTO docs (id, owner, title, created_at, updated_at, deleted_at) VALUES (?, ?, 'private title', 0, 0, ?)")
+      .bind(id, owner, deleted ? DAY : null).run();
+    for (const [i, at] of times.entries()) await env.DB.prepare("INSERT INTO versions (doc_id, n, size, created_at) VALUES (?, ?, 1, ?)")
+      .bind(id, i + 1, at).run();
+  }
+  await publication(OWNER, [DAY + 200, DAY]); // Earliest time, not version number.
+  await publication(OWNER, [DAY + 300]); // A second document is not a new publisher.
+  await publication("external", [DAY - 1, DAY + 1]); // Returning publisher, outside cohort.
+  await publication("withdrawn", [DAY + 1], true); // Withdrawal retains publication evidence.
+  await publication("failed-empty", []);
+  await publication("future", [DAY + 86400000]); // Exclusive end boundary.
+  const run = async () => (await env.DB.prepare(report).all()).results;
+  expect(await run()).toEqual([{ utc_day: "2026-09-09", metric: "first_persisted_publication", count: 2 }]);
+  expect(await linkExternalOwner(env.DB, "external", OWNER, DAY + 1000)).toBe("linked");
+  expect(await linkExternalOwner(env.DB, "external", OWNER, DAY + 2000)).toBe("linked");
+  expect(await run()).toEqual([
+    { utc_day: "2026-09-09", metric: "first_persisted_publication", count: 1 },
+    { utc_day: "2026-09-09", metric: "immutable_account_link", count: 1 },
+  ]);
+});
+
+it("emits only fixed enum fields for real plan refusals and leaves success and other failures uncounted", async () => {
+  await env.DB.prepare("INSERT INTO accounts (id, email, created_at, plan) VALUES (?, 'private@example.test', 0, 'private-plan')").bind(OWNER).run();
+  const token = newApiToken();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+    .bind(newTokenId(), await sha256Hex(token), OWNER).run();
+  const log = vi.spyOn(console, "info").mockImplementation(() => {});
+  try {
+    async function push(id?: string, html = "<p>private</p>", credential = token) {
+      const ctx = createExecutionContext();
+      const result = await worker.fetch(new Request(`https://local.test/api/v1/docs${id ? `/${id}` : ""}`, {
+        method: id ? "PUT" : "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+        body: JSON.stringify({ title: "private title", html }),
+      }), { ...env, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "",
+        PLAN_LIMITS: '{"private-plan":{"documents":1,"pushesPerDay":1,"htmlBytes":64}}',
+        UPGRADE_URL: "https://private.example.test/upgrade",
+      }, ctx);
+      await waitOnExecutionContext(ctx);
+      return result;
+    }
+    const created = await push(); expect(created.status).toBe(201);
+    const { docId } = await created.json<{ docId: string }>();
+    expect(log).not.toHaveBeenCalled();
+    expect((await push()).status).toBe(402);
+    expect((await push(docId, "x".repeat(65))).status).toBe(402);
+    expect((await push(docId)).status).toBe(402);
+    expect((await push(newDocId())).status).toBe(404);
+    expect((await push(undefined, undefined, "oat_invalid")).status).toBe(401);
+    await env.DB.prepare("INSERT INTO publisher_suspensions VALUES (?, 0)").bind(OWNER).run();
+    expect((await push()).status).toBe(403);
+    expect(log.mock.calls).toEqual([
+      ["publishing_limit_reached", { limit: "documents", authKind: "account" }],
+      ["publishing_limit_reached", { limit: "htmlBytes", authKind: "account" }],
+      ["publishing_limit_reached", { limit: "pushesPerDay", authKind: "account" }],
+    ]);
+  } finally { log.mockRestore(); }
+});

--- a/test/sql.d.ts
+++ b/test/sql.d.ts
@@ -1,0 +1,5 @@
+/** Vite loads the exact operator-run SQL for real-D1 fixture verification. */
+declare module "*.sql?raw" {
+  const sql: string;
+  export default sql;
+}


### PR DESCRIPTION
Relates to Brevilabs/app-sites#469

## Why

Launch reporting needs to distinguish a first publication, a stored account link, and a refused publish attempt. Existing document/version records already answer the first two; another event database would duplicate them.

## What

Add a read-only daily report for first retained publications and account links, plus anonymous account-plan refusal events in existing Worker logs. Report totals include withdrawn documents, exclude empty reservations, and may change when two histories are linked. Log-derived counts are explicitly observed attempts, not unique users or exhaustive totals.

## Non goal

Website-to-CLI attribution, payment reporting, legacy-license quota instrumentation, new analytics services, or production queries and configuration changes.

## Screenshot

Not applicable: log events and a read-only operator report.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real HTTP and D1 fixtures verify exact event fields and aggregate results |
| A defect would fail CI or be obvious on first use | ✅ | Tests execute the report SQL and refusal response paths |
| A revert fully restores prior state, including persisted data | ✅ | No application-state writes or migrations are introduced |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Events contain only fixed limit and credential-kind enums |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Publishing responses and database formats remain unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing quota decisions are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Payload exclusions and unchanged refusal responses are tested |
| No new dependency | ✅ | Existing logs and D1 records are reused |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The runbook labels log coverage and cohort restatement limits |

Review: run Verification 2–3 and confirm the report labels match the observations.

## Verification

1. Use a disposable local Worker database and copy the report with a chosen UTC start and end date.
2. Publish, update, withdraw, and link two histories. Run `scripts/launch-report.sql`; confirm each joined publisher is counted at its earliest retained version and account links are counted independently.
3. Trigger each account-plan limit and inspect the event. Confirm it contains only the event name, limit, and credential kind, with no identity, content, URL, or error message. Confirm authentication failures and successful publishes do not produce this event.
4. Record the reporting interval and available log coverage. Interpret repeated refusals as attempts and historical publication cohorts as subject to restatement after linking.
