### PR TITLE
v0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check hosted account routing
+        run: node scripts/check-account-actions.cjs
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/release-openartifacts.yml
+++ b/.github/workflows/release-openartifacts.yml
@@ -166,27 +166,10 @@ jobs:
             console.log(`openartifacts ${requested} appeared during this run; skipping publish`);
           } else {
             const latest = metadata["dist-tags"]?.latest;
-            const parse = (value) => {
-              const match = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.exec(value ?? "");
-              if (!match) {
-                console.error(`::error::npm latest tag is not a stable version: ${value ?? "missing"}`);
-                process.exit(1);
-              }
-              return match.slice(1).map(Number);
-            };
-            const compare = (left, right) => {
-              for (let index = 0; index < left.length; index += 1) {
-                if (left[index] !== right[index]) return left[index] - right[index];
-              }
-              return 0;
-            };
-
-            if (compare(parse(requested), parse(latest)) <= 0) {
-              console.error(`::error::openartifacts ${requested} must be newer than npm latest ${latest}`);
-              process.exit(1);
-            }
+            const { checkNextPatch } = require("./scripts/check-release-pr.cjs");
+            checkNextPatch(latest, requested);
             fs.appendFileSync(process.env.GITHUB_OUTPUT, "exists=false\n");
-            console.log(`openartifacts ${requested} is newer than npm latest ${latest}`);
+            console.log(`openartifacts ${requested} is the next patch after npm latest ${latest}`);
           }
           NODE
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ OpenArtifacts npm releases occur only when a PR titled exactly `vX.Y.Z` is merge
 into `main`. The title version must match `packages/openartifacts/package.json`
 and its `packages/openartifacts` entry in `package-lock.json`.
 
+CLI releases are patch-only: keep the major and minor versions unchanged and
+increment the patch by exactly one (for example, `0.2.2` → `0.2.3`). Do not
+skip patches, downgrade, or prepare minor or major releases. PR checks compare
+against the base branch; publication checks against npm’s current `latest`.
+
 A version bump in a descriptively titled PR does not publish. When preparing a
 release, verify all three match before handing off the PR. Do not merge or publish
 without user authorization.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ comments do not exist yet.
 - **List and unshare documents.** Deleting destroys the stored files and leaves
   a `410 Gone` tombstone. Copies already in a reader's browser cache cannot be
   recalled.
-- **Bound abuse.** Hosted free accounts get three live documents, six
+- **Bound abuse.** Hosted free accounts get one live document, six
   publishes/updates per UTC day, and 1 MiB HTML per document. The paid plan and
   paid Copilot licenses allow 500 documents, 100 pushes per day, and 10 MiB.
   All credentials share their account's allowance. Unsharing frees a document
@@ -153,7 +153,7 @@ explains the boundary.
 
 Choose your own account limits with `PLAN_LIMITS` and `DEFAULT_PLAN` in Worker
 vars; the checked-in values are the hosted free/paid policy. Without an override,
-the built-in map has one free plan: 3 documents, 6 pushes/day, and 1 MiB HTML.
+the built-in map has one free plan: 1 document, 6 pushes/day, and 1 MiB HTML.
 Billing is optional: [plan configuration and the admin API](docs/http-api.md#account-plans)
 let your own service change plans. Never expose the admin secret to clients.
 

--- a/docs/cost-at-scale.md
+++ b/docs/cost-at-scale.md
@@ -10,6 +10,9 @@ status: draft
 
 # openartifacts.ai - Business Feasibility - Cost at Scale
 
+> Historical pricing context: the paid-only publishing assumptions below predate
+> standalone free accounts. Current hosted limits are in [the HTTP API](http-api.md#quotas).
+
 Companion to [[Agent-First Docs - Product Positioning]]. That doc argues *why* the product should exist. This one asks a colder question: **what does it cost to serve, and does the cost curve stay sane from 1k to 100k to 1M users?** (Pricing was revised on 2026-07-25: publishing is paid, reading is free. See §8. Sections written against the earlier free-share plan are flagged where it matters.)
 
 Scope of the launch product being costed: **one-click sharing from Copilot for Obsidian. Push a local md/html file, get a public HTML page on the internet. No accounts for readers, no permissions, no comments.** Later phases (access control, comments, agent APIs) are costed as deltas.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -357,7 +357,7 @@ All changes ship through a pull request; never push to `main`.
 
 ## Standalone account launch order
 
-Apply additive D1 migrations through `0011_review_cache_state.sql` before this Worker.
+Apply additive D1 migrations through `0012_newsletter_delivery.sql` before this Worker.
 The unshipped revision/purpose migrations were replaced; do not apply their old
 draft versions. Hosted `ACCOUNT_ACTION_URL` and `UPGRADE_URL` must both be
 `https://openartifacts.ai/account`; CI and `npm run deploy` check this. Self-hosted

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -357,7 +357,7 @@ All changes ship through a pull request; never push to `main`.
 
 ## Standalone account launch order
 
-Apply additive D1 migrations through `0008_plan_cache.sql` before this Worker.
+Apply additive D1 migrations through `0009_newsletter_preference.sql` before this Worker.
 The unshipped revision/purpose migrations were replaced; do not apply their old
 draft versions. Hosted `ACCOUNT_ACTION_URL` and `UPGRADE_URL` must both be
 `https://openartifacts.ai/account`; CI and `npm run deploy` check this. Self-hosted

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -357,7 +357,7 @@ All changes ship through a pull request; never push to `main`.
 
 ## Standalone account launch order
 
-Apply additive D1 migrations through `0009_newsletter_preference.sql` before this Worker.
+Apply additive D1 migrations through `0010_pending_signup.sql` before this Worker.
 The unshipped revision/purpose migrations were replaced; do not apply their old
 draft versions. Hosted `ACCOUNT_ACTION_URL` and `UPGRADE_URL` must both be
 `https://openartifacts.ai/account`; CI and `npm run deploy` check this. Self-hosted

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -357,7 +357,7 @@ All changes ship through a pull request; never push to `main`.
 
 ## Standalone account launch order
 
-Apply additive D1 migrations through `0010_pending_signup.sql` before this Worker.
+Apply additive D1 migrations through `0011_review_cache_state.sql` before this Worker.
 The unshipped revision/purpose migrations were replaced; do not apply their old
 draft versions. Hosted `ACCOUNT_ACTION_URL` and `UPGRADE_URL` must both be
 `https://openartifacts.ai/account`; CI and `npm run deploy` check this. Self-hosted
@@ -375,3 +375,7 @@ Its `refresh.status` reports failure explicitly. No background synchronization i
 required. An outage retains a finite paid snapshot only until expiry; a lifetime
 snapshot remains paid until a later successful pull. Withdrawals and listing do
 not wait on the entitlement service.
+
+### Linked-account rollback floor
+
+Before enabling permanent owner links, record the first link-aware Worker version ID in the deployment record. After any owner link exists, never roll back below that version: older Workers ignore the associations and split histories and quotas. Later credential-rejection markers also require a rejection-aware rollback target; record the first version supporting migration 0011 as the new floor. Keep the additive schema when rolling back compatible code.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -353,3 +353,25 @@ the repo page will name the commit that was deployed forward until the next
 merge corrects them.
 
 All changes ship through a pull request; never push to `main`.
+
+
+## Standalone account launch order
+
+Apply additive D1 migrations through `0008_plan_cache.sql` before this Worker.
+The unshipped revision/purpose migrations were replaced; do not apply their old
+draft versions. Hosted `ACCOUNT_ACTION_URL` and `UPGRADE_URL` must both be
+`https://openartifacts.ai/account`; CI and `npm run deploy` check this. Self-hosted
+origins can omit the browser service and retain local plans.
+
+Before enabling the landing offer, verify the private read-only entitlement
+procedure and account page are deployed with matching server credentials, then
+deploy this Worker and verify its one-document free limit. Publish the approved
+`v0.2.3` CLI release and verify npm `latest` is `0.2.3` and a clean install exposes
+`account --open`. Only then enable the landing entry point. No deploy, npm publish,
+or payment-provider operation is authorized by these instructions alone.
+
+A successful `openartifacts account` refresh is the paid-access verification step.
+Its `refresh.status` reports failure explicitly. No background synchronization is
+required. An outage retains a finite paid snapshot only until expiry; a lifetime
+snapshot remains paid until a later successful pull. Withdrawals and listing do
+not wait on the entitlement service.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -52,8 +52,8 @@ published with it. So every key on one account sees one list, and any of them
 can push a new version of, or unshare, a document another one created. Replacing
 a key changes nothing about which documents you have. Publisher operations never
 accept an account id to select whose documents to access; ownership is derived
-from the credential. The separate admin API and optional account-token upgrade
-link expose account ids for routing, not as publisher credentials.
+from the credential. The separate admin API uses account ids for routing, not as publisher
+credentials.
 
 **License-key publishing requires a paid plan.** Eligible `PLUS` subscriptions
 and `BELIEVER` accounts (sold as Supporter) can publish with a license key,
@@ -609,10 +609,9 @@ No configured secret disables the route (`404`); incorrect credentials return
 `401`, an unknown plan `400`, and a missing account `404`. Retrying the same
 change is safe. Every account token sees the new plan on its next request.
 
-Optional `UPGRADE_URL` adds an absolute HTTP(S) link to plan-limit errors, with
-the account's `owner` query parameter. That ID routes checkout; it does **not**
-authorize access. Billing must independently verify account ownership. Leave
-this variable unset until checkout exists. No billing or admin secret belongs
+Optional `UPGRADE_URL` adds a generic absolute HTTP(S) account-page link to
+plan-limit errors. It carries no account identity. The account page requires a
+fresh `openartifacts account --open` handoff before any authenticated action. No billing or admin secret belongs
 in a CLI, skill, public link, or this repository.
 
 ## Quotas
@@ -657,7 +656,8 @@ For example, the current account-token document-cap response is:
 
 Waiting until tomorrow only resets daily pushes, not document capacity.
 Signing in on another machine resets neither. The CLI displays the refusal
-and upgrade link when present. Hosted checkout remains separate work.
+and account link when present. Run `openartifacts account --open` to manage
+hosted access.
 
 Two further limits sit outside all of this. On `POST /device/code`, a single
 client address may ask for five sign-in codes a minute, and past that the mint
@@ -727,15 +727,15 @@ These additive routes are served on the API host. They use no browser cookies.
 cannot access it. It returns `200` with `cache-control: no-store`:
 
 ```json
-{"accountId":"oa_…","plan":"free","limits":{"documents":1,"pushesPerDay":6,"htmlBytes":1048576},"usage":{"documents":1,"pushesToday":2},"externalLinked":false}
+{"accountId":"oa_…","plan":"free","limits":{"documents":1,"pushesPerDay":6,"htmlBytes":1048576},"usage":{"documents":1,"pushesToday":2},"externalLinked":false,"refresh":{"status":"refreshed","checkedAt":1800000000000,"expiresAt":null}}
 ```
 
 Limits reflect the deployment configuration. Usage counts live documents and
 UTC-day reservations across linked owners, including uploads still pending.
 The external identity and email are not included in this publisher response.
 
-`POST /api/v1/account/handoffs` requires the same token and exactly one JSON
-field: `{"purpose":"upgrade"}`, `{"purpose":"billing"}`, or `{"purpose":"link"}`.
+`POST /api/v1/account/handoffs` requires the same token and opens a generic
+account action. It needs no request body; identity comes only from the token.
 It returns `200` with `{"url":"https://trusted.example/actions?code=…","expiresAt":1800000600000}`
 and `cache-control: no-store`. The timestamp is epoch milliseconds. The URL is
 configured by `ACCOUNT_ACTION_URL`; it must be absolute HTTPS without credentials
@@ -747,8 +747,7 @@ Codes contain 256 random bits, expire after ten minutes, and are stored only as
 hashes. At most five actions may remain outstanding per account; the sixth
 returns `429 quota_exceeded`. Minting clears that account's expired entries.
 Revoking the originating machine token also invalidates its unconsumed codes.
-Unknown purposes, extra fields, malformed JSON, and bodies over 1024 bytes
-return `400 bad_request`. Account routes reject license credentials with `401`.
+There are no action-purpose fields. Account routes reject license credentials with `401`.
 
 ### Trusted service endpoints
 
@@ -760,11 +759,11 @@ incorrect credential. Successful responses use `cache-control: no-store`.
 consumes a live code once and returns:
 
 ```json
-{"accountId":"oa_…","email":"user@example.test","purpose":"link","externalOwner":null}
+{"accountId":"oa_…","email":"user@example.test","externalOwner":null}
 ```
 
-`externalOwner` is the linked identity or null. The service must dispatch only
-the returned purpose and preserve this server-verified account identity through
+`externalOwner` is the linked identity or null. The service must consume only after
+an explicit browser POST and preserve this server-verified account identity through
 its confirmation flow; email is informational, never account proof. Replayed,
 expired, unknown, or originating-token-revoked codes all return `404 not_found`.
 Malformed codes or extra body fields return `400`. A failed authorization does
@@ -782,38 +781,39 @@ A conflicting association returns `409 conflict`; invalid identities return
 `400`; a missing local account returns `404`. Associations are permanent and do
 not change plans, credential permissions, document IDs, or stored versions.
 
-### Ordered plan snapshots
+### Pulled account entitlement
 
-The existing service-only `PUT /admin/v1/accounts/{accountId}/plan` also accepts
-exactly `{"plan":"pro","expiresAt":1800000600000,"revision":1}`. `expiresAt` is
-null for unlimited validity or a nonnegative safe-integer epoch millisecond
-value. `revision` is a positive safe integer. Both fields must be supplied
-together; missing fields, additional fields, invalid numbers, and unconfigured
-plan names return `400`.
+OAuth identity remains local. On publishing, an hour-old plan cache or an expired
+paid snapshot triggers a read-only entitlement pull. `GET /api/v1/account` always
+tries to refresh; listing, withdrawal and token administration never call the
+entitlement service. A new account starts with a fresh default-plan cache, so its
+first free publication needs no remote call.
 
-A larger revision atomically replaces the stored snapshot. An identical retry
-of the current revision succeeds; a lower revision, or the same revision with
-different contents, returns `409 conflict`. Missing accounts return `404`.
-Success returns the stored snapshot, not its time-dependent effective plan:
-`{"owner":"oa_…","plan":"pro","expiresAt":1800000600000,"revision":1}`.
-The caller must allocate revisions durably per account and deliver reconciled
-snapshots in increasing order. A newer reconciliation can supersede a manual
-operator assignment; retries must never send changed contents under an old
-revision.
+The Worker POSTs `{"json":{"accountId":"oa_…","externalOwner":"…"}}` to
+`${LICENSE_API_URL}/api/trpc/license.openArtifactsEntitlement`, authenticating with
+its existing server `LICENSE_API_KEY`. `externalOwner` is omitted when unlinked;
+no user token, license key, email or document content is sent. The superjson result
+`result.data.json` is `{plan:"default"|"plus",expiresAt:number|null}`. Timestamps
+are Unix milliseconds. `default` maps to `DEFAULT_PLAN`, `plus` to configured `pro`.
+No automatic retry is made; the request times out after eight seconds.
 
-At `expiresAt <= now`, account authentication and status use the configured
-default plan. This requires no remote call or database mutation. The stored
-snapshot, documents, versions, credentials, and usage remain intact. Existing
-above-limit collections remain listable, editable within the effective daily
-and byte limits, and removable; additional documents are refused at the cap.
+`plan_checked_at` records fetch-start time, independently of `plan_expires_at`.
+Only a newer fetch may replace the cached plan, and the association must still
+match the one observed before that fetch. Losing or failed requests reread the
+winning stored state. Linking clears freshness; manual `{plan}` assignments reset
+expiry and advance freshness to prevent an older pending response overwriting them.
+Neither operation changes document ownership, usage, or tokens.
 
-The original `{"plan":"…"}` manual operation and `{owner,plan}` response remain
-supported. It clears expiration but preserves the latest revision fence. The
-next service reconciliation must use a larger revision to replace that override.
+Failed refreshes preserve the last snapshot only until its paid expiry, then the
+local default plan applies. Free publishing, listing and withdrawal remain usable.
+A lifetime snapshot has no expiry: during a prolonged outage it remains paid until
+a successful refresh. Refunds or cancellations may therefore lag by the one-hour
+TTL, or longer during an outage. Account output includes
+`refresh:{status:"refreshed"|"cached"|"unavailable",checkedAt:number|null,expiresAt:number|null}`;
+`cached` can mean a concurrent refresh or manual assignment won. An unavailable
+refresh is never represented as proof of a completed upgrade.
 
-`GET /admin/v1/accounts/{accountId}/external-owner` uses the same service
-credential and returns `{accountId,externalOwner}` with null when the account
-has no association, or `404` when the account is unknown. This read supports
-recovery when association succeeds but a trusted caller's subsequent local
-write fails. It does not require retaining a raw external credential or
-replaying a consumed handoff. Responses use `cache-control: no-store`.
+Self-hosts without the entitlement service retain configured local plans and
+manual assignment. Missing or invalid paid-plan configuration never grants access.
+Apply `0008_plan_cache.sql` before deploying this code; the previous unshipped
+revision migration is replaced, not upgraded in place.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -55,9 +55,9 @@ accept an account id to select whose documents to access; ownership is derived
 from the credential. The separate admin API and optional account-token upgrade
 link expose account ids for routing, not as publisher credentials.
 
-**Publishing requires a paid plan.** Both current license-server paid plans are
-entitled: `PLUS` subscriptions and the lifetime `BELIEVER` plan (sold as
-Supporter). An unknown or otherwise ineligible plan is refused with `401
+**License-key publishing requires a paid plan.** Eligible `PLUS` subscriptions
+and `BELIEVER` accounts (sold as Supporter) can publish with a license key,
+subject to their hosted-access period. An unknown or otherwise ineligible plan is refused with `401
 unauthorized` like every other auth failure, so only the human-readable
 `message` distinguishes it.
 
@@ -88,17 +88,17 @@ ceiling, and any of them can push a new version of, or unshare, a document
 another one created. Revoking a token changes nothing about which documents the
 account holds.
 
-**The two credentials never mix.** A key resolves to the Brevilabs account that
-holds it and a token to the OpenArtifacts account it was issued to; the two id
-spaces cannot collide, so neither can ever see the other's documents. A Copilot
-subscriber who wants the documents their plugin published presents the same
-license key the plugin does — this API accepts it from a terminal like any other
-caller.
+**Credential identities stay separate until explicitly linked.** A key resolves
+to its Brevilabs account and a token to its OpenArtifacts account. A trusted
+service may permanently associate the two after proving control of both; email
+matching alone cannot authorize this. Linked credentials see the joined history
+and their publishing limits count both owners. Token administration remains tied
+to the account that issued the token. Existing document URLs do not change.
 
 **Publishing follows the account's plan.** First approval uses the deployment's
 default plan. Every token shares its account's limits, and a plan change takes
 effect on the next request without signing in again. The hosted free plan has
-three live documents, six publishes/updates per UTC day, and 1 MiB HTML per doc.
+one live document, six publishes/updates per UTC day, and 1 MiB HTML per doc.
 Listing and unsharing never require available publishing quota.
 
 **Revocation is immediate.** A revoked token fails on its very next request,
@@ -586,7 +586,7 @@ Worker var `PLAN_LIMITS` is a JSON string mapping plan names to positive integer
 ceilings. HTML is measured in UTF-8 bytes and cannot exceed the 10 MiB safety bound:
 
 ```json
-{"free":{"documents":3,"pushesPerDay":6,"htmlBytes":1048576},"pro":{"documents":500,"pushesPerDay":100,"htmlBytes":10485760}}
+{"free":{"documents":1,"pushesPerDay":6,"htmlBytes":1048576},"pro":{"documents":500,"pushesPerDay":100,"htmlBytes":10485760}}
 ```
 
 `DEFAULT_PLAN` (default `free`) selects the plan for newly created accounts.
@@ -595,7 +595,7 @@ Apply `0005_account_plans.sql` before deploying this version, following the
 `free`; their tokens and documents remain valid. Unknown plans or malformed
 configuration fail closed for publishing, but do not block listing or unsharing.
 Absent or blank `PLAN_LIMITS` uses the built-in map with one `free` entry:
-3 documents, 6 pushes/day and 1 MiB HTML. `PLAN_LIMITS` replaces that map.
+1 document, 6 pushes/day and 1 MiB HTML. `PLAN_LIMITS` replaces that map.
 
 ### Change an account's plan
 
@@ -618,13 +618,14 @@ in a CLI, skill, public link, or this repository.
 ## Quotas
 
 Publishing limits follow the authenticated account, not the token, key, agent,
-or device. License-key and account-token identities remain separate.
+or device. Explicitly linked license-key and account-token owners share their
+collection and usage; linking does not grant a second allowance.
 
 | Limit | Hosted free account | Hosted paid account / paid license |
 | --- | --- | --- |
 | HTML per doc | 1 MiB | 10 MiB |
 | Pushes per UTC day | 6 | 100 |
-| Live docs held | 3 | 500 |
+| Live docs held | 1 | 500 |
 
 Account plan refusals use `402 limit_reached`. License-key refusals are unchanged:
 `413 too_large` for HTML size, `429 quota_exceeded` for document/daily limits.
@@ -718,3 +719,101 @@ curl -sS "$DOC" -o /dev/null -w '%{http_code}\n'            # → 410
 
 `scripts/smoke.sh` runs exactly this sequence against a deployment and checks
 every status.
+
+## Account status and trusted browser actions
+
+These additive routes are served on the API host. They use no browser cookies.
+`GET /api/v1/account` requires a live OAuth-issued bearer token. License keys
+cannot access it. It returns `200` with `cache-control: no-store`:
+
+```json
+{"accountId":"oa_…","plan":"free","limits":{"documents":1,"pushesPerDay":6,"htmlBytes":1048576},"usage":{"documents":1,"pushesToday":2},"externalLinked":false}
+```
+
+Limits reflect the deployment configuration. Usage counts live documents and
+UTC-day reservations across linked owners, including uploads still pending.
+The external identity and email are not included in this publisher response.
+
+`POST /api/v1/account/handoffs` requires the same token and exactly one JSON
+field: `{"purpose":"upgrade"}`, `{"purpose":"billing"}`, or `{"purpose":"link"}`.
+It returns `200` with `{"url":"https://trusted.example/actions?code=…","expiresAt":1800000600000}`
+and `cache-control: no-store`. The timestamp is epoch milliseconds. The URL is
+configured by `ACCOUNT_ACTION_URL`; it must be absolute HTTPS without credentials
+or a fragment. HTTP is allowed only for localhost, 127.0.0.1, or [::1]. An absent
+configuration returns `404` without creating a code; invalid configuration fails
+closed with `500`. Do not send the publisher token to this URL.
+
+Codes contain 256 random bits, expire after ten minutes, and are stored only as
+hashes. At most five actions may remain outstanding per account; the sixth
+returns `429 quota_exceeded`. Minting clears that account's expired entries.
+Revoking the originating machine token also invalidates its unconsumed codes.
+Unknown purposes, extra fields, malformed JSON, and bodies over 1024 bytes
+return `400 bad_request`. Account routes reject license credentials with `401`.
+
+### Trusted service endpoints
+
+These routes require `Authorization: Bearer <ADMIN_API_KEY>`, never a publisher
+credential. They return `404` if the service API is unconfigured and `401` for an
+incorrect credential. Successful responses use `cache-control: no-store`.
+
+`POST /admin/v1/handoffs/consume` accepts exactly `{"code":"…"}`. It atomically
+consumes a live code once and returns:
+
+```json
+{"accountId":"oa_…","email":"user@example.test","purpose":"link","externalOwner":null}
+```
+
+`externalOwner` is the linked identity or null. The service must dispatch only
+the returned purpose and preserve this server-verified account identity through
+its confirmation flow; email is informational, never account proof. Replayed,
+expired, unknown, or originating-token-revoked codes all return `404 not_found`.
+Malformed codes or extra body fields return `400`. A failed authorization does
+not consume the code. Never log codes, include them in analytics, or forward
+these action URLs to third-party resources. The trusted page should remove the
+code from its browser URL after exchange and require explicit confirmation for
+consequential actions; a GET of that page must not itself link an account.
+
+`PUT /admin/v1/accounts/{accountId}/external-owner` accepts exactly
+`{"externalOwner":"…"}`. The trusted caller must freshly prove the external
+identity and obtain the account holder's confirmation before calling this route;
+a license outage cache or matching email does not prove ownership. Success and
+an identical retry return `200` with `{"accountId":"oa_…","externalOwner":"…"}`.
+A conflicting association returns `409 conflict`; invalid identities return
+`400`; a missing local account returns `404`. Associations are permanent and do
+not change plans, credential permissions, document IDs, or stored versions.
+
+### Ordered plan snapshots
+
+The existing service-only `PUT /admin/v1/accounts/{accountId}/plan` also accepts
+exactly `{"plan":"pro","expiresAt":1800000600000,"revision":1}`. `expiresAt` is
+null for unlimited validity or a nonnegative safe-integer epoch millisecond
+value. `revision` is a positive safe integer. Both fields must be supplied
+together; missing fields, additional fields, invalid numbers, and unconfigured
+plan names return `400`.
+
+A larger revision atomically replaces the stored snapshot. An identical retry
+of the current revision succeeds; a lower revision, or the same revision with
+different contents, returns `409 conflict`. Missing accounts return `404`.
+Success returns the stored snapshot, not its time-dependent effective plan:
+`{"owner":"oa_…","plan":"pro","expiresAt":1800000600000,"revision":1}`.
+The caller must allocate revisions durably per account and deliver reconciled
+snapshots in increasing order. A newer reconciliation can supersede a manual
+operator assignment; retries must never send changed contents under an old
+revision.
+
+At `expiresAt <= now`, account authentication and status use the configured
+default plan. This requires no remote call or database mutation. The stored
+snapshot, documents, versions, credentials, and usage remain intact. Existing
+above-limit collections remain listable, editable within the effective daily
+and byte limits, and removable; additional documents are refused at the cap.
+
+The original `{"plan":"…"}` manual operation and `{owner,plan}` response remain
+supported. It clears expiration but preserves the latest revision fence. The
+next service reconciliation must use a larger revision to replace that override.
+
+`GET /admin/v1/accounts/{accountId}/external-owner` uses the same service
+credential and returns `{accountId,externalOwner}` with null when the account
+has no association, or `404` when the account is unknown. This read supports
+recovery when association succeeds but a trusted caller's subsequent local
+write fails. It does not require retaining a raw external credential or
+replaying a consumed handoff. Responses use `cache-control: no-store`.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -85,9 +85,9 @@ is one approval page.
    are asked to approve the device; new users must accept Terms to create their
    free account and approve it.
 6. They press Approve, which `POST`s that confirm token back and is the only
-   thing that marks the code approved. Deny is the same press with the opposite
-   effect, and it exists so that someone who was sent a link can end the code
-   rather than leaving it live until it expires.
+   thing that marks the code approved. Existing users also have Deny to end the
+   code immediately. New users can close the signup page; no account or token
+   is granted and the unapproved code expires.
 7. The CLI's next poll collects a token, which consumes the device code. The
    token is minted *there* rather than when Approve is pressed, so a raw token
    is never written to a row and a terminal that never comes back leaves no

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -293,6 +293,11 @@ Concurrent signups use the existing unique email and provider-subject constraint
 only the newly inserted account receives the submitted newsletter preference.
 
 The account stores `newsletter_opt_in` and `newsletter_choice_at`. Existing users
-are not enrolled automatically. The existing newsletter sender still needs to
-be connected before sending newsletters to this audience. No campaign is sent by
-signing in, and no Copilot user is manufactured for newsletter enrollment.
+are not enrolled automatically. When the optional private integration is configured, signup sends the verified
+email to its service-authenticated newsletter endpoint. The private service adds
+only missing newsletter recipients and preserves existing unsubscribe choices;
+it creates no billing customer, provider identity, or session. A failed attempt
+does not fail signup and is retried on a later account-plan refresh. There is no
+queue or scheduled retry, so delivery requires later activity after an outage.
+Self-hosted deployments without that integration make no newsletter request.
+No campaign is sent by signing in.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -272,3 +272,18 @@ and that is only acceptable while there is nothing on it for them to steal.
   question, answered per operation by the license key's entitlement or the
   local account's configured plan. Hosted OAuth accounts start with one free
   published document; listing and unsharing remain available over the limit.
+
+## Newsletter preference at signup
+
+The browser sign-in page explains free account creation and links the terms and
+privacy policy. Its optional newsletter checkbox starts checked. The choice travels
+through the device handshake and is shown again, editable, after OAuth. Only the
+confirmation POST records it on the account, atomically with device approval.
+A callback, denied request, expired request or replay cannot enroll an address.
+The first confirmed choice and its timestamp are retained; later sign-ins do not
+overwrite it, including an earlier opt-out. Existing accounts start with no choice.
+
+This is preference capture only. The existing Brevilabs campaign sender reads
+app-sites users, not these D1 accounts; delivery and unsubscribe integration must
+be connected before sending newsletters to this audience. No campaign is sent by
+signing in, and no Copilot user is manufactured for newsletter enrollment.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -27,7 +27,7 @@ to the license server to be identified, handing this deployment's own secret to
 another service on every request.
 
 An account here holds an id, one verified email address, and the time it was
-created, alongside its configured plan, expiry and revision. One further thing
+created, alongside its configured plan, expiry and last entitlement-check time. One further thing
 about a person is stored, and it lives in `identities`: the provider's own permanent id for them,
 which is what returns a later sign-in to the right account. Beyond those,
 nothing is read, requested or stored, so no name and no avatar.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -13,7 +13,7 @@ having never made one — and see the same documents throughout.
 
 `docs.owner` is an opaque string. Nothing parses it, and every query only ever
 compares it for equality. Two things put a value there, and they are deliberately
-never mixed:
+stored with their original provenance:
 
 | Credential | Owner id | Where it comes from |
 | --- | --- | --- |
@@ -27,8 +27,8 @@ to the license server to be identified, handing this deployment's own secret to
 another service on every request.
 
 An account here holds an id, one verified email address, and the time it was
-created. That is the whole `accounts` table. One further thing about a person is
-stored, and it lives in `identities`: the provider's own permanent id for them,
+created, alongside its configured plan, expiry and revision. One further thing
+about a person is stored, and it lives in `identities`: the provider's own permanent id for them,
 which is what returns a later sign-in to the right account. Beyond those,
 nothing is read, requested or stored, so no name and no avatar.
 
@@ -37,17 +37,36 @@ two id spaces cannot collide, and no equality test between them can accidentally
 succeed and hand one account another's documents. That property is what makes it
 safe for one column to carry both.
 
-### Why they are not merged
+### Joining document ownership without changing credentials
 
-A Copilot user who approves with the address on their license gets a *new*
-account, not the one their license key resolves to. Merging them would mean
-treating a verified email as proof of holding a particular license, which is a
-claim OAuth cannot make and the license server was never asked. So a Copilot user
-who wants their plugin documents from the CLI presents the same license key the
-plugin does — the API accepts it — and the two shelves stay separate until there
-is a deliberate exchange between them. That exchange is the follow-up named in
-[#55](https://github.com/Brevilabs/OpenArtifacts/issues/55), and it is also what
-eventually moves the license code out of this repo.
+OAuth email matching never proves control of an external account. The two
+identities stay separate until a trusted caller proves both and confirms a
+permanent association through `linkExternalOwner`. No public linking route is
+provided by this database primitive. It must not accept stale outage validation
+as proof or infer external ownership from an email address.
+
+`owner_links` pairs one external owner with one existing local account. Both
+columns are unique, the ID spaces are disjoint, and associations cannot be
+updated or deleted. Reconfirming the same pair is idempotent; conflicting pairs
+are refused. Account deletion must therefore preserve the ownership record or
+use a separately designed operator process, never cascade an unlink.
+
+The local account is the canonical collection, but document rows retain their
+original `owner` as provenance. Each ownership query derives the joined owner
+set inside its SQL statement. New documents and daily reservations also retain
+the authenticated credential's owner. A request that started before linking
+cannot escape the combined limits after linking: the next reservation counts
+both owners atomically. A refund still returns its original `(owner, day)`
+reservation even when the association was created while the upload was pending.
+Previously over-limit collections are preserved; new reservations fail until
+there is room. Linking itself consumes no publishing allowance.
+
+No document IDs, versions, deletion tombstones, or stored objects move. Existing
+keys and tokens therefore reach the joined collection without relogin or URL
+changes. Credential identity remains unchanged for token administration: an
+external key does not gain permission to list or revoke a local account's tokens.
+An association grants document access, not a plan or a new authentication method;
+entitlement reconciliation belongs to the trusted integration using it.
 
 ## How an account comes into existence
 
@@ -250,6 +269,6 @@ and that is only acceptable while there is nothing on it for them to steal.
   documents would simply stop being reachable by anyone. Worth solving before
   there are accounts worth deleting.
 - **It does not decide what an account may do.** Entitlement is a separate
-  question, answered per operation — today by the license key's plan, next by
-  [#60](https://github.com/Brevilabs/OpenArtifacts/issues/60)'s plan config. An
-  account exists before it is allowed to do anything.
+  question, answered per operation by the license key's entitlement or the
+  local account's configured plan. Hosted OAuth accounts start with one free
+  published document; listing and unsharing remain available over the limit.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -29,8 +29,7 @@ another service on every request.
 An account here holds an id, one verified email address, and the time it was
 created, alongside its configured plan, expiry and last entitlement-check time. One further thing
 about a person is stored, and it lives in `identities`: the provider's own permanent id for them,
-which is what returns a later sign-in to the right account. Beyond those,
-nothing is read, requested or stored, so no name and no avatar.
+which is what returns a later sign-in to the right account. New accounts also store their optional newsletter choice. No name or avatar is requested.
 
 **The prefix is load-bearing.** An app-sites uuid cannot start with `oa_`, so the
 two id spaces cannot collide, and no equality test between them can accidentally
@@ -81,9 +80,10 @@ is one approval page.
 4. The provider redirects back to `/approve/callback/{provider}`. The `state`
    finds that row, the authorization code is exchanged, and the provider's
    **verified** address and its permanent **subject** are read.
-5. Those resolve to an account, creating one if the subject is new. The account
-   is recorded against the code, a fresh confirm token is minted, and the page
-   asks whether to approve it.
+5. Those resolve to an existing account if possible. Otherwise the verified
+   identity is held against the code and a fresh confirm token is minted. Existing accounts
+   are asked to approve the device; new users must accept Terms to create their
+   free account and approve it.
 6. They press Approve, which `POST`s that confirm token back and is the only
    thing that marks the code approved. Deny is the same press with the opposite
    effect, and it exists so that someone who was sent a link can end the code
@@ -116,10 +116,11 @@ Resolution asks the subject first:
 | Situation | Result |
 | --- | --- |
 | This subject has signed in before | its account, whatever address the provider reports now |
-| A new subject, address free or on an account this provider has never signed in to | that account, and the identity is linked to it |
+| A new subject, address free | registration is deferred until Terms and device approval |
+| A new subject, address on an account this provider has never signed in to | that account, and the identity is linked to it |
 | A new subject, address on an account another subject on **this** provider already signs in with | refused |
 
-The third row is enforced by a uniqueness constraint on `identities`, one
+The refusal is enforced by a uniqueness constraint on `identities`, one
 subject per provider per account, rather than by a check the resolver runs
 first. Two previously unseen subjects can verify one address at the same
 moment, and a read followed by a write would let both through — which is worse
@@ -273,20 +274,25 @@ and that is only acceptable while there is nothing on it for them to steal.
   local account's configured plan. Hosted OAuth accounts start with one free
   published document; listing and unsharing remain available over the limit.
 
-## Newsletter preference at signup
+## New-account signup and newsletter preference
 
-The browser sign-in page explains free account creation and links the terms and
-privacy policy. Its required Terms checkbox starts unchecked; sign-in buttons stay
-disabled until it is checked. The server rejects sign-in attempts without explicit
-agreement before creating an OAuth handshake. Its optional newsletter checkbox
-starts checked. The choice travels
-through the device handshake and is shown again, editable, after OAuth. Only the
-confirmation POST records it on the account, atomically with device approval.
-A callback, denied request, expired request or replay cannot enroll an address.
-The first confirmed choice and its timestamp are retained; later sign-ins do not
-overwrite it, including an earlier opt-out. Existing accounts start with no choice.
+The initial browser page offers Google and GitHub sign-in. After OAuth proves the
+identity, existing accounts go directly to device approval, without Terms or
+newsletter prompts. This also applies to accounts with no recorded newsletter
+preference; signing in cannot change that preference.
 
-This is preference capture only. The existing Brevilabs campaign sender reads
-app-sites users, not these D1 accounts; delivery and unsubscribe integration must
+For a new identity, the callback holds the verified subject and email on the
+expiring device-code row. It creates no account. The next page asks the person to
+accept Terms (unchecked by default), offers optional product updates (checked by
+default), and clearly asks them to create a free account and approve their device.
+The button stays disabled until Terms is checked. A single confirmation POST
+atomically creates the account, links its provider identity, records the newsletter
+choice, and approves the device. The server requires explicit Terms agreement.
+A denied, expired, replayed, or failed confirmation cannot create an account.
+Concurrent signups use the existing unique email and provider-subject constraints;
+only the newly inserted account receives the submitted newsletter preference.
+
+The account stores `newsletter_opt_in` and `newsletter_choice_at`. Existing users
+are not enrolled automatically. The existing newsletter sender still needs to
 be connected before sending newsletters to this audience. No campaign is sent by
 signing in, and no Copilot user is manufactured for newsletter enrollment.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -301,3 +301,9 @@ does not fail signup and is retried on a later account-plan refresh. There is no
 queue or scheduled retry, so delivery requires later activity after an outage.
 Self-hosted deployments without that integration make no newsletter request.
 No campaign is sent by signing in.
+
+### Review cache safeguards
+
+Migration 0011 records license rejection completion time. Only validation begun after that rejection may authorize the credential again; delayed older successes cannot restore it, even after a later recovery. Ownership and documents are unchanged.
+
+Failed automatic entitlement refreshes back off for one minute independently of successful-check time and paid expiry. Explicit account refresh bypasses the delay. A successful concurrent refresh is reported as cached by an older failed request.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -276,7 +276,10 @@ and that is only acceptable while there is nothing on it for them to steal.
 ## Newsletter preference at signup
 
 The browser sign-in page explains free account creation and links the terms and
-privacy policy. Its optional newsletter checkbox starts checked. The choice travels
+privacy policy. Its required Terms checkbox starts unchecked; sign-in buttons stay
+disabled until it is checked. The server rejects sign-in attempts without explicit
+agreement before creating an OAuth handshake. Its optional newsletter checkbox
+starts checked. The choice travels
 through the device handshake and is shown again, editable, after OAuth. Only the
 confirmation POST records it on the account, atomically with device approval.
 A callback, denied request, expired request or replay cannot enroll an address.

--- a/migrations/0006_owner_links.sql
+++ b/migrations/0006_owner_links.sql
@@ -1,0 +1,19 @@
+-- Join document collections without rewriting ownership or in-flight counters.
+-- The credential owner remains unchanged, particularly for token administration.
+CREATE TABLE owner_links (
+  external_owner TEXT NOT NULL PRIMARY KEY
+    CHECK (length(external_owner) BETWEEN 1 AND 256
+           AND trim(external_owner) = external_owner
+           AND substr(external_owner, 1, 3) <> 'oa_'),
+  account_id TEXT NOT NULL UNIQUE REFERENCES accounts(id)
+    CHECK (length(account_id) = 29 AND substr(account_id, 1, 3) = 'oa_'
+           AND substr(account_id, 4) NOT GLOB '*[^0-9abcdefghjkmnpqrstvwxyz]*'),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0)
+);
+
+-- There is no unlink/transfer operation: credentials already granted access to
+-- the joined collection must never silently change which collection they name.
+CREATE TRIGGER owner_links_no_update BEFORE UPDATE ON owner_links
+BEGIN SELECT RAISE(ABORT, 'owner associations are immutable'); END;
+CREATE TRIGGER owner_links_no_delete BEFORE DELETE ON owner_links
+BEGIN SELECT RAISE(ABORT, 'owner associations are immutable'); END;

--- a/migrations/0007_account_handoffs.sql
+++ b/migrations/0007_account_handoffs.sql
@@ -1,0 +1,9 @@
+-- Short-lived account proof for a trusted integration; never store raw codes.
+CREATE TABLE account_handoffs (
+  code_hash TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id),
+  token_id TEXT NOT NULL,
+  purpose TEXT NOT NULL CHECK (purpose IN ('upgrade', 'billing', 'link')),
+  expires_at INTEGER NOT NULL
+);
+CREATE INDEX account_handoffs_by_account ON account_handoffs(account_id, expires_at);

--- a/migrations/0007_account_handoffs.sql
+++ b/migrations/0007_account_handoffs.sql
@@ -3,7 +3,6 @@ CREATE TABLE account_handoffs (
   code_hash TEXT PRIMARY KEY,
   account_id TEXT NOT NULL REFERENCES accounts(id),
   token_id TEXT NOT NULL,
-  purpose TEXT NOT NULL CHECK (purpose IN ('upgrade', 'billing', 'link')),
   expires_at INTEGER NOT NULL
 );
 CREATE INDEX account_handoffs_by_account ON account_handoffs(account_id, expires_at);

--- a/migrations/0008_plan_cache.sql
+++ b/migrations/0008_plan_cache.sql
@@ -1,0 +1,6 @@
+-- Unshipped pull cache: freshness and paid validity are independent.
+ALTER TABLE accounts ADD COLUMN plan_expires_at INTEGER CHECK (plan_expires_at >= 0);
+ALTER TABLE accounts ADD COLUMN plan_checked_at INTEGER CHECK (plan_checked_at >= 0);
+UPDATE accounts SET plan_checked_at = created_at;
+CREATE TRIGGER owner_link_refresh AFTER INSERT ON owner_links
+BEGIN UPDATE accounts SET plan_checked_at = NULL WHERE id = NEW.account_id; END;

--- a/migrations/0008_plan_snapshots.sql
+++ b/migrations/0008_plan_snapshots.sql
@@ -1,4 +1,0 @@
--- A service may deliver ordered plan snapshots with a bounded validity period.
--- Existing manual assignments remain unlimited and start behind every revision.
-ALTER TABLE accounts ADD COLUMN plan_expires_at INTEGER CHECK (plan_expires_at >= 0);
-ALTER TABLE accounts ADD COLUMN plan_revision INTEGER NOT NULL DEFAULT 0 CHECK (plan_revision >= 0);

--- a/migrations/0008_plan_snapshots.sql
+++ b/migrations/0008_plan_snapshots.sql
@@ -1,0 +1,4 @@
+-- A service may deliver ordered plan snapshots with a bounded validity period.
+-- Existing manual assignments remain unlimited and start behind every revision.
+ALTER TABLE accounts ADD COLUMN plan_expires_at INTEGER CHECK (plan_expires_at >= 0);
+ALTER TABLE accounts ADD COLUMN plan_revision INTEGER NOT NULL DEFAULT 0 CHECK (plan_revision >= 0);

--- a/migrations/0009_newsletter_preference.sql
+++ b/migrations/0009_newsletter_preference.sql
@@ -1,0 +1,5 @@
+-- Nullable on existing accounts: no newsletter choice has been recorded.
+ALTER TABLE accounts ADD COLUMN newsletter_opt_in INTEGER CHECK (newsletter_opt_in IN (0, 1));
+ALTER TABLE accounts ADD COLUMN newsletter_choice_at INTEGER;
+-- The choice travels through OAuth, but is committed only on device confirmation.
+ALTER TABLE device_codes ADD COLUMN newsletter_opt_in INTEGER NOT NULL DEFAULT 0 CHECK (newsletter_opt_in IN (0, 1));

--- a/migrations/0010_pending_signup.sql
+++ b/migrations/0010_pending_signup.sql
@@ -1,0 +1,3 @@
+-- Hold a verified identity until the person accepts Terms and creates an account.
+ALTER TABLE device_codes ADD COLUMN pending_subject TEXT;
+ALTER TABLE device_codes ADD COLUMN pending_email TEXT;

--- a/migrations/0011_review_cache_state.sql
+++ b/migrations/0011_review_cache_state.sql
@@ -1,0 +1,10 @@
+-- A rejection must survive overlapping successful license checks.
+ALTER TABLE publishers ADD COLUMN rejected_at INTEGER CHECK (rejected_at >= 0);
+
+-- Bound entitlement retries during an outage independently of paid validity.
+ALTER TABLE accounts ADD COLUMN plan_retry_after INTEGER;
+DROP TRIGGER owner_link_refresh;
+CREATE TRIGGER owner_link_refresh AFTER INSERT ON owner_links
+BEGIN
+  UPDATE accounts SET plan_checked_at = NULL, plan_retry_after = NULL WHERE id = NEW.account_id;
+END;

--- a/migrations/0012_newsletter_delivery.sql
+++ b/migrations/0012_newsletter_delivery.sql
@@ -1,0 +1,2 @@
+-- Delivery state is separate from the saved newsletter consent.
+ALTER TABLE accounts ADD COLUMN newsletter_synced_at INTEGER;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3857,7 +3857,7 @@
       }
     },
     "packages/openartifacts": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "bin": {
         "openartifacts": "bin/openartifacts.js"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "wrangler dev --var SERVING_HOST: --var API_HOST: --var LEGACY_SERVING_HOST: --var RETIRED_API_HOST: --local-upstream 127.0.0.1:8787",
-    "deploy": "wrangler deploy",
+    "deploy": "node scripts/check-account-actions.cjs && wrangler deploy",
     "typecheck": "tsc --noEmit && npm run typecheck -w packages/openartifacts",
     "test": "vitest run && npm test -w packages/openartifacts",
     "test:watch": "vitest"

--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -4,7 +4,7 @@ Install the CLI and the OpenArtifacts skill into detected Claude Code, Codex, Op
 and pi installations:
 
 ```bash
-npx openartifacts install
+npx --yes openartifacts@latest install
 ```
 
 Hermes Agent needs only its native skill install:
@@ -49,6 +49,35 @@ The first authenticated command opens the browser device flow and stores the res
 token with owner-only permissions. Set `OPENARTIFACTS_TOKEN` to supply a credential
 without browser sign-in; it accepts an OpenArtifacts token or a Brevilabs license key.
 Set `OPENARTIFACTS_API_HOST` to target a self-hosted deployment.
+
+## Account and browser actions
+
+An OpenArtifacts account can publish within the deployment's free limits.
+Signing in is separate from purchasing an upgrade. Check current access with:
+
+```bash
+openartifacts account
+openartifacts upgrade
+openartifacts billing
+openartifacts link-copilot
+```
+
+`account` prints JSON with the plan, limits, current usage, and whether an external
+account is linked. The other commands print `{"url":"…","expiresAt":…}` and open
+the browser. These links expire after ten minutes and can be used once. Their
+availability depends on the deployment's configured account-action service.
+
+These four commands require an OAuth-issued OpenArtifacts token. The CLI uses
+the current API host's stored token, or `OPENARTIFACTS_TOKEN` when set. Without a
+credential it starts the normal sign-in flow. If the environment contains a
+license key, unset it and run `openartifacts login` before these account commands.
+A rejected credential is reported; it does not silently start another sign-in.
+
+For linking, enter the license key only on the trusted browser page and confirm
+the association there. Never put the key in command arguments or chat. Linking
+joins document history while preserving published URLs and existing machine tokens.
+It does not itself complete a purchase. On a publishing limit, run `upgrade` to
+obtain authenticated browser access; an owner ID in a URL is not account proof.
 
 ## Hosts
 

--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -1,20 +1,20 @@
 # OpenArtifacts CLI
 
-Install the skill from your project folder and select your agent:
+Install the CLI and bundled skill into detected agents:
+
+```bash
+npx openartifacts@latest install
+```
+
+Alternatively, install only the skill from your project folder using the standard
+skills manager:
 
 ```bash
 npx skills add Brevilabs/OpenArtifacts
 ```
 
-This installs the skill and bundled themes. The agent can run the CLI through
-`npx --yes openartifacts@latest`; a global CLI installation is optional.
-Add `--global` to install the skill across projects.
-
-To install the CLI globally and copy the skill into detected agents instead:
-
-```bash
-npx --yes openartifacts@latest install
-```
+The skill can run the CLI through `npx --yes openartifacts@latest` when it is not
+installed globally. Add `--global` to the skills command to install across projects.
 
 Hermes Agent needs only its native skill install:
 

--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -57,17 +57,16 @@ Signing in is separate from purchasing an upgrade. Check current access with:
 
 ```bash
 openartifacts account
-openartifacts upgrade
-openartifacts billing
-openartifacts link-copilot
+openartifacts account --open
 ```
 
 `account` prints JSON with the plan, limits, current usage, and whether an external
-account is linked. The other commands print `{"url":"…","expiresAt":…}` and open
+account is linked, plus refresh status, last check time and paid expiry.
+`account --open` prints `{"url":"…","expiresAt":…}` and open
 the browser. These links expire after ten minutes and can be used once. Their
 availability depends on the deployment's configured account-action service.
 
-These four commands require an OAuth-issued OpenArtifacts token. The CLI uses
+Both forms require an OAuth-issued OpenArtifacts token. The CLI uses
 the current API host's stored token, or `OPENARTIFACTS_TOKEN` when set. Without a
 credential it starts the normal sign-in flow. If the environment contains a
 license key, unset it and run `openartifacts login` before these account commands.
@@ -76,7 +75,7 @@ A rejected credential is reported; it does not silently start another sign-in.
 For linking, enter the license key only on the trusted browser page and confirm
 the association there. Never put the key in command arguments or chat. Linking
 joins document history while preserving published URLs and existing machine tokens.
-It does not itself complete a purchase. On a publishing limit, run `upgrade` to
+It does not itself complete a purchase. On a publishing limit, run `account --open` to
 obtain authenticated browser access; an owner ID in a URL is not account proof.
 
 ## Hosts

--- a/packages/openartifacts/README.md
+++ b/packages/openartifacts/README.md
@@ -1,7 +1,16 @@
 # OpenArtifacts CLI
 
-Install the CLI and the OpenArtifacts skill into detected Claude Code, Codex, OpenCode,
-and pi installations:
+Install the skill from your project folder and select your agent:
+
+```bash
+npx skills add Brevilabs/OpenArtifacts
+```
+
+This installs the skill and bundled themes. The agent can run the CLI through
+`npx --yes openartifacts@latest`; a global CLI installation is optional.
+Add `--global` to install the skill across projects.
+
+To install the CLI globally and copy the skill into detected agents instead:
 
 ```bash
 npx --yes openartifacts@latest install

--- a/packages/openartifacts/package.json
+++ b/packages/openartifacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openartifacts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Install the OpenArtifacts agent skill and publish agent-rendered HTML from the terminal",
   "keywords": [
     "agent-skills",

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -78,8 +78,7 @@ the user to paste a credential into the chat.
 
 Use `openartifacts account` to report the current plan, limits, usage, and linked
 status. When the user asks to upgrade, manage billing, or link their existing
-Copilot account, run `openartifacts upgrade`, `openartifacts billing`, or
-`openartifacts link-copilot`. Relay the returned short-lived browser URL. The user
+Copilot account, run `openartifacts account --open`. Relay the returned short-lived browser URL. The user
 enters a license key and confirms linking only on that page, never in chat or
 command arguments. These commands require an OAuth-issued account token; follow
 the CLI guidance if an environment license key overrides the stored token.
@@ -88,5 +87,5 @@ the CLI guidance if an environment license key overrides the stored token.
 
 Relay the CLI's message verbatim and do not retry blindly. For `quota_exceeded`, say
 whether to wait or unshare an unused page. For `limit_reached`, show the limit and the
-guidance to run `openartifacts upgrade`. Generate that browser link when the user
+guidance to run `openartifacts account --open`. Generate that browser link when the user
 asks to upgrade; do not treat a limit error as purchase authorization.

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -86,6 +86,8 @@ the CLI guidance if an environment license key overrides the stored token.
 ## Errors
 
 Relay the CLI's message verbatim and do not retry blindly. For `quota_exceeded`, say
-whether to wait or unshare an unused page. For `limit_reached`, show the limit and the
-guidance to run `openartifacts account --open`. Generate that browser link when the user
-asks to upgrade; do not treat a limit error as purchase authorization.
+whether to wait or unshare an unused page. For `limit_reached`, show the limit.
+Relay guidance to run `openartifacts account --open` only when the CLI response
+includes it; self-hosted servers may not offer browser account management. Generate
+that browser link only when supported and the user asks to upgrade; do not treat
+a limit error as purchase authorization.

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -71,12 +71,22 @@ The CLI reads `OPENARTIFACTS_TOKEN` from the environment. It accepts an OpenArti
 token or a Brevilabs license key. Without it, the first authenticated command starts a
 browser sign-in: relay both urls and the code the CLI prints, then keep waiting.
 
-Publishing needs a paid OpenArtifacts plan. On `unauthorized`, tell the user they need a
-credential with publishing access before anything can be published. Never read
-credential files, print tokens, or ask the user to paste a credential into the chat.
+OpenArtifacts accounts can publish within their free limits. Sign-in does not
+require buying a plan. On `unauthorized`, relay the sign-in guidance rather than
+claiming payment is required. Never read credential files, print tokens, or ask
+the user to paste a credential into the chat.
+
+Use `openartifacts account` to report the current plan, limits, usage, and linked
+status. When the user asks to upgrade, manage billing, or link their existing
+Copilot account, run `openartifacts upgrade`, `openartifacts billing`, or
+`openartifacts link-copilot`. Relay the returned short-lived browser URL. The user
+enters a license key and confirms linking only on that page, never in chat or
+command arguments. These commands require an OAuth-issued account token; follow
+the CLI guidance if an environment license key overrides the stored token.
 
 ## Errors
 
 Relay the CLI's message verbatim and do not retry blindly. For `quota_exceeded`, say
 whether to wait or unshare an unused page. For `limit_reached`, show the limit and the
-upgrade link the CLI prints.
+guidance to run `openartifacts upgrade`. Generate that browser link when the user
+asks to upgrade; do not treat a limit error as purchase authorization.

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -221,10 +221,7 @@ const HELP = `Usage: openartifacts <command> [argument] [options]
 Commands:
   install            Install or upgrade the CLI and detected agent skills
   login              Approve this machine and store its token
-  account            Show this account's plan, limits, and usage as JSON
-  upgrade            Open account upgrade options
-  billing            Open account billing management
-  link-copilot       Open secure browser confirmation to link an existing license
+  account [--open]   Refresh plan, limits, and usage; open account management with --open
   publish <file.html> [--title <title>] [--doc-id <docId>]
                      Publish an HTML file; pass --doc-id to update an existing document
   list               List published documents
@@ -267,11 +264,11 @@ export async function main(args) {
     console.log(HELP);
     return;
   }
-  if (!["install", "login", "account", "upgrade", "billing", "link-copilot", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
+  if (!["install", "login", "account", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
     throw new Error(HELP);
   }
   const needsArgument = ["publish", "get", "unshare", "revoke"].includes(command);
-  if ((extra.length && command !== "publish") || (needsArgument && !argument) || (!needsArgument && argument)) {
+  if ((extra.length && command !== "publish") || (needsArgument && !argument) || (!needsArgument && argument && !(command === "account" && argument === "--open"))) {
     throw new Error(HELP);
   }
   const value = argument ?? "";
@@ -287,21 +284,19 @@ export async function main(args) {
 
   const token = await credential(host, directory);
   const client = createClient({ host, token });
-  /** @type {Record<string, "upgrade" | "billing" | "link">} */
-  const actions = { upgrade: "upgrade", billing: "billing", "link-copilot": "link" };
-  const purpose = actions[command];
-  if ((command === "account" || purpose) && !token.startsWith("oat_")) {
+  if (command === "account" && !token.startsWith("oat_")) {
     throw new Error("This command needs an OpenArtifacts account token. Run `openartifacts login`; unset OPENARTIFACTS_TOKEN if it contains a license key.");
   }
-  if (command === "account") {
+  if (command === "account" && !argument) {
     const result = await client.account();
     console.log(JSON.stringify({ accountId: result.accountId, plan: result.plan,
       limits: { documents: result.limits.documents, pushesPerDay: result.limits.pushesPerDay, htmlBytes: result.limits.htmlBytes },
-      usage: { documents: result.usage.documents, pushesToday: result.usage.pushesToday }, externalLinked: result.externalLinked }));
+      usage: { documents: result.usage.documents, pushesToday: result.usage.pushesToday }, externalLinked: result.externalLinked,
+      refresh: { status: result.refresh.status, checkedAt: result.refresh.checkedAt, expiresAt: result.refresh.expiresAt } }));
     return;
   }
-  if (purpose) {
-    const result = await client.createHandoff(purpose);
+  if (command === "account") {
+    const result = await client.createHandoff();
     const url = new URL(result.url);
     const local = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
     if (url.username || url.password || url.hash || url.href.includes(token) ||
@@ -366,7 +361,7 @@ export function presentError(error) {
     }
     if (error.code === "limit_reached") {
       if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);
-      console.error("Run `openartifacts upgrade` to get a secure account upgrade link.");
+      console.error("Run `openartifacts account --open` to get a secure account upgrade link.");
     }
   } else {
     console.error(error instanceof Error ? error.message : String(error));

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -361,7 +361,7 @@ export function presentError(error) {
     }
     if (error.code === "limit_reached") {
       if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);
-      console.error("Run `openartifacts account --open` to get a secure account upgrade link.");
+      if (error.detail.upgrade_url) console.error(`Upgrade: ${error.detail.upgrade_url}`);
     }
   } else {
     console.error(error instanceof Error ? error.message : String(error));

--- a/packages/openartifacts/src/cli.js
+++ b/packages/openartifacts/src/cli.js
@@ -90,12 +90,21 @@ async function writePrivateJson(path, value) {
   await chmod(path, 0o600);
 }
 
+/** Keep browser URLs as data, including Windows shell metacharacters.
+ * @param {string} url @param {NodeJS.Platform} [os]
+ */
+export function browserProcess(url, os = platform()) {
+  return os === "win32"
+    ? { command: "powershell.exe", args: ["-NoProfile", "-NonInteractive", "-Command", "Start-Process -FilePath $env:OPENARTIFACTS_BROWSER_URL"],
+      env: { ...process.env, OPENARTIFACTS_BROWSER_URL: url } }
+    : { command: os === "darwin" ? "open" : "xdg-open", args: [url], env: process.env };
+}
+
 /** @param {string} url */
 function openBrowser(url) {
-  const command = platform() === "darwin" ? "open" : platform() === "win32" ? "cmd" : "xdg-open";
-  const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
+  const opener = browserProcess(url);
   try {
-    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    const child = spawn(opener.command, opener.args, { env: opener.env, shell: false, detached: true, stdio: "ignore" });
     child.on("error", () => {});
     child.unref();
   } catch {}
@@ -212,6 +221,10 @@ const HELP = `Usage: openartifacts <command> [argument] [options]
 Commands:
   install            Install or upgrade the CLI and detected agent skills
   login              Approve this machine and store its token
+  account            Show this account's plan, limits, and usage as JSON
+  upgrade            Open account upgrade options
+  billing            Open account billing management
+  link-copilot       Open secure browser confirmation to link an existing license
   publish <file.html> [--title <title>] [--doc-id <docId>]
                      Publish an HTML file; pass --doc-id to update an existing document
   list               List published documents
@@ -254,7 +267,7 @@ export async function main(args) {
     console.log(HELP);
     return;
   }
-  if (!["install", "login", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
+  if (!["install", "login", "account", "upgrade", "billing", "link-copilot", "publish", "list", "get", "unshare", "tokens", "revoke"].includes(command)) {
     throw new Error(HELP);
   }
   const needsArgument = ["publish", "get", "unshare", "revoke"].includes(command);
@@ -274,6 +287,33 @@ export async function main(args) {
 
   const token = await credential(host, directory);
   const client = createClient({ host, token });
+  /** @type {Record<string, "upgrade" | "billing" | "link">} */
+  const actions = { upgrade: "upgrade", billing: "billing", "link-copilot": "link" };
+  const purpose = actions[command];
+  if ((command === "account" || purpose) && !token.startsWith("oat_")) {
+    throw new Error("This command needs an OpenArtifacts account token. Run `openartifacts login`; unset OPENARTIFACTS_TOKEN if it contains a license key.");
+  }
+  if (command === "account") {
+    const result = await client.account();
+    console.log(JSON.stringify({ accountId: result.accountId, plan: result.plan,
+      limits: { documents: result.limits.documents, pushesPerDay: result.limits.pushesPerDay, htmlBytes: result.limits.htmlBytes },
+      usage: { documents: result.usage.documents, pushesToday: result.usage.pushesToday }, externalLinked: result.externalLinked }));
+    return;
+  }
+  if (purpose) {
+    const result = await client.createHandoff(purpose);
+    const url = new URL(result.url);
+    const local = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    if (url.username || url.password || url.hash || url.href.includes(token) ||
+      (url.protocol !== "https:" && !(url.protocol === "http:" && local)) ||
+      !/^[0-9a-f]{64}$/.test(url.searchParams.get("code") ?? "") ||
+      !Number.isSafeInteger(result.expiresAt) || result.expiresAt <= Date.now()) {
+      throw new Error("The server returned an invalid account action link.");
+    }
+    console.log(JSON.stringify({ url: url.toString(), expiresAt: result.expiresAt }));
+    openBrowser(url.toString());
+    return;
+  }
 
   if (prepared) {
     try {
@@ -326,7 +366,7 @@ export function presentError(error) {
     }
     if (error.code === "limit_reached") {
       if (error.detail.limit) console.error(`Limit: ${error.detail.limit}`);
-      if (error.detail.upgrade_url) console.error(`Upgrade: ${error.detail.upgrade_url}`);
+      console.error("Run `openartifacts upgrade` to get a secure account upgrade link.");
     }
   } else {
     console.error(error instanceof Error ? error.message : String(error));

--- a/packages/openartifacts/src/client.js
+++ b/packages/openartifacts/src/client.js
@@ -42,6 +42,11 @@ export function createClient({ host, token, fetcher = fetch }) {
   }
 
   return {
+    account: () => request("/api/v1/account"),
+    /** @param {"upgrade" | "billing" | "link"} purpose */
+    createHandoff: (purpose) => request("/api/v1/account/handoffs", {
+      method: "POST", body: JSON.stringify({ purpose }),
+    }),
     /** @param {string} label */
     deviceCode: (label) =>
       request("/device/code", { method: "POST", body: JSON.stringify({ label }) }),

--- a/packages/openartifacts/src/client.js
+++ b/packages/openartifacts/src/client.js
@@ -43,10 +43,7 @@ export function createClient({ host, token, fetcher = fetch }) {
 
   return {
     account: () => request("/api/v1/account"),
-    /** @param {"upgrade" | "billing" | "link"} purpose */
-    createHandoff: (purpose) => request("/api/v1/account/handoffs", {
-      method: "POST", body: JSON.stringify({ purpose }),
-    }),
+    createHandoff: () => request("/api/v1/account/handoffs", { method: "POST" }),
     /** @param {string} label */
     deviceCode: (label) =>
       request("/device/code", { method: "POST", body: JSON.stringify({ label }) }),

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -351,7 +351,7 @@ test("prints guidance for current quota and future plan limits", () => {
   }
   assert(lines.some((line) => line.includes("quota window")));
   assert(lines.includes("Limit: 10 documents"));
-  assert(lines.some((line) => line.includes("openartifacts upgrade")));
+  assert(lines.some((line) => line.includes("openartifacts account --open")));
   assert(!lines.some((line) => line.includes("https://example.test/upgrade")));
 });
 
@@ -368,7 +368,7 @@ async function accountServer() {
       if (control.status !== 200) {
         response.end(JSON.stringify({ error: { code: "unauthorized", message: "Sign in again." } }));
       } else if (request.url === "/api/v1/account") {
-        response.end(JSON.stringify({ accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false, access_token: "never-print-response-extra" }));
+        response.end(JSON.stringify({ accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false, refresh: { status: "refreshed", checkedAt: 123, expiresAt: null }, access_token: "never-print-response-extra" }));
       } else if (request.url === "/api/v1/account/handoffs") {
         response.end(JSON.stringify({ url: control.unsafeUrl ? "javascript:alert(1)" : `https://actions.example.test/continue?code=${"a".repeat(64)}`, expiresAt: Date.now() + 600000, token: "never-print-response-extra" }));
       } else {
@@ -404,9 +404,9 @@ test("account commands use host-scoped stored OAuth tokens and print only safe J
   try {
     const account = await cliProcess(["account"], env);
     assert.equal(account.code, 0, account.stderr);
-    assert.deepEqual(JSON.parse(account.stdout), { accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
-    for (const command of ["upgrade", "billing", "link-copilot"]) {
-      const result = await cliProcess([command], env);
+    assert.deepEqual(JSON.parse(account.stdout), { accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false, refresh: { status: "refreshed", checkedAt: 123, expiresAt: null } });
+    for (const args of [["account", "--open"]]) {
+      const result = await cliProcess(args, env);
       assert.equal(result.code, 0, result.stderr);
       const parsed = JSON.parse(result.stdout);
       assert.deepEqual(Object.keys(parsed).sort(), ["expiresAt", "url"]);
@@ -416,9 +416,7 @@ test("account commands use host-scoped stored OAuth tokens and print only safe J
     }
     assert.deepEqual(remote.requests.map(({ method, path, body }) => [method, path, body]), [
       ["GET", "/api/v1/account", undefined],
-      ["POST", "/api/v1/account/handoffs", { purpose: "upgrade" }],
-      ["POST", "/api/v1/account/handoffs", { purpose: "billing" }],
-      ["POST", "/api/v1/account/handoffs", { purpose: "link" }],
+      ["POST", "/api/v1/account/handoffs", undefined],
     ]);
     assert(remote.requests.every((r) => r.authorization === "Bearer oat_stored-secret"));
   } finally { remote.server.close(); }
@@ -438,7 +436,7 @@ test("account actions honor environment credentials, refuse license arguments, a
       assert.match(result.stderr, /Usage: openartifacts/);
       assert(!result.stderr.includes("license-secret-must-not-leak"));
     }
-    const license = await cliProcess(["link-copilot"], { ...env, OPENARTIFACTS_TOKEN: "license-secret" });
+    const license = await cliProcess(["account", "--open"], { ...env, OPENARTIFACTS_TOKEN: "license-secret" });
     assert.equal(license.code, 1);
     assert.match(license.stderr, /unset OPENARTIFACTS_TOKEN/);
     assert.equal(remote.requests.length, 1);
@@ -458,7 +456,7 @@ test("account actions reject unsafe browser URLs without printing them", async (
   const remote = await accountServer();
   remote.control.unsafeUrl = true;
   try {
-    const result = await cliProcess(["upgrade"], { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host, OPENARTIFACTS_TOKEN: "oat_test-secret" });
+    const result = await cliProcess(["account", "--open"], { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host, OPENARTIFACTS_TOKEN: "oat_test-secret" });
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
     assert.match(result.stderr, /invalid account action link/);

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -5,7 +5,7 @@ import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { collectToken, configDir, detectAgents, installSkills, main, npmProcess, preparePublish, presentError } from "../src/cli.js";
+import { browserProcess, collectToken, configDir, detectAgents, installSkills, main, npmProcess, preparePublish, presentError } from "../src/cli.js";
 import { APIError } from "../src/client.js";
 
 /** Point the CLI at a scratch config directory and host for one test. */
@@ -351,5 +351,128 @@ test("prints guidance for current quota and future plan limits", () => {
   }
   assert(lines.some((line) => line.includes("quota window")));
   assert(lines.includes("Limit: 10 documents"));
-  assert(lines.includes("Upgrade: https://example.test/upgrade"));
+  assert(lines.some((line) => line.includes("openartifacts upgrade")));
+  assert(!lines.some((line) => line.includes("https://example.test/upgrade")));
+});
+
+async function accountServer() {
+  const requests = [];
+  const control = { status: 200, unsafeUrl: false };
+  const server = createServer((request, response) => {
+    let raw = "";
+    request.on("data", (chunk) => { raw += chunk; });
+    request.on("end", () => {
+      requests.push({ method: request.method, path: request.url, authorization: request.headers.authorization, body: raw ? JSON.parse(raw) : undefined });
+      response.setHeader("content-type", "application/json");
+      response.statusCode = control.status;
+      if (control.status !== 200) {
+        response.end(JSON.stringify({ error: { code: "unauthorized", message: "Sign in again." } }));
+      } else if (request.url === "/api/v1/account") {
+        response.end(JSON.stringify({ accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false, access_token: "never-print-response-extra" }));
+      } else if (request.url === "/api/v1/account/handoffs") {
+        response.end(JSON.stringify({ url: control.unsafeUrl ? "javascript:alert(1)" : `https://actions.example.test/continue?code=${"a".repeat(64)}`, expiresAt: Date.now() + 600000, token: "never-print-response-extra" }));
+      } else {
+        response.statusCode = 500;
+        response.end(JSON.stringify({ error: { message: "Unexpected login or request." } }));
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { server, requests, control, host: `http://127.0.0.1:${server.address().port}` };
+}
+
+async function cliProcess(args, values) {
+  const { spawn } = await import("node:child_process");
+  const env = { ...process.env, ...values, PATH: "" }; // Browser launch fails harmlessly; never open a real browser in tests.
+  if (!values.OPENARTIFACTS_TOKEN) delete env.OPENARTIFACTS_TOKEN;
+  const child = spawn(process.execPath, [new URL("../bin/openartifacts.js", import.meta.url).pathname, ...args], { env });
+  let stdout = "", stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const [code] = await once(child, "close");
+  return { code, stdout, stderr };
+}
+
+test("account commands use host-scoped stored OAuth tokens and print only safe JSON fields", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "oa-01a08465-cli-account-"));
+  const remote = await accountServer();
+  await writeFile(join(directory, "credentials.json"), JSON.stringify({ hosts: {
+    [remote.host]: { token: "oat_stored-secret" }, "https://other.test": { token: "oat_other-secret" },
+  } }));
+  const env = { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host };
+  try {
+    const account = await cliProcess(["account"], env);
+    assert.equal(account.code, 0, account.stderr);
+    assert.deepEqual(JSON.parse(account.stdout), { accountId: "oa_account", plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
+    for (const command of ["upgrade", "billing", "link-copilot"]) {
+      const result = await cliProcess([command], env);
+      assert.equal(result.code, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.deepEqual(Object.keys(parsed).sort(), ["expiresAt", "url"]);
+      assert.equal(new URL(parsed.url).searchParams.get("code"), "a".repeat(64));
+      assert(!`${result.stdout}${result.stderr}`.includes("secret"));
+      assert(!result.stdout.includes("never-print-response-extra"));
+    }
+    assert.deepEqual(remote.requests.map(({ method, path, body }) => [method, path, body]), [
+      ["GET", "/api/v1/account", undefined],
+      ["POST", "/api/v1/account/handoffs", { purpose: "upgrade" }],
+      ["POST", "/api/v1/account/handoffs", { purpose: "billing" }],
+      ["POST", "/api/v1/account/handoffs", { purpose: "link" }],
+    ]);
+    assert(remote.requests.every((r) => r.authorization === "Bearer oat_stored-secret"));
+  } finally { remote.server.close(); }
+});
+
+test("account actions honor environment credentials, refuse license arguments, and never silently re-login", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "oa-01a08465-cli-credentials-"));
+  const remote = await accountServer();
+  const env = { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host, OPENARTIFACTS_TOKEN: "oat_environment-secret" };
+  await writeFile(join(directory, "credentials.json"), JSON.stringify({ hosts: { [remote.host]: { token: "oat_stored-secret" } } }));
+  try {
+    assert.equal((await cliProcess(["account"], env)).code, 0);
+    assert.equal(remote.requests[0].authorization, "Bearer oat_environment-secret");
+    for (const command of ["account", "upgrade", "billing", "link-copilot"]) {
+      const result = await cliProcess([command, "license-secret-must-not-leak"], env);
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /Usage: openartifacts/);
+      assert(!result.stderr.includes("license-secret-must-not-leak"));
+    }
+    const license = await cliProcess(["link-copilot"], { ...env, OPENARTIFACTS_TOKEN: "license-secret" });
+    assert.equal(license.code, 1);
+    assert.match(license.stderr, /unset OPENARTIFACTS_TOKEN/);
+    assert.equal(remote.requests.length, 1);
+    remote.control.status = 401;
+    const rejected = await cliProcess(["account"], env);
+    assert.equal(rejected.code, 1);
+    assert.match(rejected.stderr, /openartifacts login/);
+    assert.equal(rejected.stdout, "");
+    assert(!rejected.stderr.includes("environment-secret"));
+    assert.deepEqual(remote.requests.map((r) => r.path), ["/api/v1/account", "/api/v1/account"]);
+    assert.equal(JSON.parse(await readFile(join(directory, "credentials.json"), "utf8")).hosts[remote.host].token, "oat_stored-secret");
+  } finally { remote.server.close(); }
+});
+
+test("account actions reject unsafe browser URLs without printing them", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "oa-01a08465-cli-url-"));
+  const remote = await accountServer();
+  remote.control.unsafeUrl = true;
+  try {
+    const result = await cliProcess(["upgrade"], { OPENARTIFACTS_CONFIG_DIR: directory, OPENARTIFACTS_API_HOST: remote.host, OPENARTIFACTS_TOKEN: "oat_test-secret" });
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /invalid account action link/);
+    assert(!result.stderr.includes("javascript:"));
+  } finally { remote.server.close(); }
+});
+
+test("Windows browser launch passes the complete URL as data rather than command text", () => {
+  const url = 'https://actions.example.test/?source=cli&code=abc&x=";Write-Output injected"';
+  const windows = browserProcess(url, "win32");
+  assert.equal(windows.command, "powershell.exe");
+  assert.deepEqual(windows.args, ["-NoProfile", "-NonInteractive", "-Command", "Start-Process -FilePath $env:OPENARTIFACTS_BROWSER_URL"]);
+  assert.equal(windows.env.OPENARTIFACTS_BROWSER_URL, url);
+  assert(!windows.args.some((arg) => arg.includes(url)));
+  assert.deepEqual(browserProcess(url, "darwin").args, [url]);
+  assert.deepEqual(browserProcess(url, "linux").args, [url]);
 });

--- a/packages/openartifacts/test/cli.node.js
+++ b/packages/openartifacts/test/cli.node.js
@@ -351,8 +351,8 @@ test("prints guidance for current quota and future plan limits", () => {
   }
   assert(lines.some((line) => line.includes("quota window")));
   assert(lines.includes("Limit: 10 documents"));
-  assert(lines.some((line) => line.includes("openartifacts account --open")));
-  assert(!lines.some((line) => line.includes("https://example.test/upgrade")));
+  assert(lines.some((line) => line.includes("https://example.test/upgrade")));
+  assert(!lines.some((line) => line.includes("openartifacts account --open")));
 });
 
 async function accountServer() {

--- a/scripts/check-account-actions.cjs
+++ b/scripts/check-account-actions.cjs
@@ -1,0 +1,14 @@
+const { readFileSync } = require("node:fs");
+
+/** Only the hosted deployment has mandatory account routing; self-hosted plans remain local. */
+function checkHostedAccountActions(config) {
+  const value = (key) => new RegExp(`"${key}"\\s*:\\s*"([^"]*)"`).exec(config)?.[1];
+  if (value("API_HOST") !== "api.openartifacts.ai") return;
+  for (const name of ["ACCOUNT_ACTION_URL", "UPGRADE_URL"]) {
+    if (value(name) !== "https://openartifacts.ai/account") {
+      throw new Error(`${name} must point to the hosted /account page before deployment.`);
+    }
+  }
+}
+if (require.main === module) checkHostedAccountActions(readFileSync("wrangler.jsonc", "utf8"));
+module.exports = { checkHostedAccountActions };

--- a/scripts/check-account-actions.cjs
+++ b/scripts/check-account-actions.cjs
@@ -1,8 +1,11 @@
 const { readFileSync } = require("node:fs");
+const { parseConfigFileTextToJson } = require("typescript");
 
 /** Only the hosted deployment has mandatory account routing; self-hosted plans remain local. */
 function checkHostedAccountActions(config) {
-  const value = (key) => new RegExp(`"${key}"\\s*:\\s*"([^"]*)"`).exec(config)?.[1];
+  const parsed = parseConfigFileTextToJson("wrangler.jsonc", config);
+  if (parsed.error) throw new Error("Invalid Wrangler JSONC configuration.");
+  const value = (key) => parsed.config?.vars?.[key];
   if (value("API_HOST") !== "api.openartifacts.ai") return;
   for (const name of ["ACCOUNT_ACTION_URL", "UPGRADE_URL"]) {
     if (value(name) !== "https://openartifacts.ai/account") {

--- a/scripts/check-release-pr.cjs
+++ b/scripts/check-release-pr.cjs
@@ -3,6 +3,15 @@ const { execFileSync } = require("node:child_process");
 
 const stableVersion = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
 
+function checkNextPatch(baseVersion, version) {
+  const base = stableVersion.exec(baseVersion ?? "");
+  const next = stableVersion.exec(version ?? "");
+  if (!base || !next || base[1] !== next[1] || base[2] !== next[2] ||
+      BigInt(next[3]) !== BigInt(base[3]) + 1n) {
+    throw new Error(`OpenArtifacts releases must use the next patch version after ${baseVersion}; received ${version}.`);
+  }
+}
+
 function checkReleasePR({ title, baseVersion, version, lockVersion }) {
   if (version !== lockVersion) {
     throw new Error("OpenArtifacts package.json and package-lock.json versions must match.");
@@ -12,6 +21,7 @@ function checkReleasePR({ title, baseVersion, version, lockVersion }) {
     if (!stableVersion.test(version) || title !== `v${version}`) {
       throw new Error(`An OpenArtifacts version change requires the exact PR title v${version}.`);
     }
+    checkNextPatch(baseVersion, version);
   }
 }
 
@@ -25,4 +35,4 @@ if (require.main === module) {
   console.log("OpenArtifacts release title and versions are consistent.");
 }
 
-module.exports = { checkReleasePR };
+module.exports = { checkReleasePR, checkNextPatch };

--- a/src/account.ts
+++ b/src/account.ts
@@ -34,7 +34,7 @@ function actionUrl(env: Env): URL | null {
 }
 
 export async function handleAccount(request: Request, env: Env, publisher: Publisher): Promise<Response> {
-  if (publisher.authKind !== "account") return errorResponse("unauthorized", "Sign in with an account token.");
+  if (publisher.authKind !== "account") return errorResponse("unauthorized", "Sign in with an account token.", { "www-authenticate": "Bearer" });
   const path = new URL(request.url).pathname;
   if (path === "/api/v1/account" && request.method === "GET") {
     const row = await env.DB.prepare(`${OWNER_SCOPE_SQL}
@@ -45,7 +45,7 @@ export async function handleAccount(request: Request, env: Env, publisher: Publi
       FROM accounts a WHERE a.id = ?`)
       .bind(publisher.owner, publisher.owner, utcDay(Date.now()), publisher.owner)
       .first<{ accountId: string; plan: string; plan_expires_at: number | null; plan_checked_at: number | null; documents: number; pushesToday: number; externalLinked: number }>();
-    if (!row) return errorResponse("unauthorized", "Sign in again.");
+    if (!row) return errorResponse("unauthorized", "Sign in again.", { "www-authenticate": "Bearer" });
     const plan = effectivePlan(env, row.plan, row.plan_expires_at);
     return Response.json({ accountId: row.accountId, plan, limits: planLimits(env, plan),
       usage: { documents: row.documents, pushesToday: row.pushesToday }, externalLinked: !!row.externalLinked,
@@ -63,7 +63,7 @@ export async function handleAccount(request: Request, env: Env, publisher: Publi
     env.DB.prepare(`INSERT INTO account_handoffs (code_hash, account_id, token_id, expires_at)
       SELECT ?, a.id, t.id, ? FROM tokens t JOIN accounts a ON a.id = t.account_id
       WHERE t.token_hash = ? AND a.id = ?
-        AND (SELECT COUNT(*) FROM account_handoffs WHERE account_id = a.id) < 5
+        AND (SELECT COUNT(*) FROM account_handoffs h JOIN tokens live ON live.id = h.token_id AND live.account_id = h.account_id WHERE h.account_id = a.id) < 5
       RETURNING code_hash`).bind(await sha256Hex(code), expiresAt, tokenHash, publisher.owner),
   ]);
   if (results[1]!.results.length === 0) return errorResponse("quota_exceeded", "Too many pending account actions, or token revoked. Sign in again or wait ten minutes.");

--- a/src/account.ts
+++ b/src/account.ts
@@ -7,7 +7,6 @@ import { effectivePlan, planLimits } from "./plans.js";
 import { readBodyWithin, utcDay } from "./quota.js";
 
 const NO_STORE = { "cache-control": "no-store" };
-const PURPOSES = new Set(["upgrade", "billing", "link"]);
 const HANDOFF_MS = 10 * 60 * 1000;
 
 /** Bounded, exact one-field JSON shared by the account and service APIs. */
@@ -39,34 +38,33 @@ export async function handleAccount(request: Request, env: Env, publisher: Publi
   const path = new URL(request.url).pathname;
   if (path === "/api/v1/account" && request.method === "GET") {
     const row = await env.DB.prepare(`${OWNER_SCOPE_SQL}
-      SELECT a.id AS accountId, a.plan, a.plan_expires_at,
+      SELECT a.id AS accountId, a.plan, a.plan_expires_at, a.plan_checked_at,
         (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) AS documents,
         (SELECT COALESCE(SUM(pushes), 0) FROM push_quota WHERE owner IN (SELECT owner FROM owner_scope) AND day = ?) AS pushesToday,
         EXISTS(SELECT 1 FROM owner_links WHERE account_id = a.id) AS externalLinked
       FROM accounts a WHERE a.id = ?`)
       .bind(publisher.owner, publisher.owner, utcDay(Date.now()), publisher.owner)
-      .first<{ accountId: string; plan: string; plan_expires_at: number | null; documents: number; pushesToday: number; externalLinked: number }>();
+      .first<{ accountId: string; plan: string; plan_expires_at: number | null; plan_checked_at: number | null; documents: number; pushesToday: number; externalLinked: number }>();
     if (!row) return errorResponse("unauthorized", "Sign in again.");
     const plan = effectivePlan(env, row.plan, row.plan_expires_at);
     return Response.json({ accountId: row.accountId, plan, limits: planLimits(env, plan),
-      usage: { documents: row.documents, pushesToday: row.pushesToday }, externalLinked: !!row.externalLinked }, { headers: NO_STORE });
+      usage: { documents: row.documents, pushesToday: row.pushesToday }, externalLinked: !!row.externalLinked,
+      refresh: { status: publisher.accountRefresh, checkedAt: row.plan_checked_at, expiresAt: row.plan_expires_at } }, { headers: NO_STORE });
   }
   if (path !== "/api/v1/account/handoffs" || request.method !== "POST") return errorResponse("not_found", "No account route.");
   const url = actionUrl(env);
   if (!url) return errorResponse("not_found", "Account actions are not configured.");
-  const purpose = await stringField(request, "purpose");
-  if (!purpose || !PURPOSES.has(purpose)) return errorResponse("bad_request", "Expected purpose upgrade, billing, or link.");
   const tokenHash = await sha256Hex(parseBearerToken(request.headers.get("authorization"))!);
   const code = Array.from(crypto.getRandomValues(new Uint8Array(32)), (b) => b.toString(16).padStart(2, "0")).join("");
   const now = Date.now();
   const expiresAt = now + HANDOFF_MS;
   const results = await env.DB.batch([
     env.DB.prepare("DELETE FROM account_handoffs WHERE account_id = ? AND expires_at <= ?").bind(publisher.owner, now),
-    env.DB.prepare(`INSERT INTO account_handoffs (code_hash, account_id, token_id, purpose, expires_at)
-      SELECT ?, a.id, t.id, ?, ? FROM tokens t JOIN accounts a ON a.id = t.account_id
+    env.DB.prepare(`INSERT INTO account_handoffs (code_hash, account_id, token_id, expires_at)
+      SELECT ?, a.id, t.id, ? FROM tokens t JOIN accounts a ON a.id = t.account_id
       WHERE t.token_hash = ? AND a.id = ?
         AND (SELECT COUNT(*) FROM account_handoffs WHERE account_id = a.id) < 5
-      RETURNING code_hash`).bind(await sha256Hex(code), purpose, expiresAt, tokenHash, publisher.owner),
+      RETURNING code_hash`).bind(await sha256Hex(code), expiresAt, tokenHash, publisher.owner),
   ]);
   if (results[1]!.results.length === 0) return errorResponse("quota_exceeded", "Too many pending account actions, or token revoked. Sign in again or wait ten minutes.");
   url.searchParams.set("code", code);
@@ -81,7 +79,7 @@ export async function consumeHandoff(request: Request, env: Env): Promise<Respon
     WHERE code_hash = ? AND expires_at > ?
       AND EXISTS(SELECT 1 FROM tokens t JOIN accounts a ON a.id = t.account_id
                  WHERE t.id = account_handoffs.token_id AND a.id = account_handoffs.account_id)
-    RETURNING account_id AS accountId, purpose,
+    RETURNING account_id AS accountId,
       (SELECT email FROM accounts WHERE id = account_handoffs.account_id) AS email,
       (SELECT external_owner FROM owner_links WHERE account_id = account_handoffs.account_id) AS externalOwner`)
     .bind(await sha256Hex(code), Date.now()).first();

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,0 +1,90 @@
+import { parseBearerToken, type Publisher } from "./auth.js";
+import type { Env } from "./config.js";
+import { errorResponse } from "./errors.js";
+import { sha256Hex } from "./hash.js";
+import { OWNER_SCOPE_SQL } from "./owners.js";
+import { effectivePlan, planLimits } from "./plans.js";
+import { readBodyWithin, utcDay } from "./quota.js";
+
+const NO_STORE = { "cache-control": "no-store" };
+const PURPOSES = new Set(["upgrade", "billing", "link"]);
+const HANDOFF_MS = 10 * 60 * 1000;
+
+/** Bounded, exact one-field JSON shared by the account and service APIs. */
+export async function stringField(request: Request, field: string): Promise<string | null> {
+  const raw = await readBodyWithin(request, 1024);
+  if (!raw) return null;
+  try {
+    const body: unknown = JSON.parse(new TextDecoder().decode(raw));
+    if (!body || typeof body !== "object" || Array.isArray(body) ||
+      Object.keys(body).length !== 1 || !(field in body)) return null;
+    const value = (body as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : null;
+  } catch { return null; }
+}
+
+function actionUrl(env: Env): URL | null {
+  if (!env.ACCOUNT_ACTION_URL?.trim()) return null;
+  const url = new URL(env.ACCOUNT_ACTION_URL);
+  const local = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (url.username || url.password || url.hash ||
+    (url.protocol !== "https:" && !(url.protocol === "http:" && local))) {
+    throw new Error("ACCOUNT_ACTION_URL must be HTTPS without credentials or fragment (local HTTP is allowed).");
+  }
+  return url;
+}
+
+export async function handleAccount(request: Request, env: Env, publisher: Publisher): Promise<Response> {
+  if (publisher.authKind !== "account") return errorResponse("unauthorized", "Sign in with an account token.");
+  const path = new URL(request.url).pathname;
+  if (path === "/api/v1/account" && request.method === "GET") {
+    const row = await env.DB.prepare(`${OWNER_SCOPE_SQL}
+      SELECT a.id AS accountId, a.plan, a.plan_expires_at,
+        (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) AS documents,
+        (SELECT COALESCE(SUM(pushes), 0) FROM push_quota WHERE owner IN (SELECT owner FROM owner_scope) AND day = ?) AS pushesToday,
+        EXISTS(SELECT 1 FROM owner_links WHERE account_id = a.id) AS externalLinked
+      FROM accounts a WHERE a.id = ?`)
+      .bind(publisher.owner, publisher.owner, utcDay(Date.now()), publisher.owner)
+      .first<{ accountId: string; plan: string; plan_expires_at: number | null; documents: number; pushesToday: number; externalLinked: number }>();
+    if (!row) return errorResponse("unauthorized", "Sign in again.");
+    const plan = effectivePlan(env, row.plan, row.plan_expires_at);
+    return Response.json({ accountId: row.accountId, plan, limits: planLimits(env, plan),
+      usage: { documents: row.documents, pushesToday: row.pushesToday }, externalLinked: !!row.externalLinked }, { headers: NO_STORE });
+  }
+  if (path !== "/api/v1/account/handoffs" || request.method !== "POST") return errorResponse("not_found", "No account route.");
+  const url = actionUrl(env);
+  if (!url) return errorResponse("not_found", "Account actions are not configured.");
+  const purpose = await stringField(request, "purpose");
+  if (!purpose || !PURPOSES.has(purpose)) return errorResponse("bad_request", "Expected purpose upgrade, billing, or link.");
+  const tokenHash = await sha256Hex(parseBearerToken(request.headers.get("authorization"))!);
+  const code = Array.from(crypto.getRandomValues(new Uint8Array(32)), (b) => b.toString(16).padStart(2, "0")).join("");
+  const now = Date.now();
+  const expiresAt = now + HANDOFF_MS;
+  const results = await env.DB.batch([
+    env.DB.prepare("DELETE FROM account_handoffs WHERE account_id = ? AND expires_at <= ?").bind(publisher.owner, now),
+    env.DB.prepare(`INSERT INTO account_handoffs (code_hash, account_id, token_id, purpose, expires_at)
+      SELECT ?, a.id, t.id, ?, ? FROM tokens t JOIN accounts a ON a.id = t.account_id
+      WHERE t.token_hash = ? AND a.id = ?
+        AND (SELECT COUNT(*) FROM account_handoffs WHERE account_id = a.id) < 5
+      RETURNING code_hash`).bind(await sha256Hex(code), purpose, expiresAt, tokenHash, publisher.owner),
+  ]);
+  if (results[1]!.results.length === 0) return errorResponse("quota_exceeded", "Too many pending account actions, or token revoked. Sign in again or wait ten minutes.");
+  url.searchParams.set("code", code);
+  return Response.json({ url: url.toString(), expiresAt }, { headers: NO_STORE });
+}
+
+/** The service credential is checked by handleAdmin before this one-use proof. */
+export async function consumeHandoff(request: Request, env: Env): Promise<Response> {
+  const code = await stringField(request, "code");
+  if (!code || !/^[0-9a-f]{64}$/.test(code)) return errorResponse("bad_request", "Expected a handoff code.");
+  const row = await env.DB.prepare(`DELETE FROM account_handoffs
+    WHERE code_hash = ? AND expires_at > ?
+      AND EXISTS(SELECT 1 FROM tokens t JOIN accounts a ON a.id = t.account_id
+                 WHERE t.id = account_handoffs.token_id AND a.id = account_handoffs.account_id)
+    RETURNING account_id AS accountId, purpose,
+      (SELECT email FROM accounts WHERE id = account_handoffs.account_id) AS email,
+      (SELECT external_owner FROM owner_links WHERE account_id = account_handoffs.account_id) AS externalOwner`)
+    .bind(await sha256Hex(code), Date.now()).first();
+  if (!row) return errorResponse("not_found", "No live handoff.");
+  return Response.json(row, { headers: NO_STORE });
+}

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,3 +1,5 @@
+import { consumeHandoff, stringField } from "./account.js";
+import { linkExternalOwner } from "./owners.js";
 import { parseBearerToken } from "./auth.js";
 import type { Env } from "./config.js";
 import { errorResponse } from "./errors.js";
@@ -6,10 +8,12 @@ import { readBodyWithin } from "./quota.js";
 
 export const ADMIN_PREFIX = "/admin/v1";
 
-/** Billing owns subscription state. This narrowly scoped API only changes an existing account's plan. */
+/** Trusted service API: account plans, ownership associations, and one-use account proofs. */
 export async function handleAdmin(request: Request, url: URL, env: Env): Promise<Response> {
-  const match = /^\/admin\/v1\/accounts\/([^/]+)\/plan$/.exec(url.pathname);
-  if (!env.ADMIN_API_KEY?.trim() || request.method !== "PUT" || !match) {
+  const match = /^\/admin\/v1\/accounts\/([^/]+)\/(plan|external-owner)$/.exec(url.pathname);
+  const consume = request.method === "POST" && url.pathname === "/admin/v1/handoffs/consume";
+  const readOwner = request.method === "GET" && match?.[2] === "external-owner";
+  if (!env.ADMIN_API_KEY?.trim() || (!consume && !readOwner && (request.method !== "PUT" || !match))) {
     return errorResponse("not_found", "No admin route.");
   }
   const token = parseBearerToken(request.headers.get("authorization"));
@@ -18,6 +22,26 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   if (!token || !crypto.subtle.timingSafeEqual(await digest(token), await digest(env.ADMIN_API_KEY))) {
     return errorResponse("unauthorized", "Expected the admin bearer credential.", { "www-authenticate": "Bearer" });
   }
+  if (consume) return await consumeHandoff(request, env);
+  let owner: string;
+  try { owner = decodeURIComponent(match![1]!); } catch {
+    return errorResponse("not_found", "No account with that id.");
+  }
+  if (readOwner) {
+    const association = await env.DB.prepare(`SELECT a.id AS accountId, l.external_owner AS externalOwner
+      FROM accounts a LEFT JOIN owner_links l ON l.account_id = a.id WHERE a.id = ?`).bind(owner).first();
+    if (!association) return errorResponse("not_found", "No account with that id.");
+    return Response.json(association, { headers: { "cache-control": "no-store" } });
+  }
+  if (match![2] === "external-owner") {
+    const externalOwner = await stringField(request, "externalOwner");
+    if (externalOwner === null) return errorResponse("bad_request", "Expected only externalOwner.");
+    const result = await linkExternalOwner(env.DB, externalOwner, owner, Date.now());
+    if (result === "invalid") return errorResponse("bad_request", "Invalid owner identity.");
+    if (result === "account_not_found") return errorResponse("not_found", "No account with that id.");
+    if (result === "conflict") return errorResponse("conflict", "An owner is already associated with another account.");
+    return Response.json({ accountId: owner, externalOwner }, { headers: { "cache-control": "no-store" } });
+  }
   const raw = await readBodyWithin(request, 1024);
   if (!raw) return errorResponse("bad_request", "Admin body must be at most 1024 bytes.");
   let body: unknown;
@@ -25,18 +49,35 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
     return errorResponse("bad_request", "Body must be JSON.");
   }
   if (!body || typeof body !== "object" || Array.isArray(body) || !("plan" in body) ||
-    typeof body.plan !== "string" || Object.keys(body).length !== 1) {
-    return errorResponse("bad_request", "Expected only a plan name.");
+    typeof body.plan !== "string") return errorResponse("bad_request", "Expected a plan name.");
+  const snapshot = Object.hasOwn(body, "revision") || Object.hasOwn(body, "expiresAt");
+  const value = body as { plan: string; revision?: unknown; expiresAt?: unknown };
+  if (snapshot ? Object.keys(body).length !== 3 || !Number.isSafeInteger(value.revision) ||
+      typeof value.revision !== "number" || value.revision <= 0 ||
+      (value.expiresAt !== null && (typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt < 0))
+    : Object.keys(body).length !== 1) {
+    return errorResponse("bad_request", "Expected only plan, or plan with expiresAt and a positive revision.");
   }
   // A malformed deployment is a 500, while a caller naming no configured plan is a 400.
   if (!Object.hasOwn(configuredPlans(env), body.plan)) {
     return errorResponse("bad_request", "Unknown plan.");
   }
-  let owner: string;
-  try { owner = decodeURIComponent(match[1]!); } catch {
-    return errorResponse("not_found", "No account with that id.");
+  if (snapshot) {
+    const revision = value.revision as number;
+    const expiresAt = value.expiresAt as number | null;
+    const updated = await env.DB.prepare(`UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_revision = ?
+      WHERE id = ? AND plan_revision < ? RETURNING id AS owner, plan, plan_expires_at AS expiresAt, plan_revision AS revision`)
+      .bind(value.plan, expiresAt, revision, owner, revision).first();
+    if (updated) return Response.json(updated, { headers: { "cache-control": "no-store" } });
+    const current = await env.DB.prepare("SELECT id AS owner, plan, plan_expires_at AS expiresAt, plan_revision AS revision FROM accounts WHERE id = ?")
+      .bind(owner).first<{ owner: string; plan: string; expiresAt: number | null; revision: number }>();
+    if (!current) return errorResponse("not_found", "No account with that id.");
+    if (current.revision !== revision || current.plan !== value.plan || current.expiresAt !== expiresAt) {
+      return errorResponse("conflict", "Plan snapshot revision is stale or has different content.");
+    }
+    return Response.json(current, { headers: { "cache-control": "no-store" } });
   }
-  const updated = await env.DB.prepare("UPDATE accounts SET plan = ? WHERE id = ? RETURNING id, plan")
+  const updated = await env.DB.prepare("UPDATE accounts SET plan = ?, plan_expires_at = NULL WHERE id = ? RETURNING id, plan")
     .bind(body.plan, owner).first<{ id: string; plan: string }>();
   if (!updated) return errorResponse("not_found", "No account with that id.");
   return Response.json({ owner: updated.id, plan: updated.plan }, { headers: { "cache-control": "no-store" } });

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -12,8 +12,7 @@ export const ADMIN_PREFIX = "/admin/v1";
 export async function handleAdmin(request: Request, url: URL, env: Env): Promise<Response> {
   const match = /^\/admin\/v1\/accounts\/([^/]+)\/(plan|external-owner)$/.exec(url.pathname);
   const consume = request.method === "POST" && url.pathname === "/admin/v1/handoffs/consume";
-  const readOwner = request.method === "GET" && match?.[2] === "external-owner";
-  if (!env.ADMIN_API_KEY?.trim() || (!consume && !readOwner && (request.method !== "PUT" || !match))) {
+  if (!env.ADMIN_API_KEY?.trim() || (!consume && (request.method !== "PUT" || !match))) {
     return errorResponse("not_found", "No admin route.");
   }
   const token = parseBearerToken(request.headers.get("authorization"));
@@ -26,12 +25,6 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   let owner: string;
   try { owner = decodeURIComponent(match![1]!); } catch {
     return errorResponse("not_found", "No account with that id.");
-  }
-  if (readOwner) {
-    const association = await env.DB.prepare(`SELECT a.id AS accountId, l.external_owner AS externalOwner
-      FROM accounts a LEFT JOIN owner_links l ON l.account_id = a.id WHERE a.id = ?`).bind(owner).first();
-    if (!association) return errorResponse("not_found", "No account with that id.");
-    return Response.json(association, { headers: { "cache-control": "no-store" } });
   }
   if (match![2] === "external-owner") {
     const externalOwner = await stringField(request, "externalOwner");
@@ -50,35 +43,13 @@ export async function handleAdmin(request: Request, url: URL, env: Env): Promise
   }
   if (!body || typeof body !== "object" || Array.isArray(body) || !("plan" in body) ||
     typeof body.plan !== "string") return errorResponse("bad_request", "Expected a plan name.");
-  const snapshot = Object.hasOwn(body, "revision") || Object.hasOwn(body, "expiresAt");
-  const value = body as { plan: string; revision?: unknown; expiresAt?: unknown };
-  if (snapshot ? Object.keys(body).length !== 3 || !Number.isSafeInteger(value.revision) ||
-      typeof value.revision !== "number" || value.revision <= 0 ||
-      (value.expiresAt !== null && (typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt < 0))
-    : Object.keys(body).length !== 1) {
-    return errorResponse("bad_request", "Expected only plan, or plan with expiresAt and a positive revision.");
-  }
+  if (Object.keys(body).length !== 1) return errorResponse("bad_request", "Expected only a plan name.");
   // A malformed deployment is a 500, while a caller naming no configured plan is a 400.
   if (!Object.hasOwn(configuredPlans(env), body.plan)) {
     return errorResponse("bad_request", "Unknown plan.");
   }
-  if (snapshot) {
-    const revision = value.revision as number;
-    const expiresAt = value.expiresAt as number | null;
-    const updated = await env.DB.prepare(`UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_revision = ?
-      WHERE id = ? AND plan_revision < ? RETURNING id AS owner, plan, plan_expires_at AS expiresAt, plan_revision AS revision`)
-      .bind(value.plan, expiresAt, revision, owner, revision).first();
-    if (updated) return Response.json(updated, { headers: { "cache-control": "no-store" } });
-    const current = await env.DB.prepare("SELECT id AS owner, plan, plan_expires_at AS expiresAt, plan_revision AS revision FROM accounts WHERE id = ?")
-      .bind(owner).first<{ owner: string; plan: string; expiresAt: number | null; revision: number }>();
-    if (!current) return errorResponse("not_found", "No account with that id.");
-    if (current.revision !== revision || current.plan !== value.plan || current.expiresAt !== expiresAt) {
-      return errorResponse("conflict", "Plan snapshot revision is stale or has different content.");
-    }
-    return Response.json(current, { headers: { "cache-control": "no-store" } });
-  }
-  const updated = await env.DB.prepare("UPDATE accounts SET plan = ?, plan_expires_at = NULL WHERE id = ? RETURNING id, plan")
-    .bind(body.plan, owner).first<{ id: string; plan: string }>();
+  const updated = await env.DB.prepare("UPDATE accounts SET plan = ?, plan_expires_at = NULL, plan_checked_at = MAX(?, COALESCE(plan_checked_at, 0) + 1) WHERE id = ? RETURNING id, plan")
+    .bind(body.plan, Date.now(), owner).first<{ id: string; plan: string }>();
   if (!updated) return errorResponse("not_found", "No account with that id.");
   return Response.json({ owner: updated.id, plan: updated.plan }, { headers: { "cache-control": "no-store" } });
 }

--- a/src/api/push.ts
+++ b/src/api/push.ts
@@ -251,7 +251,7 @@ export async function createDoc(
     if (limits) {
       return limitReached(
         env, publisher, "documents",
-        `Your account can hold ${maxDocs} published documents. Unshare one to publish another.`,
+        `Your account can hold ${maxDocs} published ${maxDocs === 1 ? "document" : "documents"}. Unshare enough documents to get below this limit before publishing another.`,
       );
     }
     return errorResponse(

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -242,17 +242,21 @@ async function chooser(
   // through their provider and lands them on a confirmation they never asked
   // for is the first half of the attack the confirm step exists to stop, and
   // there is no reason to leave it lying around.
-  const buttons = configuredProviders(env)
-    .map((provider) =>
-      form(
-        `${APPROVAL_PREFIX}/start/${provider}`,
-        { [USER_CODE_PARAM]: userCode },
-        `Continue with ${PROVIDER_LABELS[provider]}`,
-      ),
+  const providers = configuredProviders(env);
+  const buttons = providers
+    .map(
+      (provider) =>
+        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}">Sign in with ${PROVIDER_LABELS[provider]}</button>`,
     )
-    .join("\n    ");
-
-  return page({ ...CHOOSE, detail: codeDetail(userCode), actions: actions(buttons) }, 200);
+    .join("\n");
+  const signup = `<form class="signup" method="post" action="${APPROVAL_PREFIX}/start/${providers[0]}">
+    <input type="hidden" name="${USER_CODE_PARAM}" value="${escapeHtml(userCode)}">
+    <label class="newsletter"><input type="checkbox" name="newsletter" value="yes" checked> <span>Send me product updates via the Brevilabs newsletter.</span></label>
+    <p class="terms">For your first sign-in only. Existing newsletter preferences stay unchanged.</p>
+    <p class="terms">By clicking Sign in, you agree to our <a href="https://openartifacts.ai/terms">Terms</a> and create a free account if you’re new. See our <a href="https://openartifacts.ai/privacy">Privacy Policy</a>.</p>
+    <div class="actions">${buttons}</div>
+  </form>`;
+  return page({ ...CHOOSE, detail: codeDetail(userCode), actions: signup }, 200);
 }
 
 /** Start a handshake: mint its state and verifier, and record them on the code. */
@@ -284,7 +288,17 @@ async function begin(
   const now = (deps.now ?? Date.now)();
   const state = newHandshakeToken();
   const verifier = newHandshakeToken();
-  if (!(await startDeviceHandshake(env.DB, userCode, chosen, state, verifier, now))) {
+  if (
+    !(await startDeviceHandshake(
+      env.DB,
+      userCode,
+      chosen,
+      state,
+      verifier,
+      now,
+      submitted.get("newsletter") === "yes",
+    ))
+  ) {
     return page(CODE_GONE, 404);
   }
 
@@ -308,12 +322,7 @@ async function begin(
  * come out of that row rather than off the url, so neither can be swapped by
  * whoever follows the link.
  */
-async function prove(
-  url: URL,
-  env: Env,
-  provider: string,
-  deps: ApprovalDeps,
-): Promise<Response> {
+async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): Promise<Response> {
   if (!approvalIsConfigured(env)) return page(NOT_CONFIGURED, 503);
 
   const now = (deps.now ?? Date.now)();
@@ -386,6 +395,14 @@ async function prove(
   const device =
     handshake.label === null ? UNNAMED_DEVICE : `<b><bdi>${escapeHtml(handshake.label)}</bdi></b>`;
 
+  const preference = await env.DB.prepare("SELECT newsletter_choice_at FROM accounts WHERE id = ?")
+    .bind(account.id)
+    .first<{ newsletter_choice_at: number | null }>();
+  const newsletter =
+    preference?.newsletter_choice_at == null
+      ? `<label class="newsletter"><input type="checkbox" name="newsletter" value="yes"${handshake.newsletter_opt_in ? " checked" : ""}> <span>Send me product updates via the Brevilabs newsletter.</span></label>`
+      : `<p class="terms">Your existing newsletter preference stays unchanged.</p>`;
+
   return page(
     {
       ...CONFIRM,
@@ -393,11 +410,9 @@ async function prove(
       detail: codeDetail(handshake.user_code),
       actions: actions(
         [
-          form(
-            `${APPROVAL_PREFIX}/confirm`,
-            { [CONFIRM_TOKEN_FIELD]: confirmToken },
-            "Approve this device",
-          ),
+          `<form class="confirm-signup" method="post" action="${APPROVAL_PREFIX}/confirm">
+            <input type="hidden" name="${CONFIRM_TOKEN_FIELD}" value="${confirmToken}">
+            ${newsletter}<button type="submit">Approve this device</button></form>`,
           form(`${APPROVAL_PREFIX}/deny`, { [CONFIRM_TOKEN_FIELD]: confirmToken }, "Deny"),
         ].join(""),
       ),
@@ -424,7 +439,10 @@ async function confirm(request: Request, env: Env, deps: ApprovalDeps): Promise<
   const token = submitted.get(CONFIRM_TOKEN_FIELD);
   const now = (deps.now ?? Date.now)();
 
-  const userCode = token === null ? null : await confirmDeviceApproval(env.DB, token, now);
+  const userCode =
+    token === null
+      ? null
+      : await confirmDeviceApproval(env.DB, token, now, submitted.get("newsletter") === "yes");
   if (userCode === null) return page(EXPIRED, 400);
 
   return page({ ...APPROVED, detail: codeDetail(userCode) }, 200);
@@ -561,10 +579,9 @@ function page(copy: BrandPage, status: number): Response {
 }
 
 const CHOOSE: BrandPage = {
-  title: "Approve a device",
-  heading: "Approve this device.",
-  message:
-    "Your terminal is waiting on the code below. Sign in to continue. The first time creates your account, which stores your verified email address and the id your provider uses for you. Nothing else.",
+  title: "Create your free account",
+  heading: "Create your free account.",
+  message: "Publish your first document free. Already have an account? Sign in below to continue.",
 };
 
 const CONFIRM: BrandPage = {
@@ -595,7 +612,7 @@ const ENTER_CODE: BrandPage = {
   heading: "Enter your code.",
   /** Always rendered with the form as its actions, and sometimes with a note. */
   message:
-    "Your terminal is waiting on a short code. Type it in exactly as it appears there. Signing in on the next page creates your account the first time, which stores your verified email address and the id your provider uses for you. Nothing else.",
+    "Your terminal is waiting on a short code. Type it in exactly as it appears there. Continue to create your free account or sign in.",
 };
 
 const CODE_GONE: BrandPage = {

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -242,11 +242,15 @@ async function chooser(
   // through their provider and lands them on a confirmation they never asked
   // for is the first half of the attack the confirm step exists to stop, and
   // there is no reason to leave it lying around.
+  const providerIcons = {
+    google: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></svg>',
+    github: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 .75a11.25 11.25 0 0 0-3.558 21.922c.563.104.77-.244.77-.542 0-.267-.01-.975-.015-1.913-3.13.68-3.79-1.508-3.79-1.508-.512-1.3-1.25-1.646-1.25-1.646-1.022-.7.077-.686.077-.686 1.13.08 1.724 1.16 1.724 1.16 1.005 1.723 2.637 1.225 3.28.937.102-.728.393-1.225.715-1.507-2.498-.284-5.124-1.249-5.124-5.56 0-1.228.44-2.233 1.16-3.02-.116-.285-.503-1.429.11-2.979 0 0 .945-.303 3.094 1.154A10.8 10.8 0 0 1 12 6.184c.956.004 1.918.13 2.817.379 2.148-1.457 3.091-1.154 3.091-1.154.615 1.55.228 2.694.112 2.979.722.787 1.159 1.792 1.159 3.02 0 4.322-2.63 5.272-5.135 5.55.403.35.762 1.041.762 2.1 0 1.516-.014 2.739-.014 3.111 0 .3.203.65.774.54A11.251 11.251 0 0 0 12 .75Z"/></svg>',
+  };
   const providers = configuredProviders(env);
   const buttons = providers
     .map(
       (provider) =>
-        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}" disabled>Sign in with ${PROVIDER_LABELS[provider]}</button>`,
+        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}" disabled>${providerIcons[provider]}<span>Sign in with ${PROVIDER_LABELS[provider]}</span></button>`,
     )
     .join("\n");
   const signup = `<form class="signup" method="post" action="${APPROVAL_PREFIX}/start/${providers[0]}">

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -400,7 +400,7 @@ async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): 
       {
         title: "Create your free account",
         heading: "Create your free account.",
-        message: `Continue as ${escapeHtml(email)}. Create a free account and allow ${device} to publish as you until you revoke it. If this is not your terminal, choose Deny.`,
+        message: `Continue as ${escapeHtml(email)}. Create a free account and allow ${device} to publish as you until you revoke it. If this is not your terminal, close this page.`,
         detail: codeDetail(handshake.user_code),
         actions: `<form class="signup" method="post" action="${APPROVAL_PREFIX}/confirm">
         <input type="hidden" name="${CONFIRM_TOKEN_FIELD}" value="${confirmToken}">
@@ -409,7 +409,6 @@ async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): 
         <label class="newsletter"><input type="checkbox" name="newsletter" value="yes" checked> <span>Send me product updates via the Brevilabs newsletter.</span></label>
         <div class="actions"><button type="submit" disabled>Create account and approve device</button></div>
       </form>
-      ${actions(form(`${APPROVAL_PREFIX}/deny`, { [CONFIRM_TOKEN_FIELD]: confirmToken }, "Deny"))}
       <script>
         const signup = document.querySelector('form.signup');
         const terms = signup.elements.namedItem('terms');

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -27,6 +27,7 @@
  * browser with a person behind it, not a client matching on an error code, so
  * `docs/http-api.md`'s JSON envelope would be the wrong answer to give them.
  */
+import { syncNewsletter } from "../newsletter.js";
 import { type Env } from "../config.js";
 import {
   confirmDeviceApproval,
@@ -101,6 +102,7 @@ export interface ApprovalDeps {
   now?: () => number;
   /** Injected by tests, since arctic's handshake reaches the network. */
   oauth?: OAuthClient;
+  fetch?: typeof fetch;
   /**
    * Injected by tests that need a limiter a deployment has not declared, or a
    * verdict they choose. Production reads `env.APPROVAL_LOOKUP_LIMITER`.
@@ -464,6 +466,7 @@ async function confirm(request: Request, env: Env, deps: ApprovalDeps): Promise<
   const token = submitted.get(CONFIRM_TOKEN_FIELD);
   const now = (deps.now ?? Date.now)();
 
+  const accountId = newAccountId();
   const userCode =
     token === null
       ? null
@@ -473,11 +476,12 @@ async function confirm(request: Request, env: Env, deps: ApprovalDeps): Promise<
           now,
           submitted.get("newsletter") === "yes",
           submitted.get("terms") === "yes",
-          newAccountId(),
+          accountId,
           defaultPlan(env),
         );
   if (userCode === null) return page(EXPIRED, 400);
 
+  await syncNewsletter(env, accountId, deps.fetch);
   return page({ ...APPROVED, detail: codeDetail(userCode) }, 200);
 }
 

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -2,13 +2,11 @@
  * The approval page: the only place a human ever interacts with OpenArtifacts,
  * and the only way an account comes into existence.
  *
- * There is no sign-up form, no sign-in page and no session. A CLI prints a url
- * carrying the user code it is waiting on, the person opens it, proves
- * an email with Google or GitHub, and presses a button to approve. The first
- * approval an address makes is the registration; every one after it finds the
- * same account. When the page is done, nothing about the browser is remembered
- * — the token the CLI receives is the credential from then on, which is why
- * there is nothing here for a session to be for.
+ * A CLI prints a device-approval URL. The person chooses Google or GitHub,
+ * then an existing account approves the device. A new user accepts Terms and
+ * optionally subscribes to product updates before a single POST creates their
+ * free account and approves the device. No browser session is retained; the
+ * token the CLI receives is the credential from then on.
  *
  * **Proving who you are and approving a terminal are two steps, and the second
  * is a `POST` a person presses.** RFC 8628 §5.4 is the reason. A provider's
@@ -243,36 +241,22 @@ async function chooser(
   // for is the first half of the attack the confirm step exists to stop, and
   // there is no reason to leave it lying around.
   const providerIcons = {
-    google: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></svg>',
-    github: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 .75a11.25 11.25 0 0 0-3.558 21.922c.563.104.77-.244.77-.542 0-.267-.01-.975-.015-1.913-3.13.68-3.79-1.508-3.79-1.508-.512-1.3-1.25-1.646-1.25-1.646-1.022-.7.077-.686.077-.686 1.13.08 1.724 1.16 1.724 1.16 1.005 1.723 2.637 1.225 3.28.937.102-.728.393-1.225.715-1.507-2.498-.284-5.124-1.249-5.124-5.56 0-1.228.44-2.233 1.16-3.02-.116-.285-.503-1.429.11-2.979 0 0 .945-.303 3.094 1.154A10.8 10.8 0 0 1 12 6.184c.956.004 1.918.13 2.817.379 2.148-1.457 3.091-1.154 3.091-1.154.615 1.55.228 2.694.112 2.979.722.787 1.159 1.792 1.159 3.02 0 4.322-2.63 5.272-5.135 5.55.403.35.762 1.041.762 2.1 0 1.516-.014 2.739-.014 3.111 0 .3.203.65.774.54A11.251 11.251 0 0 0 12 .75Z"/></svg>',
+    google:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"/></svg>',
+    github:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 .75a11.25 11.25 0 0 0-3.558 21.922c.563.104.77-.244.77-.542 0-.267-.01-.975-.015-1.913-3.13.68-3.79-1.508-3.79-1.508-.512-1.3-1.25-1.646-1.25-1.646-1.022-.7.077-.686.077-.686 1.13.08 1.724 1.16 1.724 1.16 1.005 1.723 2.637 1.225 3.28.937.102-.728.393-1.225.715-1.507-2.498-.284-5.124-1.249-5.124-5.56 0-1.228.44-2.233 1.16-3.02-.116-.285-.503-1.429.11-2.979 0 0 .945-.303 3.094 1.154A10.8 10.8 0 0 1 12 6.184c.956.004 1.918.13 2.817.379 2.148-1.457 3.091-1.154 3.091-1.154.615 1.55.228 2.694.112 2.979.722.787 1.159 1.792 1.159 3.02 0 4.322-2.63 5.272-5.135 5.55.403.35.762 1.041.762 2.1 0 1.516-.014 2.739-.014 3.111 0 .3.203.65.774.54A11.251 11.251 0 0 0 12 .75Z"/></svg>',
   };
   const providers = configuredProviders(env);
   const buttons = providers
     .map(
       (provider) =>
-        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}" disabled>${providerIcons[provider]}<span>Sign in with ${PROVIDER_LABELS[provider]}</span></button>`,
+        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}">${providerIcons[provider]}<span>Sign in with ${PROVIDER_LABELS[provider]}</span></button>`,
     )
     .join("\n");
   const signup = `<form class="signup" method="post" action="${APPROVAL_PREFIX}/start/${providers[0]}">
     <input type="hidden" name="${USER_CODE_PARAM}" value="${escapeHtml(userCode)}">
-    <label class="newsletter"><input type="checkbox" name="newsletter" value="yes" checked> <span>Send me product updates via the Brevilabs newsletter.</span></label>
-    <p class="terms">For your first sign-in only. Existing newsletter preferences stay unchanged.</p>
-    <label class="newsletter terms-consent"><input type="checkbox" name="terms" value="yes" required> <span>I agree to the <a href="https://openartifacts.ai/terms">Terms</a>.</span></label>
-    <p class="terms">Signing in creates a free account if you’re new. See our <a href="https://openartifacts.ai/privacy">Privacy Policy</a>.</p>
     <div class="actions">${buttons}</div>
-  </form>
-  <script>
-    const signup = document.querySelector('form.signup');
-    const terms = signup.elements.namedItem('terms');
-    const updateButtons = () => {
-      for (const button of signup.querySelectorAll('button[type="submit"]')) {
-        button.disabled = !terms.checked;
-      }
-    };
-    terms.addEventListener('change', updateButtons);
-    window.addEventListener('pageshow', updateButtons);
-    updateButtons();
-  </script>`;
+  </form>`;
   return page({ ...CHOOSE, detail: codeDetail(userCode), actions: signup }, 200);
 }
 
@@ -302,31 +286,10 @@ async function begin(
   const limiter = deps.limiter ?? env.APPROVAL_LOOKUP_LIMITER;
   if (!(await withinClientLimit(limiter, request))) return page(CODE_GONE, 404);
 
-  if (submitted.get("terms") !== "yes") {
-    return page(
-      {
-        ...CHOOSE,
-        message: "Agree to the Terms before signing in.",
-        actions: `<a href="${APPROVAL_PREFIX}?${USER_CODE_PARAM}=${encodeURIComponent(userCode)}">Back to sign in</a>`,
-      },
-      400,
-    );
-  }
-
   const now = (deps.now ?? Date.now)();
   const state = newHandshakeToken();
   const verifier = newHandshakeToken();
-  if (
-    !(await startDeviceHandshake(
-      env.DB,
-      userCode,
-      chosen,
-      state,
-      verifier,
-      now,
-      submitted.get("newsletter") === "yes",
-    ))
-  ) {
+  if (!(await startDeviceHandshake(env.DB, userCode, chosen, state, verifier, now))) {
     return page(CODE_GONE, 404);
   }
 
@@ -342,8 +305,8 @@ async function begin(
 }
 
 /**
- * The provider's redirect back, where the email is proved and the account is
- * created — and where nothing is approved.
+ * The provider's redirect back, where the identity is proved, without creating
+ * an account or approving a device.
  *
  * The `state` is the only thing this request carries that this page put there,
  * so it is what the handshake is looked up by. The device code and the provider
@@ -401,19 +364,28 @@ async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): 
     newAccountId(),
     now,
     defaultPlan(env),
+    false,
   );
-  if (account === null) return page(EMAIL_CLAIMED, 409);
+  if (
+    account === null &&
+    (await env.DB.prepare("SELECT 1 FROM accounts WHERE email = ?").bind(email).first())
+  ) {
+    return page(EMAIL_CLAIMED, 409);
+  }
 
-  // An account created a moment ago whose code has since expired is left behind
-  // on purpose: it costs one row, it is the same account the person's next
-  // approval will find, and undoing it would mean deleting an account that may
-  // already own documents.
-  // Also the point at which one handshake is settled on one identity: two
-  // people completing the same authorization url race here, and the loser is
-  // told to start again rather than overwriting a confirmation page that has
-  // already been rendered for somebody else.
+  // Only the first callback can hold a proven identity. New identities remain
+  // on the expiring device row until the person accepts Terms in a POST.
   const confirmToken = newHandshakeToken();
-  if (!(await holdProvenIdentity(env.DB, state, account.id, confirmToken, now))) {
+  if (
+    !(await holdProvenIdentity(
+      env.DB,
+      state,
+      account?.id ?? null,
+      confirmToken,
+      now,
+      account === null ? { subject: asserted.subject, email } : undefined,
+    ))
+  ) {
     return page(EXPIRED, 400);
   }
 
@@ -423,13 +395,37 @@ async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): 
   const device =
     handshake.label === null ? UNNAMED_DEVICE : `<b><bdi>${escapeHtml(handshake.label)}</bdi></b>`;
 
-  const preference = await env.DB.prepare("SELECT newsletter_choice_at FROM accounts WHERE id = ?")
-    .bind(account.id)
-    .first<{ newsletter_choice_at: number | null }>();
-  const newsletter =
-    preference?.newsletter_choice_at == null
-      ? `<label class="newsletter"><input type="checkbox" name="newsletter" value="yes"${handshake.newsletter_opt_in ? " checked" : ""}> <span>Send me product updates via the Brevilabs newsletter.</span></label>`
-      : `<p class="terms">Your existing newsletter preference stays unchanged.</p>`;
+  if (account === null) {
+    return page(
+      {
+        title: "Create your free account",
+        heading: "Create your free account.",
+        message: `Continue as ${escapeHtml(email)}. Create a free account and allow ${device} to publish as you until you revoke it. If this is not your terminal, choose Deny.`,
+        detail: codeDetail(handshake.user_code),
+        actions: `<form class="signup" method="post" action="${APPROVAL_PREFIX}/confirm">
+        <input type="hidden" name="${CONFIRM_TOKEN_FIELD}" value="${confirmToken}">
+        <label class="newsletter terms-consent"><input type="checkbox" name="terms" value="yes" required> <span>I agree to the <a href="https://openartifacts.ai/terms">Terms</a>.</span></label>
+        <p class="terms">One published document is free. See our <a href="https://openartifacts.ai/privacy">Privacy Policy</a>.</p>
+        <label class="newsletter"><input type="checkbox" name="newsletter" value="yes" checked> <span>Send me product updates via the Brevilabs newsletter.</span></label>
+        <div class="actions"><button type="submit" disabled>Create account and approve device</button></div>
+      </form>
+      ${actions(form(`${APPROVAL_PREFIX}/deny`, { [CONFIRM_TOKEN_FIELD]: confirmToken }, "Deny"))}
+      <script>
+        const signup = document.querySelector('form.signup');
+        const terms = signup.elements.namedItem('terms');
+        const updateButtons = () => {
+          for (const button of signup.querySelectorAll('button[type="submit"]')) {
+            button.disabled = !terms.checked;
+          }
+        };
+        terms.addEventListener('change', updateButtons);
+        window.addEventListener('pageshow', updateButtons);
+        updateButtons();
+      </script>`,
+      },
+      200,
+    );
+  }
 
   return page(
     {
@@ -438,9 +434,11 @@ async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): 
       detail: codeDetail(handshake.user_code),
       actions: actions(
         [
-          `<form class="confirm-signup" method="post" action="${APPROVAL_PREFIX}/confirm">
-            <input type="hidden" name="${CONFIRM_TOKEN_FIELD}" value="${confirmToken}">
-            ${newsletter}<button type="submit">Approve this device</button></form>`,
+          form(
+            `${APPROVAL_PREFIX}/confirm`,
+            { [CONFIRM_TOKEN_FIELD]: confirmToken },
+            "Approve this device",
+          ),
           form(`${APPROVAL_PREFIX}/deny`, { [CONFIRM_TOKEN_FIELD]: confirmToken }, "Deny"),
         ].join(""),
       ),
@@ -470,7 +468,15 @@ async function confirm(request: Request, env: Env, deps: ApprovalDeps): Promise<
   const userCode =
     token === null
       ? null
-      : await confirmDeviceApproval(env.DB, token, now, submitted.get("newsletter") === "yes");
+      : await confirmDeviceApproval(
+          env.DB,
+          token,
+          now,
+          submitted.get("newsletter") === "yes",
+          submitted.get("terms") === "yes",
+          newAccountId(),
+          defaultPlan(env),
+        );
   if (userCode === null) return page(EXPIRED, 400);
 
   return page({ ...APPROVED, detail: codeDetail(userCode) }, 200);
@@ -607,9 +613,9 @@ function page(copy: BrandPage, status: number): Response {
 }
 
 const CHOOSE: BrandPage = {
-  title: "Create your free account",
-  heading: "Create your free account.",
-  message: "Publish your first document free. Already have an account? Sign in below to continue.",
+  title: "Sign in to OpenArtifacts",
+  heading: "Sign in to OpenArtifacts.",
+  message: "Choose Google or GitHub to continue.",
 };
 
 const CONFIRM: BrandPage = {

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -246,16 +246,29 @@ async function chooser(
   const buttons = providers
     .map(
       (provider) =>
-        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}">Sign in with ${PROVIDER_LABELS[provider]}</button>`,
+        `<button type="submit" formaction="${APPROVAL_PREFIX}/start/${provider}" disabled>Sign in with ${PROVIDER_LABELS[provider]}</button>`,
     )
     .join("\n");
   const signup = `<form class="signup" method="post" action="${APPROVAL_PREFIX}/start/${providers[0]}">
     <input type="hidden" name="${USER_CODE_PARAM}" value="${escapeHtml(userCode)}">
     <label class="newsletter"><input type="checkbox" name="newsletter" value="yes" checked> <span>Send me product updates via the Brevilabs newsletter.</span></label>
     <p class="terms">For your first sign-in only. Existing newsletter preferences stay unchanged.</p>
-    <p class="terms">By clicking Sign in, you agree to our <a href="https://openartifacts.ai/terms">Terms</a> and create a free account if you’re new. See our <a href="https://openartifacts.ai/privacy">Privacy Policy</a>.</p>
+    <label class="newsletter terms-consent"><input type="checkbox" name="terms" value="yes" required> <span>I agree to the <a href="https://openartifacts.ai/terms">Terms</a>.</span></label>
+    <p class="terms">Signing in creates a free account if you’re new. See our <a href="https://openartifacts.ai/privacy">Privacy Policy</a>.</p>
     <div class="actions">${buttons}</div>
-  </form>`;
+  </form>
+  <script>
+    const signup = document.querySelector('form.signup');
+    const terms = signup.elements.namedItem('terms');
+    const updateButtons = () => {
+      for (const button of signup.querySelectorAll('button[type="submit"]')) {
+        button.disabled = !terms.checked;
+      }
+    };
+    terms.addEventListener('change', updateButtons);
+    window.addEventListener('pageshow', updateButtons);
+    updateButtons();
+  </script>`;
   return page({ ...CHOOSE, detail: codeDetail(userCode), actions: signup }, 200);
 }
 
@@ -284,6 +297,17 @@ async function begin(
 
   const limiter = deps.limiter ?? env.APPROVAL_LOOKUP_LIMITER;
   if (!(await withinClientLimit(limiter, request))) return page(CODE_GONE, 404);
+
+  if (submitted.get("terms") !== "yes") {
+    return page(
+      {
+        ...CHOOSE,
+        message: "Agree to the Terms before signing in.",
+        actions: `<a href="${APPROVAL_PREFIX}?${USER_CODE_PARAM}=${encodeURIComponent(userCode)}">Back to sign in</a>`,
+      },
+      400,
+    );
+  }
 
   const now = (deps.now ?? Date.now)();
   const state = newHandshakeToken();

--- a/src/approval/handler.ts
+++ b/src/approval/handler.ts
@@ -404,9 +404,9 @@ async function prove(url: URL, env: Env, provider: string, deps: ApprovalDeps): 
         detail: codeDetail(handshake.user_code),
         actions: `<form class="signup" method="post" action="${APPROVAL_PREFIX}/confirm">
         <input type="hidden" name="${CONFIRM_TOKEN_FIELD}" value="${confirmToken}">
-        <label class="newsletter terms-consent"><input type="checkbox" name="terms" value="yes" required> <span>I agree to the <a href="https://openartifacts.ai/terms">Terms</a>.</span></label>
         <p class="terms">One published document is free. See our <a href="https://openartifacts.ai/privacy">Privacy Policy</a>.</p>
         <label class="newsletter"><input type="checkbox" name="newsletter" value="yes" checked> <span>Send me product updates via the Brevilabs newsletter.</span></label>
+        <label class="newsletter terms-consent"><input type="checkbox" name="terms" value="yes" required> <span>I agree to the <a href="https://openartifacts.ai/terms">Terms</a>.</span></label>
         <div class="actions"><button type="submit" disabled>Create account and approve device</button></div>
       </form>
       <script>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -151,6 +151,15 @@ export function parseBearerToken(header: string | null): string | null {
   return match?.[1] ?? null;
 }
 
+/** Match the API dispatcher, including its normalization of empty path segments. */
+export function isPublishingRequest(request: Request): boolean {
+  const [collection, docId, ...extra] = new URL(request.url).pathname
+    .slice("/api/v1".length).split("/").filter(Boolean);
+  return collection === "docs" && extra.length === 0 &&
+    ((docId === undefined && request.method === "POST") ||
+     (docId !== undefined && request.method === "PUT"));
+}
+
 export async function authenticateRequest(
   request: Request,
   env: Env,
@@ -167,7 +176,7 @@ export async function authenticateRequest(
   // `return await`: see the note on the router's catch in index.ts.
   const path = new URL(request.url).pathname;
   const account = request.method === "GET" && path === "/api/v1/account";
-  const publishing = ["POST", "PUT"].includes(request.method) && /^\/api\/v1\/docs(?:\/|$)/.test(path);
+  const publishing = isPublishingRequest(request);
   return await resolvePublisher(token, env, { ...deps, forceAccountRefresh: account, skipAccountRefresh: !account && !publishing });
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,7 +42,7 @@ import { LICENSE_CACHE_TTL_MS, TOKEN_LAST_USED_RESOLUTION_MS, type Env } from ".
 import { d1PublisherStore, findLiveToken, touchTokenUse, type PublisherStore } from "./db.js";
 import { errorResponse, type ErrorCode } from "./errors.js";
 import { sha256Hex } from "./hash.js";
-import { effectivePlan } from "./plans.js";
+import { accountPlan, type RefreshStatus } from "./entitlement.js";
 import { TOKEN_PREFIX } from "./ids.js";
 
 /** tRPC endpoint on the license server, appended to `LICENSE_API_URL`. */
@@ -109,6 +109,7 @@ export interface Publisher {
   plan: string;
   /** Present only for our own tokens; never infer identity type from a plan name. */
   authKind?: "account";
+  accountRefresh?: RefreshStatus;
 }
 
 export type PublisherFailure =
@@ -135,6 +136,8 @@ export interface AuthDeps {
   /** Injected by tests so they never touch the network. */
   fetch?: typeof fetch;
   now?: () => number;
+  forceAccountRefresh?: boolean;
+  skipAccountRefresh?: boolean;
   store?: PublisherStore;
 }
 
@@ -162,7 +165,10 @@ export async function authenticateRequest(
     };
   }
   // `return await`: see the note on the router's catch in index.ts.
-  return await resolvePublisher(token, env, deps);
+  const path = new URL(request.url).pathname;
+  const account = request.method === "GET" && path === "/api/v1/account";
+  const publishing = ["POST", "PUT"].includes(request.method) && /^\/api\/v1\/docs(?:\/|$)/.test(path);
+  return await resolvePublisher(token, env, { ...deps, forceAccountRefresh: account, skipAccountRefresh: !account && !publishing });
 }
 
 export async function resolvePublisher(
@@ -235,9 +241,8 @@ export async function resolvePublisher(
 /**
  * Resolve one of this deployment's own tokens to the account it publishes as.
  *
- * There is no cache and no outage story, because there is nothing to be out:
- * the token's owner is a row in this database rather than an answer from
- * another service. That is also why a revoked token stops working on its very
+ * Identity is always local; only paid entitlement has a remote cache.
+ * A remote outage never invalidates the token or blocks management. That is also why a revoked token stops working on its very
  * next request, where a revoked license key keeps working until its cached
  * validation ages out.
  */
@@ -265,7 +270,8 @@ async function resolveAccountToken(
     await touchTokenUse(env.DB, live.id, at, at - TOKEN_LAST_USED_RESOLUTION_MS);
   }
 
-  return { ok: true, publisher: { owner: live.account_id, plan: effectivePlan(env, live.plan, live.plan_expires_at, at), authKind: "account" } };
+  const result = await accountPlan(env, live.account_id, deps);
+  return { ok: true, publisher: { owner: live.account_id, plan: result.plan, accountRefresh: result.status, authKind: "account" } };
 }
 
 const FAILURE_STATUS: Record<PublisherFailure, ErrorCode> = {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,6 +42,7 @@ import { LICENSE_CACHE_TTL_MS, TOKEN_LAST_USED_RESOLUTION_MS, type Env } from ".
 import { d1PublisherStore, findLiveToken, touchTokenUse, type PublisherStore } from "./db.js";
 import { errorResponse, type ErrorCode } from "./errors.js";
 import { sha256Hex } from "./hash.js";
+import { effectivePlan } from "./plans.js";
 import { TOKEN_PREFIX } from "./ids.js";
 
 /** tRPC endpoint on the license server, appended to `LICENSE_API_URL`. */
@@ -201,29 +202,33 @@ export async function resolvePublisher(
       return { ok: true, publisher: { owner: check.owner, plan: check.plan } };
 
     case "denied":
-      // Deliberately no row write and no row delete. A previously valid key that
-      // has since lapsed keeps its `publishers` row — that row is what an
-      // outage falls back to, and throwing it away would turn a revoked key
-      // into a lost account. It simply stops resolving.
+      // This row caches a credential, not ownership: docs belong to `owner`
+      // independently. Forget rejected credentials so an outage cannot revive
+      // their last successful validation. A fresh valid response may restore it.
+      await store.remove(id);
       return {
         ok: false,
         reason: "invalid_license",
         message: "That license key is not valid for publishing.",
       };
 
-    case "unreachable":
-      if (cached) {
+    case "unreachable": {
+      // Another request may have rejected this key while our check was pending.
+      // Only the current cache can authorize fallback, never the earlier snapshot.
+      const fallback = await store.read(id);
+      if (fallback) {
         // Stale but real. An outage must not lock out a publisher who has
         // published before. The plan rides along, so a publisher downgraded
         // since their last successful validation loses publishing here too
         // while keeping list and delete.
-        return { ok: true, publisher: { owner: cached.owner, plan: cached.plan } };
+        return { ok: true, publisher: { owner: fallback.owner, plan: fallback.plan } };
       }
       return {
         ok: false,
         reason: "license_unavailable",
         message: "License validation is temporarily unavailable. Please try again shortly.",
       };
+    }
   }
 }
 
@@ -260,7 +265,7 @@ async function resolveAccountToken(
     await touchTokenUse(env.DB, live.id, at, at - TOKEN_LAST_USED_RESOLUTION_MS);
   }
 
-  return { ok: true, publisher: { owner: live.account_id, plan: live.plan, authKind: "account" } };
+  return { ok: true, publisher: { owner: live.account_id, plan: effectivePlan(env, live.plan, live.plan_expires_at, at), authKind: "account" } };
 }
 
 const FAILURE_STATUS: Record<PublisherFailure, ErrorCode> = {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -153,7 +153,9 @@ export function parseBearerToken(header: string | null): string | null {
 
 /** Match the API dispatcher, including its normalization of empty path segments. */
 export function isPublishingRequest(request: Request): boolean {
-  const [collection, docId, ...extra] = new URL(request.url).pathname
+  const pathname = new URL(request.url).pathname;
+  if (!pathname.startsWith("/api/v1/")) return false;
+  const [collection, docId, ...extra] = pathname
     .slice("/api/v1".length).split("/").filter(Boolean);
   return collection === "docs" && extra.length === 0 &&
     ((docId === undefined && request.method === "POST") ||

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -191,27 +191,33 @@ export async function resolvePublisher(
   const cached = await store.read(id);
   const checkedAt = now();
 
-  if (cached && checkedAt - cached.validated_at < LICENSE_CACHE_TTL_MS) {
+  if (cached && (cached.rejected_at == null || cached.validated_at > cached.rejected_at) && checkedAt - cached.validated_at < LICENSE_CACHE_TTL_MS) {
     return { ok: true, publisher: { owner: cached.owner, plan: cached.plan } };
   }
 
   const check = await validateLicense(token, env, deps);
 
   switch (check.status) {
-    case "valid":
-      await store.save({
+    case "valid": {
+      const saved = await store.save({
         key_hash: id,
         plan: check.plan,
         validated_at: checkedAt,
         owner: check.owner,
       });
-      return { ok: true, publisher: { owner: check.owner, plan: check.plan } };
+      // A check begun before a rejection cannot undo that rejection. Recheck
+      // after writing too, so a rejection during the write cannot authorize it.
+      const current = saved ? await store.read(id) : null;
+      if (current && (current.rejected_at == null || current.validated_at > current.rejected_at)) {
+        return { ok: true, publisher: { owner: current.owner, plan: current.plan } };
+      }
+      return { ok: false, reason: "invalid_license", message: "That license key is not valid for publishing." };
+    }
 
     case "denied":
       // This row caches a credential, not ownership: docs belong to `owner`
-      // independently. Forget rejected credentials so an outage cannot revive
-      // their last successful validation. A fresh valid response may restore it.
-      await store.remove(id);
+      // independently. Retain rejection ordering even after a later check succeeds.
+      await store.reject(id, now());
       return {
         ok: false,
         reason: "invalid_license",
@@ -222,7 +228,7 @@ export async function resolvePublisher(
       // Another request may have rejected this key while our check was pending.
       // Only the current cache can authorize fallback, never the earlier snapshot.
       const fallback = await store.read(id);
-      if (fallback) {
+      if (fallback && (fallback.rejected_at == null || fallback.validated_at > fallback.rejected_at)) {
         // Stale but real. An outage must not lock out a publisher who has
         // published before. The plan rides along, so a publisher downgraded
         // since their last successful validation loses publishing here too

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,8 @@ export interface Env {
   UPGRADE_URL?: string;
   /** Server-to-server bearer credential. Unset disables the admin surface. */
   ADMIN_API_KEY?: string;
+  /** Trusted browser action endpoint. HTTPS, or loopback HTTP for development. */
+  ACCOUNT_ACTION_URL?: string;
 
   /**
    * OAuth client credentials for the approval page, one pair per provider.

--- a/src/db.ts
+++ b/src/db.ts
@@ -122,6 +122,7 @@ export interface DeviceCodeRow {
   label: string | null;
   /** Epoch ms of a refusal on the approval page, and null until one is given. */
   denied_at: number | null;
+  newsletter_opt_in: number;
   expires_at: number;
   created_at: number;
 }
@@ -133,7 +134,7 @@ export interface DeviceCodeRow {
  */
 export type PendingHandshake = Pick<
   DeviceCodeRow,
-  "user_code" | "provider" | "verifier" | "label"
+  "user_code" | "provider" | "verifier" | "label" | "newsletter_opt_in"
 >;
 
 /**
@@ -448,13 +449,11 @@ export async function findServableVersion(
  * for the same reason, and answered identically for all three so the shape of
  * the reply cannot confirm another publisher's doc exists.
  */
-export async function ownsLiveDoc(
-  db: D1Database,
-  docId: string,
-  owner: string,
-): Promise<boolean> {
+export async function ownsLiveDoc(db: D1Database, docId: string, owner: string): Promise<boolean> {
   const row = await db
-    .prepare(`${OWNER_SCOPE_SQL} SELECT 1 FROM docs WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL`)
+    .prepare(
+      `${OWNER_SCOPE_SQL} SELECT 1 FROM docs WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL`,
+    )
     .bind(owner, owner, docId)
     .first();
 
@@ -762,17 +761,18 @@ export async function startDeviceHandshake(
   state: string,
   verifier: string,
   nowMs: number,
+  newsletter = false,
 ): Promise<boolean> {
   const started = await db
     .prepare(
       `UPDATE device_codes
           SET provider = ?, state = ?, verifier = ?,
-              account_id = NULL, confirm_token = NULL
+              account_id = NULL, confirm_token = NULL, newsletter_opt_in = ?
         WHERE user_code = ? AND confirm_token IS NULL
           AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
         RETURNING user_code`,
     )
-    .bind(provider, state, verifier, userCode, nowMs)
+    .bind(provider, state, verifier, newsletter ? 1 : 0, userCode, nowMs)
     .first<{ user_code: string }>();
 
   return started !== null;
@@ -795,7 +795,7 @@ export async function findPendingHandshake(
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT user_code, provider, verifier, label FROM device_codes
+      `SELECT user_code, provider, verifier, label, newsletter_opt_in FROM device_codes
         WHERE state = ? AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?`,
     )
     .bind(state, nowMs)
@@ -880,22 +880,34 @@ export async function confirmDeviceApproval(
   db: D1Database,
   confirmToken: string,
   atMs: number,
+  newsletter = false,
 ): Promise<string | null> {
-  const approved = await db
-    .prepare(
-      `UPDATE device_codes
-          SET approved_at = ?, state = NULL, confirm_token = NULL
-        WHERE confirm_token = ?
-          AND approved_at IS NULL
-          AND denied_at IS NULL
-          AND account_id IS NOT NULL
-          AND expires_at > ?
-        RETURNING user_code`,
-    )
-    .bind(atMs, confirmToken, atMs)
-    .first<{ user_code: string }>();
-
-  return approved?.user_code ?? null;
+  // Both writes commit together. Only a browser holding the confirmation secret
+  // can enroll an account; OAuth callbacks alone never record newsletter consent.
+  // A later sign-in cannot overwrite a previous choice (including opting out).
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE accounts
+      SET newsletter_opt_in = ?,
+          newsletter_choice_at = ?
+      WHERE newsletter_choice_at IS NULL AND id IN (
+        SELECT account_id FROM device_codes WHERE confirm_token = ?
+          AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
+      )`,
+      )
+      .bind(newsletter ? 1 : 0, atMs, confirmToken, atMs),
+    db
+      .prepare(
+        `UPDATE device_codes
+      SET approved_at = ?, state = NULL, confirm_token = NULL
+      WHERE confirm_token = ? AND approved_at IS NULL AND denied_at IS NULL
+        AND account_id IS NOT NULL AND expires_at > ?
+      RETURNING user_code`,
+      )
+      .bind(atMs, confirmToken, atMs),
+  ]);
+  return (results[1]?.results[0] as { user_code: string } | undefined)?.user_code ?? null;
 }
 
 /**
@@ -1150,7 +1162,7 @@ export async function collectDeviceToken(
 export async function findLiveToken(
   db: D1Database,
   tokenHash: string,
-): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at">) | null> {
+): Promise<Pick<TokenRow, "id" | "account_id" | "last_used_at"> | null> {
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(

--- a/src/db.ts
+++ b/src/db.ts
@@ -122,7 +122,6 @@ export interface DeviceCodeRow {
   label: string | null;
   /** Epoch ms of a refusal on the approval page, and null until one is given. */
   denied_at: number | null;
-  newsletter_opt_in: number;
   expires_at: number;
   created_at: number;
 }
@@ -132,10 +131,7 @@ export interface DeviceCodeRow {
  * rides along so the confirmation page can name the machine being approved
  * instead of calling it "that terminal".
  */
-export type PendingHandshake = Pick<
-  DeviceCodeRow,
-  "user_code" | "provider" | "verifier" | "label" | "newsletter_opt_in"
->;
+export type PendingHandshake = Pick<DeviceCodeRow, "user_code" | "provider" | "verifier" | "label">;
 
 /**
  * A token an approval issued.
@@ -652,6 +648,8 @@ export async function findOrCreateAccount(
  *
  * @param newId an account id to use if one has to be minted, so this stays
  *   deterministic under test
+ * @param create false on OAuth callbacks: resolve/link existing accounts only;
+ *   an unknown identity must accept Terms before registration.
  */
 export async function resolveAccountForIdentity(
   db: D1Database,
@@ -661,6 +659,7 @@ export async function resolveAccountForIdentity(
   newId: string,
   nowMs: number,
   plan = "free",
+  create = true,
 ): Promise<AccountRow | null> {
   const linked = await db
     .prepare(
@@ -677,6 +676,7 @@ export async function resolveAccountForIdentity(
     .bind(email)
     .first<AccountRow>();
 
+  if (byEmail === null && !create) return null;
   const account = byEmail ?? (await findOrCreateAccount(db, newId, email, nowMs, plan));
 
   // No conflict target, so *either* constraint refuses the insert quietly. The
@@ -761,18 +761,18 @@ export async function startDeviceHandshake(
   state: string,
   verifier: string,
   nowMs: number,
-  newsletter = false,
 ): Promise<boolean> {
   const started = await db
     .prepare(
       `UPDATE device_codes
           SET provider = ?, state = ?, verifier = ?,
-              account_id = NULL, confirm_token = NULL, newsletter_opt_in = ?
+              account_id = NULL, confirm_token = NULL,
+              pending_subject = NULL, pending_email = NULL
         WHERE user_code = ? AND confirm_token IS NULL
           AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
         RETURNING user_code`,
     )
-    .bind(provider, state, verifier, newsletter ? 1 : 0, userCode, nowMs)
+    .bind(provider, state, verifier, userCode, nowMs)
     .first<{ user_code: string }>();
 
   return started !== null;
@@ -795,7 +795,7 @@ export async function findPendingHandshake(
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT user_code, provider, verifier, label, newsletter_opt_in FROM device_codes
+      `SELECT user_code, provider, verifier, label FROM device_codes
         WHERE state = ? AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?`,
     )
     .bind(state, nowMs)
@@ -837,14 +837,15 @@ export async function findPendingHandshake(
 export async function holdProvenIdentity(
   db: D1Database,
   state: string,
-  accountId: string,
+  accountId: string | null,
   confirmToken: string,
   nowMs: number,
+  identity?: { subject: string; email: string },
 ): Promise<boolean> {
   const held = await db
     .prepare(
       `UPDATE device_codes
-          SET account_id = ?, confirm_token = ?, verifier = NULL
+          SET account_id = ?, confirm_token = ?, verifier = NULL, pending_subject = ?, pending_email = ?
         WHERE state = ?
           AND verifier IS NOT NULL
           AND approved_at IS NULL
@@ -852,7 +853,7 @@ export async function holdProvenIdentity(
           AND expires_at > ?
         RETURNING user_code`,
     )
-    .bind(accountId, confirmToken, state, nowMs)
+    .bind(accountId, confirmToken, identity?.subject ?? null, identity?.email ?? null, state, nowMs)
     .first<{ user_code: string }>();
 
   return held !== null;
@@ -881,33 +882,55 @@ export async function confirmDeviceApproval(
   confirmToken: string,
   atMs: number,
   newsletter = false,
+  terms = false,
+  newId = "",
+  plan = "free",
 ): Promise<string | null> {
-  // Both writes commit together. Only a browser holding the confirmation secret
-  // can enroll an account; OAuth callbacks alone never record newsletter consent.
-  // A later sign-in cannot overwrite a previous choice (including opting out).
+  // The whole registration and approval is one transaction. The live secret and
+  // explicit Terms choice guard every insert; a denied/expired/replayed form
+  // cannot create an account. Unique identity constraints decide competing signups.
+  const live = `confirm_token = ? AND approved_at IS NULL AND denied_at IS NULL
+    AND expires_at > ? AND pending_subject IS NOT NULL AND ? = 1`;
   const results = await db.batch([
     db
       .prepare(
-        `UPDATE accounts
-      SET newsletter_opt_in = ?,
-          newsletter_choice_at = ?
-      WHERE newsletter_choice_at IS NULL AND id IN (
-        SELECT account_id FROM device_codes WHERE confirm_token = ?
-          AND approved_at IS NULL AND denied_at IS NULL AND expires_at > ?
-      )`,
+        `INSERT INTO accounts
+      (id, email, created_at, plan, plan_checked_at, newsletter_opt_in, newsletter_choice_at)
+      SELECT ?, pending_email, ?, ?, ?, ?, ? FROM device_codes d
+      WHERE ${live} AND NOT EXISTS (
+        SELECT 1 FROM identities i WHERE i.provider = d.provider AND i.subject = d.pending_subject
+      ) ON CONFLICT DO NOTHING`,
       )
-      .bind(newsletter ? 1 : 0, atMs, confirmToken, atMs),
+      .bind(newId, atMs, plan, atMs, newsletter ? 1 : 0, atMs, confirmToken, atMs, terms ? 1 : 0),
+    db
+      .prepare(
+        `INSERT INTO identities (provider, subject, account_id, created_at)
+      SELECT d.provider, d.pending_subject, a.id, ? FROM device_codes d
+      JOIN accounts a ON a.email = d.pending_email
+      WHERE ${live} ON CONFLICT DO NOTHING`,
+      )
+      .bind(atMs, confirmToken, atMs, terms ? 1 : 0),
+    db
+      .prepare(
+        `UPDATE device_codes SET account_id = (
+        SELECT account_id FROM identities WHERE provider = device_codes.provider
+          AND subject = device_codes.pending_subject
+      ) WHERE ${live}`,
+      )
+      .bind(confirmToken, atMs, terms ? 1 : 0),
     db
       .prepare(
         `UPDATE device_codes
-      SET approved_at = ?, state = NULL, confirm_token = NULL
+      SET approved_at = ?, state = NULL, confirm_token = NULL,
+          pending_subject = NULL, pending_email = NULL
       WHERE confirm_token = ? AND approved_at IS NULL AND denied_at IS NULL
         AND account_id IS NOT NULL AND expires_at > ?
+        AND (pending_subject IS NULL OR ? = 1)
       RETURNING user_code`,
       )
-      .bind(atMs, confirmToken, atMs),
+      .bind(atMs, confirmToken, atMs, terms ? 1 : 0),
   ]);
-  return (results[1]?.results[0] as { user_code: string } | undefined)?.user_code ?? null;
+  return (results[3]?.results[0] as { user_code: string } | undefined)?.user_code ?? null;
 }
 
 /**
@@ -934,7 +957,8 @@ export async function denyDeviceApproval(
   const denied = await db
     .prepare(
       `UPDATE device_codes
-          SET denied_at = ?, state = NULL, confirm_token = NULL, verifier = NULL
+          SET denied_at = ?, state = NULL, confirm_token = NULL, verifier = NULL,
+              pending_subject = NULL, pending_email = NULL
         WHERE confirm_token = ?
           AND approved_at IS NULL
           AND denied_at IS NULL

--- a/src/db.ts
+++ b/src/db.ts
@@ -606,11 +606,11 @@ export async function findOrCreateAccount(
 ): Promise<AccountRow> {
   const inserted = await db
     .prepare(
-      `INSERT INTO accounts (id, email, created_at, plan) VALUES (?, ?, ?, ?)
+      `INSERT INTO accounts (id, email, created_at, plan, plan_checked_at) VALUES (?, ?, ?, ?, ?)
        ON CONFLICT(email) DO NOTHING
        RETURNING id, email, created_at`,
     )
-    .bind(id, email, atMs, plan)
+    .bind(id, email, atMs, plan, atMs)
     .first<AccountRow>();
   if (inserted !== null) return inserted;
 
@@ -1150,15 +1150,15 @@ export async function collectDeviceToken(
 export async function findLiveToken(
   db: D1Database,
   tokenHash: string,
-): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string; plan_expires_at: number | null }) | null> {
+): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at">) | null> {
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT t.id, t.account_id, t.last_used_at, a.plan, a.plan_expires_at
+      `SELECT t.id, t.account_id, t.last_used_at
          FROM tokens t JOIN accounts a ON a.id = t.account_id WHERE t.token_hash = ?`,
     )
     .bind(tokenHash)
-    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string; plan_expires_at: number | null }>();
+    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at">>();
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,7 @@
  * every row here is reconstructible from it, so a lost D1 is a rebuild rather
  * than a data loss. Queries land here as the phase that needs them arrives.
  */
+import { OWNER_SCOPE_SQL } from "./owners.js";
 
 /** Publisher row, which doubles as the license-validation cache (phase 2). */
 export interface PublisherRow {
@@ -161,6 +162,7 @@ export type ListedTokenRow = Pick<TokenRow, "id" | "label" | "created_at" | "las
 export interface PublisherStore {
   read(keyHash: string): Promise<PublisherRow | null>;
   save(row: PublisherRow): Promise<void>;
+  remove(keyHash: string): Promise<void>;
 }
 
 /** Version numbers start at 1; a `docs` row at 0 has never been pushed to. */
@@ -173,6 +175,10 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
         .prepare("SELECT key_hash, plan, validated_at, owner FROM publishers WHERE key_hash = ?")
         .bind(keyHash)
         .first<PublisherRow>();
+    },
+
+    async remove(keyHash) {
+      await db.prepare("DELETE FROM publishers WHERE key_hash = ?").bind(keyHash).run();
     },
 
     // `owner` is written on every validation, like `plan` is. That is a refresh,
@@ -223,18 +229,20 @@ export async function insertDocWithinQuota(
 ): Promise<boolean> {
   const result = await db
     .prepare(
-      `INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
+      `${OWNER_SCOPE_SQL}
+       INSERT INTO docs (id, owner, title, latest_version, created_at, updated_at)
        SELECT ?, ?, ?, ?, ?, ?
-        WHERE (SELECT COUNT(*) FROM docs WHERE owner = ? AND deleted_at IS NULL) < ?`,
+        WHERE (SELECT COUNT(*) FROM docs WHERE owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL) < ?`,
     )
     .bind(
+      doc.owner,
+      doc.owner,
       doc.id,
       doc.owner,
       doc.title,
       FIRST_VERSION,
       doc.created_at,
       doc.updated_at,
-      doc.owner,
       maxDocs,
     )
     .run();
@@ -304,12 +312,13 @@ export async function reserveNextVersion(
 ): Promise<number | null> {
   const reserved = await db
     .prepare(
-      `UPDATE docs
+      `${OWNER_SCOPE_SQL}
+       UPDATE docs
           SET latest_version = latest_version + 1
-        WHERE id = ? AND owner = ? AND deleted_at IS NULL
+        WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL
         RETURNING latest_version`,
     )
-    .bind(docId, owner)
+    .bind(owner, owner, docId)
     .first<{ latest_version: number }>();
 
   return reserved?.latest_version ?? null;
@@ -445,8 +454,8 @@ export async function ownsLiveDoc(
   owner: string,
 ): Promise<boolean> {
   const row = await db
-    .prepare("SELECT 1 FROM docs WHERE id = ? AND owner = ? AND deleted_at IS NULL")
-    .bind(docId, owner)
+    .prepare(`${OWNER_SCOPE_SQL} SELECT 1 FROM docs WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL`)
+    .bind(owner, owner, docId)
     .first();
 
   return row !== null;
@@ -474,12 +483,13 @@ export async function softDeleteDoc(
 ): Promise<boolean> {
   const deleted = await db
     .prepare(
-      `UPDATE docs
+      `${OWNER_SCOPE_SQL}
+       UPDATE docs
           SET deleted_at = ?
-        WHERE id = ? AND owner = ? AND deleted_at IS NULL
+        WHERE id = ? AND owner IN (SELECT owner FROM owner_scope) AND deleted_at IS NULL
         RETURNING id`,
     )
-    .bind(atMs, docId, owner)
+    .bind(owner, owner, atMs, docId)
     .first<{ id: string }>();
 
   return deleted !== null;
@@ -551,19 +561,21 @@ export async function listPublisherDocs(
     after === null
       ? db
           .prepare(
-            `SELECT ${columns} FROM docs d
-              WHERE d.owner = ? AND d.deleted_at IS NULL
+            `${OWNER_SCOPE_SQL}
+             SELECT ${columns} FROM docs d
+              WHERE d.owner IN (SELECT owner FROM owner_scope) AND d.deleted_at IS NULL
               ${order}`,
           )
-          .bind(owner, limit)
+          .bind(owner, owner, limit)
       : db
           .prepare(
-            `SELECT ${columns} FROM docs d
-              WHERE d.owner = ? AND d.deleted_at IS NULL
+            `${OWNER_SCOPE_SQL}
+             SELECT ${columns} FROM docs d
+              WHERE d.owner IN (SELECT owner FROM owner_scope) AND d.deleted_at IS NULL
                 AND (d.created_at, d.id) < (?, ?)
               ${order}`,
           )
-          .bind(owner, after.created_at, after.id, limit);
+          .bind(owner, owner, after.created_at, after.id, limit);
 
   return (await statement.all<DocListRow>()).results;
 }
@@ -1138,15 +1150,15 @@ export async function collectDeviceToken(
 export async function findLiveToken(
   db: D1Database,
   tokenHash: string,
-): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string }) | null> {
+): Promise<(Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string; plan_expires_at: number | null }) | null> {
   // `return await`: see the note on the router's catch in index.ts.
   return await db
     .prepare(
-      `SELECT t.id, t.account_id, t.last_used_at, a.plan
+      `SELECT t.id, t.account_id, t.last_used_at, a.plan, a.plan_expires_at
          FROM tokens t JOIN accounts a ON a.id = t.account_id WHERE t.token_hash = ?`,
     )
     .bind(tokenHash)
-    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string }>();
+    .first<Pick<TokenRow, "id" | "account_id" | "last_used_at"> & { plan: string; plan_expires_at: number | null }>();
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,6 +14,8 @@ export interface PublisherRow {
   plan: string;
   /** Epoch ms of the last successful license-server validation. */
   validated_at: number;
+  /** Latest rejection completion time; only a validation begun later can authorize. */
+  rejected_at?: number | null;
   /** The app-sites `User.id` this key belongs to. */
   owner: string;
 }
@@ -158,8 +160,8 @@ export type ListedTokenRow = Pick<TokenRow, "id" | "label" | "created_at" | "las
  */
 export interface PublisherStore {
   read(keyHash: string): Promise<PublisherRow | null>;
-  save(row: PublisherRow): Promise<void>;
-  remove(keyHash: string): Promise<void>;
+  save(row: PublisherRow): Promise<boolean>;
+  reject(keyHash: string, at: number): Promise<void>;
 }
 
 /** Version numbers start at 1; a `docs` row at 0 has never been pushed to. */
@@ -169,13 +171,18 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
   return {
     read(keyHash) {
       return db
-        .prepare("SELECT key_hash, plan, validated_at, owner FROM publishers WHERE key_hash = ?")
+        .prepare("SELECT key_hash, plan, validated_at, owner, rejected_at FROM publishers WHERE key_hash = ?")
         .bind(keyHash)
         .first<PublisherRow>();
     },
 
-    async remove(keyHash) {
-      await db.prepare("DELETE FROM publishers WHERE key_hash = ?").bind(keyHash).run();
+    async reject(keyHash, at) {
+      // Keep the rejection even for a cold key: deleting loses the ordering
+      // evidence that stops an older in-flight success from restoring access.
+      await db.prepare(`INSERT INTO publishers (key_hash, plan, validated_at, owner, rejected_at)
+        VALUES (?, '', 0, '', ?)
+        ON CONFLICT(key_hash) DO UPDATE SET rejected_at = MAX(COALESCE(publishers.rejected_at, 0), excluded.rejected_at)`)
+        .bind(keyHash, at).run();
     },
 
     // `owner` is written on every validation, like `plan` is. That is a refresh,
@@ -184,15 +191,17 @@ export function d1PublisherStore(db: D1Database): PublisherStore {
     // us. If key transfer is ever added there, this cache becomes a hole — see
     // the note in `docs/identity.md`.
     async save(row) {
-      await db
+      const result = await db
         .prepare(
           `INSERT INTO publishers (key_hash, plan, validated_at, owner) VALUES (?, ?, ?, ?)
            ON CONFLICT(key_hash) DO UPDATE SET plan = excluded.plan,
                                                validated_at = excluded.validated_at,
-                                               owner = excluded.owner`,
+                                               owner = excluded.owner
+           WHERE publishers.rejected_at IS NULL OR excluded.validated_at > publishers.rejected_at`,
         )
         .bind(row.key_hash, row.plan, row.validated_at, row.owner)
         .run();
+      return result.meta.changes > 0;
     },
   };
 }

--- a/src/entitlement.ts
+++ b/src/entitlement.ts
@@ -61,5 +61,5 @@ export async function accountPlan(env: Env, owner: string, deps: {
     if (status === "unavailable" && cached.checkedAt !== null &&
         cached.checkedAt !== original.checkedAt) status = "cached";
   }
-  return { plan: effectivePlan(env, cached.plan, cached.expiresAt, now()), status };
+  return { plan: deps.skipAccountRefresh ? cached.plan : effectivePlan(env, cached.plan, cached.expiresAt, now()), status };
 }

--- a/src/entitlement.ts
+++ b/src/entitlement.ts
@@ -1,0 +1,51 @@
+import { LICENSE_CACHE_TTL_MS, type Env } from "./config.js";
+import { configuredPlans, defaultPlan, effectivePlan } from "./plans.js";
+
+export type RefreshStatus = "cached" | "refreshed" | "unavailable";
+type Snapshot = { plan: string; expiresAt: number | null; checkedAt: number | null; externalOwner: string | null };
+
+/** Credentials stay in D1. Only the Worker-proven account/link and service secret cross the network. */
+export async function accountPlan(env: Env, owner: string, deps: {
+  now?: () => number; fetch?: typeof fetch; forceAccountRefresh?: boolean; skipAccountRefresh?: boolean;
+} = {}): Promise<{ plan: string; status: RefreshStatus }> {
+  const read = () => env.DB.prepare(`SELECT plan, plan_expires_at AS expiresAt, plan_checked_at AS checkedAt,
+    (SELECT external_owner FROM owner_links WHERE account_id = accounts.id) AS externalOwner
+    FROM accounts WHERE id = ?`).bind(owner).first<Snapshot>();
+  let cached = await read();
+  if (!cached) return { plan: defaultPlan(env), status: "unavailable" };
+  const now = deps.now ?? Date.now;
+  const at = now();
+  let status: RefreshStatus = "cached";
+  if (!deps.skipAccountRefresh && (deps.forceAccountRefresh || cached.checkedAt === null || cached.checkedAt <= at - LICENSE_CACHE_TTL_MS ||
+      (cached.expiresAt !== null && cached.expiresAt <= at))) {
+    status = "unavailable";
+    if (env.LICENSE_API_URL && env.LICENSE_API_KEY) {
+      // Distinguish same-millisecond refreshes from the stored snapshot without a revision counter.
+      const started = Math.max(at, (cached.checkedAt ?? 0) + 1);
+      try {
+        const response = await (deps.fetch ?? fetch)(`${env.LICENSE_API_URL.replace(/\/+$/, "")}/api/trpc/license.openArtifactsEntitlement`, {
+          method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${env.LICENSE_API_KEY}` },
+          body: JSON.stringify({ json: { accountId: owner, ...(cached.externalOwner ? { externalOwner: cached.externalOwner } : {}) } }),
+          signal: AbortSignal.timeout(8000),
+        });
+        const body = await response.json() as { result?: { data?: { json?: { plan?: unknown; expiresAt?: unknown } } } };
+        const value = body.result?.data?.json;
+        if (!response.ok || !value || (value.plan !== "default" && value.plan !== "plus") ||
+            (value.expiresAt !== null && (typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt < 0))) {
+          throw new Error("Invalid entitlement response");
+        }
+        const plan = value.plan === "plus" ? "pro" : defaultPlan(env);
+        if (!Object.hasOwn(configuredPlans(env), plan)) throw new Error("Unconfigured paid plan");
+        const written = await env.DB.prepare(`UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_checked_at = ?
+          WHERE id = ? AND (plan_checked_at IS NULL OR plan_checked_at < ?)
+            AND (SELECT external_owner FROM owner_links WHERE account_id = accounts.id) IS ?`)
+          .bind(plan, value.expiresAt, started, owner, started, cached.externalOwner).run();
+        status = written.meta.changes ? "refreshed" : "cached";
+      } catch { /* Keep the snapshot; expiry still applies locally, including during an outage. */ }
+    }
+    // A concurrent manual assignment, link, or newer refresh wins even when our fetch fails.
+    cached = await read();
+    if (!cached) return { plan: defaultPlan(env), status: "unavailable" };
+  }
+  return { plan: effectivePlan(env, cached.plan, cached.expiresAt, now()), status };
+}

--- a/src/entitlement.ts
+++ b/src/entitlement.ts
@@ -1,3 +1,4 @@
+import { syncNewsletter } from "./newsletter.js";
 import { LICENSE_CACHE_TTL_MS, type Env } from "./config.js";
 import { configuredPlans, defaultPlan, effectivePlan } from "./plans.js";
 
@@ -18,6 +19,7 @@ export async function accountPlan(env: Env, owner: string, deps: {
   let status: RefreshStatus = "cached";
   if (!deps.skipAccountRefresh && (deps.forceAccountRefresh || cached.checkedAt === null || cached.checkedAt <= at - LICENSE_CACHE_TTL_MS ||
       (cached.expiresAt !== null && cached.expiresAt <= at))) {
+    await syncNewsletter(env, owner, deps.fetch);
     status = "unavailable";
     if (env.LICENSE_API_URL && env.LICENSE_API_KEY) {
       // Distinguish same-millisecond refreshes from the stored snapshot without a revision counter.

--- a/src/entitlement.ts
+++ b/src/entitlement.ts
@@ -3,13 +3,13 @@ import { LICENSE_CACHE_TTL_MS, type Env } from "./config.js";
 import { configuredPlans, defaultPlan, effectivePlan } from "./plans.js";
 
 export type RefreshStatus = "cached" | "refreshed" | "unavailable";
-type Snapshot = { plan: string; expiresAt: number | null; checkedAt: number | null; externalOwner: string | null };
+type Snapshot = { plan: string; expiresAt: number | null; checkedAt: number | null; externalOwner: string | null; retryAfter: number | null };
 
 /** Credentials stay in D1. Only the Worker-proven account/link and service secret cross the network. */
 export async function accountPlan(env: Env, owner: string, deps: {
   now?: () => number; fetch?: typeof fetch; forceAccountRefresh?: boolean; skipAccountRefresh?: boolean;
 } = {}): Promise<{ plan: string; status: RefreshStatus }> {
-  const read = () => env.DB.prepare(`SELECT plan, plan_expires_at AS expiresAt, plan_checked_at AS checkedAt,
+  const read = () => env.DB.prepare(`SELECT plan, plan_expires_at AS expiresAt, plan_checked_at AS checkedAt, plan_retry_after AS retryAfter,
     (SELECT external_owner FROM owner_links WHERE account_id = accounts.id) AS externalOwner
     FROM accounts WHERE id = ?`).bind(owner).first<Snapshot>();
   let cached = await read();
@@ -17,8 +17,11 @@ export async function accountPlan(env: Env, owner: string, deps: {
   const now = deps.now ?? Date.now;
   const at = now();
   let status: RefreshStatus = "cached";
-  if (!deps.skipAccountRefresh && (deps.forceAccountRefresh || cached.checkedAt === null || cached.checkedAt <= at - LICENSE_CACHE_TTL_MS ||
-      (cached.expiresAt !== null && cached.expiresAt <= at))) {
+  if (!deps.skipAccountRefresh && (deps.forceAccountRefresh ||
+      ((cached.retryAfter === null || cached.retryAfter <= at) &&
+       (cached.checkedAt === null || cached.checkedAt <= at - LICENSE_CACHE_TTL_MS ||
+        (cached.expiresAt !== null && cached.expiresAt <= at))))) {
+    const original = cached;
     await syncNewsletter(env, owner, deps.fetch);
     status = "unavailable";
     if (env.LICENSE_API_URL && env.LICENSE_API_KEY) {
@@ -38,16 +41,25 @@ export async function accountPlan(env: Env, owner: string, deps: {
         }
         const plan = value.plan === "plus" ? "pro" : defaultPlan(env);
         if (!Object.hasOwn(configuredPlans(env), plan)) throw new Error("Unconfigured paid plan");
-        const written = await env.DB.prepare(`UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_checked_at = ?
+        const written = await env.DB.prepare(`UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_checked_at = ?, plan_retry_after = NULL
           WHERE id = ? AND (plan_checked_at IS NULL OR plan_checked_at < ?)
             AND (SELECT external_owner FROM owner_links WHERE account_id = accounts.id) IS ?`)
           .bind(plan, value.expiresAt, started, owner, started, cached.externalOwner).run();
         status = written.meta.changes ? "refreshed" : "cached";
-      } catch { /* Keep the snapshot; expiry still applies locally, including during an outage. */ }
+      } catch {
+        // Backoff is independent of paid validity and successful-verification time.
+        // Do not delay a concurrent successful refresh or a newly linked account.
+        await env.DB.prepare(`UPDATE accounts SET plan_retry_after = ?
+          WHERE id = ? AND plan_checked_at IS ?
+            AND (SELECT external_owner FROM owner_links WHERE account_id = accounts.id) IS ?`)
+          .bind(now() + 60_000, owner, original.checkedAt, original.externalOwner).run();
+      }
     }
     // A concurrent manual assignment, link, or newer refresh wins even when our fetch fails.
     cached = await read();
     if (!cached) return { plan: defaultPlan(env), status: "unavailable" };
+    if (status === "unavailable" && cached.checkedAt !== null &&
+        cached.checkedAt !== original.checkedAt) status = "cached";
   }
   return { plan: effectivePlan(env, cached.plan, cached.expiresAt, now()), status };
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@
  * The code is stable for clients to match; the message stays free to change.
  */
 export type ErrorCode =
+  | "conflict"
   | "bad_request"
   | "unauthorized"
   | "not_found"
@@ -22,6 +23,7 @@ export type ErrorCode =
   | "access_denied";
 
 const ERROR_STATUS: Record<ErrorCode, number> = {
+  conflict: 409,
   bad_request: 400,
   unauthorized: 401,
   not_found: 404,

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -69,7 +69,7 @@ export function isDocId(value: string): boolean {
  *
  * `docs.owner` holds two kinds of value: an app-sites `User.id` that the
  * license server resolved, and an id this repo minted for an account created by
- * approval. They are never merged, and this prefix is what makes that
+ * approval. The credential IDs stay distinct, and this prefix makes that
  * structural rather than a convention — an app-sites uuid cannot start with
  * `oa_`, so no equality test between the two spaces can ever accidentally
  * succeed and hand one account another's documents.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { handleAccount } from "./account.js";
 import { deleteDoc, listDocs } from "./api/manage.js";
 import { ADMIN_PREFIX, handleAdmin } from "./admin.js";
 import { APPROVAL_PREFIX, handleApproval } from "./approval/handler.js";
@@ -111,6 +112,10 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
     .slice(API_PREFIX.length)
     .split("/")
     .filter(Boolean);
+
+  if (collection === "account" && extra.length === 0) {
+    return await handleAccount(request, env, auth.publisher);
+  }
 
   // Entitlement is per operation. Authentication above says *who* this is;
   // only publishing asks whether their plan may. Applying it to the whole

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { APPROVAL_PREFIX, handleApproval } from "./approval/handler.js";
 import { createDoc, updateDoc } from "./api/push.js";
 import {
   authenticateRequest,
+  isPublishingRequest,
   INELIGIBLE_PLAN,
   mayPublish,
   publisherErrorResponse,
@@ -125,11 +126,7 @@ async function handleApi(request: Request, url: URL, env: Env): Promise<Response
   //
   // Scoped to the two routes that actually publish, not to the method: a
   // `POST` at a path no route claims stays `404`, as the contract says.
-  const publishing =
-    collection === "docs" &&
-    extra.length === 0 &&
-    ((docId === undefined && request.method === "POST") ||
-      (docId !== undefined && request.method === "PUT"));
+  const publishing = isPublishingRequest(request);
   if (publishing && auth.publisher.authKind !== "account" && !mayPublish(auth.publisher.plan)) {
     return publisherErrorResponse(INELIGIBLE_PLAN);
   }

--- a/src/newsletter.ts
+++ b/src/newsletter.ts
@@ -5,7 +5,7 @@ export async function syncNewsletter(env: Env, accountId: string, fetcher = fetc
   if (!env.LICENSE_API_URL || !env.LICENSE_API_KEY) return;
   try {
     const account = await env.DB.prepare(
-      "SELECT email FROM accounts WHERE id = ? AND newsletter_opt_in = 1",
+      "SELECT email FROM accounts WHERE id = ? AND newsletter_opt_in = 1 AND newsletter_synced_at IS NULL",
     ).bind(accountId).first<{ email: string }>();
     if (!account) return;
     const response = await fetcher(
@@ -15,9 +15,15 @@ export async function syncNewsletter(env: Env, accountId: string, fetcher = fetc
         headers: { "content-type": "application/json", authorization: `Bearer ${env.LICENSE_API_KEY}` },
         body: JSON.stringify({ json: { email: account.email } }),
         signal: AbortSignal.timeout(1000),
+        redirect: "error",
       },
     );
     if (!response.ok) throw new Error("Newsletter unavailable");
+    const result = await response.json() as { result?: { data?: { json?: { ok?: boolean } } } };
+    if (result.result?.data?.json?.ok !== true) throw new Error("Newsletter unavailable");
+    await env.DB.prepare(
+      "UPDATE accounts SET newsletter_synced_at = ? WHERE id = ? AND email = ? AND newsletter_opt_in = 1",
+    ).bind(Date.now(), accountId, account.email).run();
   } catch {
     // Never expose identity or credentials in logs; never fail account creation.
     console.warn("Newsletter signup deferred until a later account refresh");

--- a/src/newsletter.ts
+++ b/src/newsletter.ts
@@ -1,0 +1,25 @@
+import type { Env } from "./config.js";
+
+/** Optional hosted integration. Saved consent allows an activity-driven retry. */
+export async function syncNewsletter(env: Env, accountId: string, fetcher = fetch): Promise<void> {
+  if (!env.LICENSE_API_URL || !env.LICENSE_API_KEY) return;
+  try {
+    const account = await env.DB.prepare(
+      "SELECT email FROM accounts WHERE id = ? AND newsletter_opt_in = 1",
+    ).bind(accountId).first<{ email: string }>();
+    if (!account) return;
+    const response = await fetcher(
+      `${env.LICENSE_API_URL.replace(/\/+$/, "")}/api/trpc/license.openArtifactsNewsletter`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${env.LICENSE_API_KEY}` },
+        body: JSON.stringify({ json: { email: account.email } }),
+        signal: AbortSignal.timeout(1000),
+      },
+    );
+    if (!response.ok) throw new Error("Newsletter unavailable");
+  } catch {
+    // Never expose identity or credentials in logs; never fail account creation.
+    console.warn("Newsletter signup deferred until a later account refresh");
+  }
+}

--- a/src/owners.ts
+++ b/src/owners.ts
@@ -1,0 +1,55 @@
+/**
+ * Document ownership can join two proven identities without moving their rows.
+ * Keep credential identity separate: these aliases never authorize token access.
+ */
+import { ACCOUNT_ID_PREFIX } from "./ids.js";
+
+/**
+ * Bind the authenticated owner twice, before the statement's other parameters.
+ * Resolve inside each statement so a link committed during a request applies to
+ * its next reservation or ownership check, including a request using an old key.
+ */
+export const OWNER_SCOPE_SQL = `WITH canonical AS (
+  SELECT COALESCE((SELECT account_id FROM owner_links WHERE external_owner = ?), ?) AS id
+), owner_scope AS (
+  SELECT id AS owner FROM canonical
+  UNION ALL
+  SELECT external_owner FROM owner_links JOIN canonical ON account_id = id
+)`;
+
+export type OwnerLinkResult = "linked" | "conflict" | "invalid" | "account_not_found";
+
+/**
+ * Trusted callers must prove both identities before invoking this primitive.
+ * Email equality or an outage cache is not proof. Associations are permanent;
+ * repeated confirmation of the same pair succeeds without changing anything.
+ */
+export async function linkExternalOwner(
+  db: D1Database,
+  externalOwner: string,
+  accountId: string,
+  atMs: number,
+): Promise<OwnerLinkResult> {
+  if (
+    externalOwner.trim() !== externalOwner || externalOwner.length === 0 ||
+    /[\u0000-\u0020\u007f]/.test(externalOwner) ||
+    externalOwner.length > 256 || externalOwner.startsWith(ACCOUNT_ID_PREFIX) ||
+    !/^oa_[0-9abcdefghjkmnpqrstvwxyz]{26}$/.test(accountId) ||
+    !Number.isSafeInteger(atMs) || atMs < 0
+  ) return "invalid";
+
+  const inserted = await db.prepare(
+    `INSERT INTO owner_links (external_owner, account_id, created_at)
+     SELECT ?, id, ? FROM accounts WHERE id = ?
+     ON CONFLICT DO NOTHING RETURNING account_id`,
+  ).bind(externalOwner, atMs, accountId).first<{ account_id: string }>();
+  if (inserted !== null) return "linked";
+
+  const existing = await db.prepare(
+    "SELECT account_id FROM owner_links WHERE external_owner = ?",
+  ).bind(externalOwner).first<{ account_id: string }>();
+  if (existing?.account_id === accountId) return "linked";
+  const account = await db.prepare("SELECT id FROM accounts WHERE id = ?")
+    .bind(accountId).first();
+  return account === null ? "account_not_found" : "conflict";
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -70,6 +70,9 @@ ${FAVICON_LINK}
   .signup { margin-top: 1.5rem; }
   .newsletter { display: flex; align-items: flex-start; gap: 0.6rem; color: #e9ebee; font-size: 0.95rem; line-height: 1.5; }
   .newsletter input { accent-color: #f6ae52; width: 1rem; height: 1rem; margin: 0.2rem 0 0; flex-shrink: 0; }
+  .signup .actions { flex-direction: column; gap: 0.75rem; margin-top: 2rem; }
+  .signup .actions button { display: flex; align-items: center; justify-content: center; gap: 0.75rem; width: 100%; margin-top: 0; }
+  .signup .actions button svg { width: 1.25rem; height: 1.25rem; flex-shrink: 0; }
   .signup .actions button:disabled { border-color: #292d35; background: #191c22; color: #636b78; cursor: not-allowed; }
   .terms-consent { margin-top: 1.5rem; }
   .terms-consent a { display: inline; margin: 0; }

--- a/src/page.ts
+++ b/src/page.ts
@@ -65,8 +65,6 @@ ${FAVICON_LINK}
   .actions input { margin-top: 2rem; padding: 0.85rem 1.25rem; min-width: 11rem; border: 1px solid #2c313b; border-radius: 0.75rem; background: #07080b; color: #f4f5f7; font-family: "IBM Plex Mono", ui-monospace, Menlo, Consolas, monospace; font-size: 1rem; letter-spacing: 0.16em; text-transform: uppercase; }
   .actions input::placeholder { color: #5b626e; }
   .actions input:focus { outline: none; border-color: #f6ae52; }
-  .actions form.confirm-signup { display: block; width: 100%; margin-top: 1.5rem; }
-  .confirm-signup .newsletter input { padding: 0; min-width: 0; margin: 0.2rem 0 0; }
   .signup { margin-top: 1.5rem; }
   .newsletter { display: flex; align-items: flex-start; gap: 0.6rem; color: #e9ebee; font-size: 0.95rem; line-height: 1.5; }
   .newsletter input { accent-color: #f6ae52; width: 1rem; height: 1rem; margin: 0.2rem 0 0; flex-shrink: 0; }
@@ -74,6 +72,7 @@ ${FAVICON_LINK}
   .signup .actions button { display: flex; align-items: center; justify-content: center; gap: 0.75rem; width: 100%; margin-top: 0; }
   .signup .actions button svg { width: 1.25rem; height: 1.25rem; flex-shrink: 0; }
   .signup .actions button:disabled { border-color: #292d35; background: #191c22; color: #636b78; cursor: not-allowed; }
+  .signup .terms + .newsletter { margin-top: 1rem; }
   .terms-consent { margin-top: 1.5rem; }
   .terms-consent a { display: inline; margin: 0; }
   .terms { font-size: 0.85rem; line-height: 1.6; }

--- a/src/page.ts
+++ b/src/page.ts
@@ -70,6 +70,9 @@ ${FAVICON_LINK}
   .signup { margin-top: 1.5rem; }
   .newsletter { display: flex; align-items: flex-start; gap: 0.6rem; color: #e9ebee; font-size: 0.95rem; line-height: 1.5; }
   .newsletter input { accent-color: #f6ae52; width: 1rem; height: 1rem; margin: 0.2rem 0 0; flex-shrink: 0; }
+  .signup .actions button:disabled { border-color: #292d35; background: #191c22; color: #636b78; cursor: not-allowed; }
+  .terms-consent { margin-top: 1.5rem; }
+  .terms-consent a { display: inline; margin: 0; }
   .terms { font-size: 0.85rem; line-height: 1.6; }
   .terms a { display: inline; margin: 0; }
 </style>

--- a/src/page.ts
+++ b/src/page.ts
@@ -65,6 +65,13 @@ ${FAVICON_LINK}
   .actions input { margin-top: 2rem; padding: 0.85rem 1.25rem; min-width: 11rem; border: 1px solid #2c313b; border-radius: 0.75rem; background: #07080b; color: #f4f5f7; font-family: "IBM Plex Mono", ui-monospace, Menlo, Consolas, monospace; font-size: 1rem; letter-spacing: 0.16em; text-transform: uppercase; }
   .actions input::placeholder { color: #5b626e; }
   .actions input:focus { outline: none; border-color: #f6ae52; }
+  .actions form.confirm-signup { display: block; width: 100%; margin-top: 1.5rem; }
+  .confirm-signup .newsletter input { padding: 0; min-width: 0; margin: 0.2rem 0 0; }
+  .signup { margin-top: 1.5rem; }
+  .newsletter { display: flex; align-items: flex-start; gap: 0.6rem; color: #e9ebee; font-size: 0.95rem; line-height: 1.5; }
+  .newsletter input { accent-color: #f6ae52; width: 1rem; height: 1rem; margin: 0.2rem 0 0; flex-shrink: 0; }
+  .terms { font-size: 0.85rem; line-height: 1.6; }
+  .terms a { display: inline; margin: 0; }
 </style>
 </head>
 <body>

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -9,7 +9,7 @@ export interface PlanLimits {
 }
 
 const DEFAULT_PLANS: Record<string, PlanLimits> = {
-  free: { documents: 3, pushesPerDay: 6, htmlBytes: 1024 * 1024 },
+  free: { documents: 1, pushesPerDay: 6, htmlBytes: 1024 * 1024 },
 };
 
 /** Finite positive ceilings only; the HTML memory safety bound is never configurable. */
@@ -42,6 +42,11 @@ export function defaultPlan(env: Env): string {
   const plan = env.DEFAULT_PLAN ?? "free";
   planLimits(env, plan);
   return plan;
+}
+
+/** Expiration changes access on the next request, never ownership or stored history. */
+export function effectivePlan(env: Env, plan: string, expiresAt: number | null, now = Date.now()): string {
+  return expiresAt !== null && expiresAt <= now ? defaultPlan(env) : plan;
 }
 
 export function limitReached(env: Env, publisher: Publisher, limit: string, message: string): Response {

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -57,7 +57,7 @@ export function limitReached(env: Env, publisher: Publisher, limit: string, mess
       throw new Error("UPGRADE_URL must be an absolute HTTP(S) URL without credentials.");
     }
     // This routes checkout, never authenticates it. Billing must prove account ownership.
-    url.searchParams.set("owner", publisher.owner);
+    url.searchParams.delete("owner");
     upgradeUrl = url.toString();
   }
   return errorResponse("limit_reached", message, undefined, {

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -60,7 +60,9 @@ export function limitReached(env: Env, publisher: Publisher, limit: string, mess
     url.searchParams.delete("owner");
     upgradeUrl = url.toString();
   }
-  return errorResponse("limit_reached", message, undefined, {
+  return errorResponse("limit_reached", env.ACCOUNT_ACTION_URL?.trim()
+    ? `${message} Run openartifacts account --open to manage your plan.`
+    : message, undefined, {
     plan: publisher.plan, limit, ...(upgradeUrl ? { upgrade_url: upgradeUrl } : {}),
   });
 }

--- a/src/quota.ts
+++ b/src/quota.ts
@@ -5,6 +5,7 @@
  * Copilot user never reaches any of them. The numbers themselves live in
  * `config.ts`; this file is how they are counted.
  */
+import { OWNER_SCOPE_SQL } from "./owners.js";
 import { MAX_DOC_BYTES, MAX_PUSHES_PER_DAY } from "./config.js";
 
 /**
@@ -88,9 +89,10 @@ export function utcDay(atMs: number): string {
  *
  * Claim rather than check: the count is read and incremented by a single
  * statement, so two concurrent pushes cannot both see 99 and both proceed. The
- * `WHERE` on the upsert's update branch is what enforces the limit — when it
- * fails SQLite leaves the row alone and `RETURNING` yields nothing, which is
- * the rejection.
+ * insert's predicate sums both linked owners before either insert or update.
+ * When it fails SQLite leaves the row alone and `RETURNING` yields nothing.
+ * The bucket retains the credential owner so refunds crossing a link still
+ * return the exact reservation, without moving or resetting either counter.
  */
 export async function reserveDailyPush(
   db: D1Database,
@@ -100,12 +102,16 @@ export async function reserveDailyPush(
 ): Promise<boolean> {
   const claimed = await db
     .prepare(
-      `INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, 1)
+      `${OWNER_SCOPE_SQL}
+       INSERT INTO push_quota (owner, day, pushes)
+       SELECT ?, ?, 1 WHERE (
+         SELECT COALESCE(SUM(pushes), 0) FROM push_quota
+          WHERE owner IN (SELECT owner FROM owner_scope) AND day = ?
+       ) < ?
        ON CONFLICT(owner, day) DO UPDATE SET pushes = push_quota.pushes + 1
-         WHERE push_quota.pushes < ?
        RETURNING pushes`,
     )
-    .bind(owner, day, limit)
+    .bind(owner, owner, owner, day, day, limit)
     .first<{ pushes: number }>();
 
   return claimed !== null;

--- a/test/account-actions.test.ts
+++ b/test/account-actions.test.ts
@@ -1,0 +1,156 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, expect, it } from "vitest";
+import type { Env } from "../src/config.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId } from "../src/ids.js";
+import worker from "../src/index.js";
+
+const ACCOUNT = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER = "oa_bbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SERVICE = "test-service-secret";
+const EXTERNAL = "external-account";
+let token: string;
+let tokenId: string;
+let otherToken: string;
+const defaults = { ADMIN_API_KEY: SERVICE, ACCOUNT_ACTION_URL: "https://actions.example.test/continue" };
+
+beforeEach(async () => {
+  for (const id of [ACCOUNT, OTHER]) {
+    await env.DB.prepare("INSERT INTO accounts (id, email, created_at) VALUES (?, ?, 0)")
+      .bind(id, `${id}@example.test`).run();
+  }
+  token = newApiToken(); tokenId = newTokenId(); otherToken = newApiToken();
+  for (const [id, value, account] of [[tokenId, token, ACCOUNT], [newTokenId(), otherToken, OTHER]]) {
+    await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+      .bind(id, await sha256Hex(value!), account).run();
+  }
+});
+
+async function send(method: string, path: string, credential: string, body?: unknown, overrides: Partial<Env> = {}) {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`https://api.local.test${path}`, {
+    method, headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), { ...env, ...defaults, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "", ...overrides }, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+const consume = (code: string, credential = SERVICE) => send("POST", "/admin/v1/handoffs/consume", credential, { code });
+const count = async () => (await env.DB.prepare("SELECT COUNT(*) AS n FROM account_handoffs").first<{ n: number }>())!.n;
+async function mint(purpose = "upgrade", credential = token) {
+  const response = await send("POST", "/api/v1/account/handoffs", credential, { purpose });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  const result = await response.json() as { url: string; expiresAt: number };
+  return { ...result, code: new URL(result.url).searchParams.get("code")! };
+}
+
+it("reports account plan, limits, combined usage and association without revealing external identity", async () => {
+  expect((await send("PUT", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE, { externalOwner: EXTERNAL })).status).toBe(200);
+  for (const owner of [ACCOUNT, EXTERNAL]) {
+    await env.DB.prepare("INSERT INTO docs (id, owner, title, created_at, updated_at) VALUES (?, ?, '', 0, 0)").bind(owner, owner).run();
+    await env.DB.prepare("INSERT INTO push_quota (owner, day, pushes) VALUES (?, ?, 2)").bind(owner, new Date().toISOString().slice(0, 10)).run();
+  }
+  const response = await send("GET", "/api/v1/account", token);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ accountId: ACCOUNT, plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 2, pushesToday: 4 }, externalLinked: true });
+  const other = await (await send("GET", "/api/v1/account", otherToken)).json();
+  expect(other).toMatchObject({ accountId: OTHER, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
+});
+
+it("preserves each purpose, consumes once, stores only hashes and returns linked identity to the service", async () => {
+  await send("PUT", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE, { externalOwner: EXTERNAL });
+  for (const purpose of ["upgrade", "billing", "link"]) {
+    const before = Date.now();
+    const handoff = await mint(purpose);
+    expect(handoff.expiresAt).toBeGreaterThanOrEqual(before + 600000);
+    expect(handoff.expiresAt).toBeLessThanOrEqual(Date.now() + 600000);
+    const stored = await env.DB.prepare("SELECT * FROM account_handoffs").all();
+    expect(JSON.stringify(stored)).not.toContain(handoff.code);
+    expect(JSON.stringify(stored)).not.toContain(token);
+    const response = await consume(handoff.code);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ accountId: ACCOUNT, email: `${ACCOUNT}@example.test`, purpose, externalOwner: EXTERNAL });
+    expect((await consume(handoff.code)).status).toBe(404);
+  }
+});
+
+it("allows one concurrent consumption and at most five concurrent outstanding actions per account", async () => {
+  const attempts = await Promise.all(Array.from({ length: 8 }, () => send("POST", "/api/v1/account/handoffs", token, { purpose: "link" })));
+  expect(attempts.filter((r) => r.status === 200)).toHaveLength(5);
+  expect(attempts.filter((r) => r.status === 429)).toHaveLength(3);
+  const body = await attempts.find((r) => r.status === 200)!.json() as { url: string };
+  const code = new URL(body.url).searchParams.get("code")!;
+  expect((await Promise.all([consume(code), consume(code)])).map((r) => r.status).sort()).toEqual([200, 404]);
+  expect(await count()).toBe(4);
+  await mint("billing", otherToken);
+  expect(await count()).toBe(5);
+});
+
+it("refuses expired and revoked originating credentials and clears only the owner's expired actions", async () => {
+  const expired = await mint();
+  await env.DB.prepare("UPDATE account_handoffs SET expires_at = 0").run();
+  expect((await consume(expired.code)).status).toBe(404);
+  await mint("link", otherToken);
+  const revoked = await mint();
+  expect(await count()).toBe(2);
+  await env.DB.prepare("DELETE FROM tokens WHERE id = ?").bind(tokenId).run();
+  expect((await consume(revoked.code)).status).toBe(404);
+  expect((await send("POST", "/api/v1/account/handoffs", token, { purpose: "billing" })).status).toBe(401);
+});
+
+it("requires the service credential and does not consume proof on an unauthorized request", async () => {
+  const handoff = await mint();
+  for (const credential of [token, otherToken, "wrong"]) expect((await consume(handoff.code, credential)).status).toBe(401);
+  expect(await count()).toBe(1);
+  expect((await consume(handoff.code)).status).toBe(200);
+});
+
+it("rejects extra fields, forged purposes, oversized input and malformed codes", async () => {
+  for (const body of [{ purpose: "delete" }, { purpose: "link", accountId: OTHER }, { purpose: 1 }, [], null, { purpose: "x".repeat(2000) }]) {
+    expect((await send("POST", "/api/v1/account/handoffs", token, body)).status).toBe(400);
+  }
+  for (const body of [{ code: "x" }, { code: "a".repeat(64), purpose: "link" }, { code: 1 }]) {
+    expect((await send("POST", "/admin/v1/handoffs/consume", SERVICE, body)).status).toBe(400);
+  }
+  expect(await count()).toBe(0);
+});
+
+it("fails closed before writing for unconfigured or unsafe action destinations", async () => {
+  for (const [url, status] of [["", 404], ["http://evil.test/path", 500], ["https://user:pass@example.test", 500], ["https://example.test/#fragment", 500], ["javascript:alert(1)", 500]] as const) {
+    expect((await send("POST", "/api/v1/account/handoffs", token, { purpose: "link" }, { ACCOUNT_ACTION_URL: url })).status).toBe(status);
+  }
+  expect(await count()).toBe(0);
+  const local = await send("POST", "/api/v1/account/handoffs", token, { purpose: "link" }, { ACCOUNT_ACTION_URL: "http://localhost:3000/action" });
+  expect(local.status).toBe(200);
+});
+
+it("requires OAuth credentials and confines service routes to the API host", async () => {
+  const key = "license-test-key";
+  await env.DB.prepare("INSERT INTO publishers (key_hash, owner, plan, validated_at) VALUES (?, ?, 'plus', ?)").bind(await sha256Hex(key), EXTERNAL, Date.now()).run();
+  expect((await send("GET", "/api/v1/account", key)).status).toBe(401);
+  expect((await send("POST", "/api/v1/account/handoffs", key, { purpose: "link" })).status).toBe(401);
+  expect((await send("POST", "/admin/v1/handoffs/consume", SERVICE, { code: "a".repeat(64) }, { API_HOST: "other.test", SERVING_HOST: "api.local.test" })).status).toBe(404);
+});
+
+it("associates only through service authorization, repeats safely, rejects conflicting pairs", async () => {
+  const path = `/admin/v1/accounts/${ACCOUNT}/external-owner`;
+  expect((await send("PUT", path, token, { externalOwner: EXTERNAL })).status).toBe(401);
+  for (let n = 0; n < 2; n++) expect((await send("PUT", path, SERVICE, { externalOwner: EXTERNAL })).status).toBe(200);
+  expect((await send("PUT", path, SERVICE, { externalOwner: "other-external" })).status).toBe(409);
+  expect((await send("PUT", `/admin/v1/accounts/${OTHER}/external-owner`, SERVICE, { externalOwner: EXTERNAL })).status).toBe(409);
+  expect((await send("PUT", path, SERVICE, { externalOwner: ACCOUNT })).status).toBe(400);
+  expect((await send("PUT", path, SERVICE, { externalOwner: EXTERNAL, plan: "pro" })).status).toBe(400);
+});
+
+it("lets only the trusted service recover the current owner association", async () => {
+  const path = `/admin/v1/accounts/${ACCOUNT}/external-owner`;
+  expect((await send("GET", path, token)).status).toBe(401);
+  expect((await send("GET", "/admin/v1/accounts/missing/external-owner", SERVICE)).status).toBe(404);
+  const empty = await send("GET", path, SERVICE);
+  expect(empty.headers.get("cache-control")).toBe("no-store");
+  expect(await empty.json()).toEqual({ accountId: ACCOUNT, externalOwner: null });
+  await send("PUT", path, SERVICE, { externalOwner: EXTERNAL });
+  expect(await (await send("GET", path, SERVICE)).json()).toEqual({ accountId: ACCOUNT, externalOwner: EXTERNAL });
+});

--- a/test/account-actions.test.ts
+++ b/test/account-actions.test.ts
@@ -126,7 +126,9 @@ it("fails closed before writing for unconfigured or unsafe action destinations",
 it("requires OAuth credentials and confines service routes to the API host", async () => {
   const key = "license-test-key";
   await env.DB.prepare("INSERT INTO publishers (key_hash, owner, plan, validated_at) VALUES (?, ?, 'plus', ?)").bind(await sha256Hex(key), EXTERNAL, Date.now()).run();
-  expect((await send("GET", "/api/v1/account", key)).status).toBe(401);
+  const rejected = await send("GET", "/api/v1/account", key);
+  expect(rejected.status).toBe(401);
+  expect(rejected.headers.get("www-authenticate")).toBe("Bearer");
   expect((await send("POST", "/api/v1/account/handoffs", key, { purpose: "link" })).status).toBe(401);
   expect((await send("POST", "/admin/v1/handoffs/consume", SERVICE, { code: "a".repeat(64) }, { API_HOST: "other.test", SERVING_HOST: "api.local.test" })).status).toBe(404);
 });
@@ -146,4 +148,13 @@ it("does not consume on GET or expose a separate external-owner recovery route",
   expect((await send("GET", `/admin/v1/handoffs/consume?code=${handoff.code}`, SERVICE)).status).toBe(404);
   expect((await send("GET", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE)).status).toBe(404);
   expect((await consume(handoff.code)).status).toBe(200);
+});
+
+it("revoked-token proofs do not consume another live token's pending allowance", async () => {
+  for (let i = 0; i < 5; i++) await mint();
+  const replacement = newApiToken();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+    .bind(newTokenId(), await sha256Hex(replacement), ACCOUNT).run();
+  await env.DB.prepare("DELETE FROM tokens WHERE id = ?").bind(tokenId).run();
+  await mint(replacement);
 });

--- a/test/account-actions.test.ts
+++ b/test/account-actions.test.ts
@@ -37,8 +37,8 @@ async function send(method: string, path: string, credential: string, body?: unk
 }
 const consume = (code: string, credential = SERVICE) => send("POST", "/admin/v1/handoffs/consume", credential, { code });
 const count = async () => (await env.DB.prepare("SELECT COUNT(*) AS n FROM account_handoffs").first<{ n: number }>())!.n;
-async function mint(purpose = "upgrade", credential = token) {
-  const response = await send("POST", "/api/v1/account/handoffs", credential, { purpose });
+async function mint(credential = token) {
+  const response = await send("POST", "/api/v1/account/handoffs", credential);
   expect(response.status).toBe(200);
   expect(response.headers.get("cache-control")).toBe("no-store");
   const result = await response.json() as { url: string; expiresAt: number };
@@ -53,16 +53,16 @@ it("reports account plan, limits, combined usage and association without reveali
   }
   const response = await send("GET", "/api/v1/account", token);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ accountId: ACCOUNT, plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 2, pushesToday: 4 }, externalLinked: true });
+  expect(await response.json()).toEqual({ accountId: ACCOUNT, plan: "free", limits: { documents: 1, pushesPerDay: 6, htmlBytes: 1048576 }, usage: { documents: 2, pushesToday: 4 }, externalLinked: true, refresh: { status: "unavailable", checkedAt: null, expiresAt: null } });
   const other = await (await send("GET", "/api/v1/account", otherToken)).json();
   expect(other).toMatchObject({ accountId: OTHER, usage: { documents: 0, pushesToday: 0 }, externalLinked: false });
 });
 
-it("preserves each purpose, consumes once, stores only hashes and returns linked identity to the service", async () => {
+it("consumes once only on POST, stores hashes and returns linked identity to the service", async () => {
   await send("PUT", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE, { externalOwner: EXTERNAL });
-  for (const purpose of ["upgrade", "billing", "link"]) {
+  {
     const before = Date.now();
-    const handoff = await mint(purpose);
+    const handoff = await mint();
     expect(handoff.expiresAt).toBeGreaterThanOrEqual(before + 600000);
     expect(handoff.expiresAt).toBeLessThanOrEqual(Date.now() + 600000);
     const stored = await env.DB.prepare("SELECT * FROM account_handoffs").all();
@@ -71,7 +71,7 @@ it("preserves each purpose, consumes once, stores only hashes and returns linked
     const response = await consume(handoff.code);
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(await response.json()).toEqual({ accountId: ACCOUNT, email: `${ACCOUNT}@example.test`, purpose, externalOwner: EXTERNAL });
+    expect(await response.json()).toEqual({ accountId: ACCOUNT, email: `${ACCOUNT}@example.test`, externalOwner: EXTERNAL });
     expect((await consume(handoff.code)).status).toBe(404);
   }
 });
@@ -84,7 +84,7 @@ it("allows one concurrent consumption and at most five concurrent outstanding ac
   const code = new URL(body.url).searchParams.get("code")!;
   expect((await Promise.all([consume(code), consume(code)])).map((r) => r.status).sort()).toEqual([200, 404]);
   expect(await count()).toBe(4);
-  await mint("billing", otherToken);
+  await mint(otherToken);
   expect(await count()).toBe(5);
 });
 
@@ -92,7 +92,7 @@ it("refuses expired and revoked originating credentials and clears only the owne
   const expired = await mint();
   await env.DB.prepare("UPDATE account_handoffs SET expires_at = 0").run();
   expect((await consume(expired.code)).status).toBe(404);
-  await mint("link", otherToken);
+  await mint(otherToken);
   const revoked = await mint();
   expect(await count()).toBe(2);
   await env.DB.prepare("DELETE FROM tokens WHERE id = ?").bind(tokenId).run();
@@ -108,9 +108,6 @@ it("requires the service credential and does not consume proof on an unauthorize
 });
 
 it("rejects extra fields, forged purposes, oversized input and malformed codes", async () => {
-  for (const body of [{ purpose: "delete" }, { purpose: "link", accountId: OTHER }, { purpose: 1 }, [], null, { purpose: "x".repeat(2000) }]) {
-    expect((await send("POST", "/api/v1/account/handoffs", token, body)).status).toBe(400);
-  }
   for (const body of [{ code: "x" }, { code: "a".repeat(64), purpose: "link" }, { code: 1 }]) {
     expect((await send("POST", "/admin/v1/handoffs/consume", SERVICE, body)).status).toBe(400);
   }
@@ -144,13 +141,9 @@ it("associates only through service authorization, repeats safely, rejects confl
   expect((await send("PUT", path, SERVICE, { externalOwner: EXTERNAL, plan: "pro" })).status).toBe(400);
 });
 
-it("lets only the trusted service recover the current owner association", async () => {
-  const path = `/admin/v1/accounts/${ACCOUNT}/external-owner`;
-  expect((await send("GET", path, token)).status).toBe(401);
-  expect((await send("GET", "/admin/v1/accounts/missing/external-owner", SERVICE)).status).toBe(404);
-  const empty = await send("GET", path, SERVICE);
-  expect(empty.headers.get("cache-control")).toBe("no-store");
-  expect(await empty.json()).toEqual({ accountId: ACCOUNT, externalOwner: null });
-  await send("PUT", path, SERVICE, { externalOwner: EXTERNAL });
-  expect(await (await send("GET", path, SERVICE)).json()).toEqual({ accountId: ACCOUNT, externalOwner: EXTERNAL });
+it("does not consume on GET or expose a separate external-owner recovery route", async () => {
+  const handoff = await mint();
+  expect((await send("GET", `/admin/v1/handoffs/consume?code=${handoff.code}`, SERVICE)).status).toBe(404);
+  expect((await send("GET", `/admin/v1/accounts/${ACCOUNT}/external-owner`, SERVICE)).status).toBe(404);
+  expect((await consume(handoff.code)).status).toBe(200);
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -235,6 +235,7 @@ describe("startDeviceHandshake", () => {
       provider: "github",
       verifier: "v2",
       label: null,
+      newsletter_opt_in: 0,
     });
   });
 
@@ -271,6 +272,7 @@ describe("findPendingHandshake", () => {
       provider: "github",
       verifier: "verifier-find",
       label: null,
+      newsletter_opt_in: 0,
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -235,7 +235,6 @@ describe("startDeviceHandshake", () => {
       provider: "github",
       verifier: "v2",
       label: null,
-      newsletter_opt_in: 0,
     });
   });
 
@@ -272,7 +271,6 @@ describe("findPendingHandshake", () => {
       provider: "github",
       verifier: "verifier-find",
       label: null,
-      newsletter_opt_in: 0,
     });
   });
 

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -122,7 +122,9 @@ async function readCode(userCode = USER_CODE) {
 }
 
 async function accountCount(): Promise<number> {
-  const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM accounts").first<{ n: number }>();
+  const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM accounts").first<{
+    n: number;
+  }>();
   return row?.n ?? 0;
 }
 
@@ -133,7 +135,10 @@ async function startedState(userCode = USER_CODE): Promise<string> {
 
 /** Start a handshake the way the chooser's button does. */
 function begin(provider: ProviderId = "google", userCode = USER_CODE): Promise<Response> {
-  return post(`/approve/start/${provider}`, { user_code: userCode, terms: "yes" });
+  return post(`/approve/start/${provider}`, {
+    user_code: userCode,
+    terms: "yes",
+  });
 }
 
 /**
@@ -191,7 +196,10 @@ async function approve(
     state: await startedState(userCode),
     oauth: oauthAnswering(email, subject ?? `sub-${provider}`),
   });
-  return await post("/approve/confirm", { confirm_token: confirmToken(await proven.text()) });
+  return await post("/approve/confirm", {
+    terms: "yes",
+    confirm_token: confirmToken(await proven.text()),
+  });
 }
 
 beforeEach(async () => {
@@ -446,7 +454,10 @@ describe("a lookup a page made rather than a person", () => {
       "/approve/start/google",
       {
         method: "POST",
-        headers: { "cf-connecting-ip": "198.51.100.23", "sec-fetch-dest": "iframe" },
+        headers: {
+          "cf-connecting-ip": "198.51.100.23",
+          "sec-fetch-dest": "iframe",
+        },
         body: new URLSearchParams({ user_code: USER_CODE, terms: "yes" }),
       },
       { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
@@ -458,19 +469,6 @@ describe("a lookup a page made rather than a person", () => {
 });
 
 describe("POST /approve/start/{provider}", () => {
-  it.each([undefined, "no"])(
-    "requires explicit terms agreement before starting a handshake (%s)",
-    async (terms) => {
-      const response = await post("/approve/start/google", {
-        user_code: USER_CODE,
-        ...(terms ? { terms } : {}),
-      });
-      expect(response.status).toBe(400);
-      expect(await response.text()).toContain("Agree to the Terms before signing in.");
-      expect((await readCode())?.state).toBeNull();
-      expect(await accountCount()).toBe(0);
-    },
-  );
   it("sends the browser to Google with PKCE and records the handshake on the code", async () => {
     const response = await begin("google");
 
@@ -513,7 +511,14 @@ describe("POST /approve/start/{provider}", () => {
   });
 
   it("has no route for a provider this deployment cannot use", async () => {
-    expect((await post("/approve/start/gitlab", { user_code: USER_CODE, terms: "yes" })).status).toBe(404);
+    expect(
+      (
+        await post("/approve/start/gitlab", {
+          user_code: USER_CODE,
+          terms: "yes",
+        })
+      ).status,
+    ).toBe(404);
     expect(
       (
         await post(
@@ -530,7 +535,12 @@ describe("POST /approve/start/{provider}", () => {
 
     await seedCode("EXPIRED-2", NOW - 1);
     expect(
-      (await post("/approve/start/google", { user_code: "EXPIRED-2", terms: "yes" })).status,
+      (
+        await post("/approve/start/google", {
+          user_code: "EXPIRED-2",
+          terms: "yes",
+        })
+      ).status,
     ).toBe(404);
   });
 });
@@ -550,12 +560,13 @@ describe("GET /approve/callback/{provider}", () => {
 
     expect(response.status).toBe(200);
     const html = await response.text();
-    expect(html).toContain("Approve this code?");
+    expect(html).toContain("Create your free account.");
     expect(html).toContain("ada@example.com");
     expect(html).toContain(`>${USER_CODE}</div>`);
 
     const row = await readCode();
-    expect(row?.account_id?.startsWith(ACCOUNT_ID_PREFIX)).toBe(true);
+    expect(row?.account_id).toBeNull();
+    expect(await accountCount()).toBe(0);
     // The identity is proven and the code is not approved. #57 polls the second.
     expect(row?.approved_at).toBeNull();
     // The token that can approve it exists only here and in the page above.
@@ -574,7 +585,10 @@ describe("GET /approve/callback/{provider}", () => {
 
     const [first, second] = await Promise.all([
       callback({ state, oauth: oauthAnswering("ada@example.com", "sub-ada") }),
-      callback({ state, oauth: oauthAnswering("mallory@example.com", "sub-mallory") }),
+      callback({
+        state,
+        oauth: oauthAnswering("mallory@example.com", "sub-mallory"),
+      }),
     ]);
 
     const statuses = [first.status, second.status].sort();
@@ -584,8 +598,13 @@ describe("GET /approve/callback/{provider}", () => {
     expect(confirmToken(await won.text())).toBe(row?.confirm_token);
   });
 
-  it("creates the account for the address the provider verified", async () => {
-    await callback();
+  it("creates the account for the verified address only after Terms and approval", async () => {
+    const html = await (await callback()).text();
+    expect(await accountCount()).toBe(0);
+    await post("/approve/confirm", {
+      terms: "yes",
+      confirm_token: confirmToken(html),
+    });
 
     const account = await env.DB.prepare("SELECT email FROM accounts WHERE id = ?")
       .bind((await readCode())?.account_id)
@@ -639,7 +658,10 @@ describe("GET /approve/callback/{provider}", () => {
 
   it("says nothing was approved when the user cancelled at the provider", async () => {
     const oauth = oauthAnswering("ada@example.com");
-    const response = await callback({ query: { code: "", error: "access_denied" }, oauth });
+    const response = await callback({
+      query: { code: "", error: "access_denied" },
+      oauth,
+    });
 
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("Nothing was approved.");
@@ -676,7 +698,14 @@ describe("POST /approve/confirm", () => {
     await callback();
 
     expect((await post("/approve/confirm", {})).status).toBe(400);
-    expect((await post("/approve/confirm", { confirm_token: "guessed" })).status).toBe(400);
+    expect(
+      (
+        await post("/approve/confirm", {
+          terms: "yes",
+          confirm_token: "guessed",
+        })
+      ).status,
+    ).toBe(400);
     expect((await readCode())?.approved_at).toBeNull();
   });
 
@@ -694,7 +723,9 @@ describe("POST /approve/confirm", () => {
     await callback({ state });
 
     // The initiator has the state and nothing else.
-    expect((await post("/approve/confirm", { confirm_token: state })).status).toBe(400);
+    expect((await post("/approve/confirm", { terms: "yes", confirm_token: state })).status).toBe(
+      400,
+    );
     expect((await post("/approve/confirm", { state })).status).toBe(400);
     expect((await readCode())?.approved_at).toBeNull();
   });
@@ -702,7 +733,10 @@ describe("POST /approve/confirm", () => {
   it("refuses a press for a handshake whose identity was never proved", async () => {
     await begin();
 
-    const response = await post("/approve/confirm", { confirm_token: await startedState() });
+    const response = await post("/approve/confirm", {
+      terms: "yes",
+      confirm_token: await startedState(),
+    });
 
     expect(response.status).toBe(400);
     expect((await readCode())?.approved_at).toBeNull();
@@ -712,10 +746,14 @@ describe("POST /approve/confirm", () => {
     await begin();
     const token = confirmToken(await (await callback()).text());
 
-    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(200);
+    expect((await post("/approve/confirm", { terms: "yes", confirm_token: token })).status).toBe(
+      200,
+    );
     const approvedAt = (await readCode())?.approved_at;
 
-    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(400);
+    expect((await post("/approve/confirm", { terms: "yes", confirm_token: token })).status).toBe(
+      400,
+    );
     expect((await readCode())?.approved_at).toBe(approvedAt);
   });
 
@@ -724,7 +762,14 @@ describe("POST /approve/confirm", () => {
     const confirmation = confirmToken(await (await callback()).text());
 
     expect((await begin("github")).status).toBe(404);
-    expect((await post("/approve/confirm", { confirm_token: confirmation })).status).toBe(200);
+    expect(
+      (
+        await post("/approve/confirm", {
+          terms: "yes",
+          confirm_token: confirmation,
+        })
+      ).status,
+    ).toBe(200);
     expect((await readCode())?.approved_at).toBeGreaterThanOrEqual(NOW);
   });
 
@@ -735,7 +780,9 @@ describe("POST /approve/confirm", () => {
       .bind(NOW - 1, USER_CODE)
       .run();
 
-    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(400);
+    expect((await post("/approve/confirm", { terms: "yes", confirm_token: token })).status).toBe(
+      400,
+    );
     expect((await readCode())?.approved_at).toBeNull();
   });
 });
@@ -790,7 +837,14 @@ describe("approving more than once", () => {
     await approve();
     const owner = (await readCode())?.account_id;
 
-    expect((await post("/approve/start/google", { user_code: USER_CODE, terms: "yes" })).status).toBe(404);
+    expect(
+      (
+        await post("/approve/start/google", {
+          user_code: USER_CODE,
+          terms: "yes",
+        })
+      ).status,
+    ).toBe(404);
     expect((await send(`/approve?user_code=${USER_CODE}`)).status).toBe(404);
     expect((await readCode())?.account_id).toBe(owner);
   });
@@ -813,10 +867,14 @@ describe("the approval surface inside the router", () => {
   });
 
   it("has no approval page on the serving host", async () => {
-    const response = await send(`/approve?user_code=${USER_CODE}`, {}, {
-      SERVING_HOST: "openartifacts.workers.dev",
-      API_HOST: "api.openartifacts.ai",
-    });
+    const response = await send(
+      `/approve?user_code=${USER_CODE}`,
+      {},
+      {
+        SERVING_HOST: "openartifacts.workers.dev",
+        API_HOST: "api.openartifacts.ai",
+      },
+    );
 
     expect(response.status).toBe(404);
     expect(await response.text()).toContain("This document isn’t available.");
@@ -915,7 +973,10 @@ describe("the serving origin", () => {
    * the promise stays an absolute rather than a per-host argument.
    */
   it("sets no cookie on any response it gives a reader", async () => {
-    const serving = { SERVING_HOST: "openartifacts.workers.dev", API_HOST: "api.openartifacts.ai" };
+    const serving = {
+      SERVING_HOST: "openartifacts.workers.dev",
+      API_HOST: "api.openartifacts.ai",
+    };
     const paths = [
       `/d/${DOC_ID}`,
       `/d/${DOC_ID}/v1`,
@@ -938,23 +999,31 @@ describe("the serving origin", () => {
   it("sets no cookie on a deleted doc or on the legacy host's redirect", async () => {
     await env.DB.prepare("UPDATE docs SET deleted_at = ? WHERE id = ?").bind(NOW, DOC_ID).run();
 
-    const gone = await send(`/d/${DOC_ID}`, {}, {
-      SERVING_HOST: "openartifacts.workers.dev",
-      API_HOST: "api.openartifacts.ai",
-    });
+    const gone = await send(
+      `/d/${DOC_ID}`,
+      {},
+      {
+        SERVING_HOST: "openartifacts.workers.dev",
+        API_HOST: "api.openartifacts.ai",
+      },
+    );
     expect(gone.status).toBe(410);
     expect(gone.headers.has("set-cookie")).toBe(false);
 
-    const redirected = await send(`/d/${DOC_ID}`, {}, {
-      SERVING_HOST: "openartifacts.site",
-      LEGACY_SERVING_HOST: "openartifacts.workers.dev",
-    });
+    const redirected = await send(
+      `/d/${DOC_ID}`,
+      {},
+      {
+        SERVING_HOST: "openartifacts.site",
+        LEGACY_SERVING_HOST: "openartifacts.workers.dev",
+      },
+    );
     expect(redirected.status).toBe(307);
     expect(redirected.headers.has("set-cookie")).toBe(false);
   });
 });
 
-describe("signup newsletter choice", () => {
+describe("new-account signup", () => {
   async function preference() {
     return env.DB.prepare(
       "SELECT newsletter_opt_in, newsletter_choice_at FROM accounts WHERE email = ?",
@@ -965,38 +1034,51 @@ describe("signup newsletter choice", () => {
         newsletter_choice_at: number | null;
       }>();
   }
-  async function startChoice(checked: boolean) {
-    await post("/approve/start/google", {
-      user_code: USER_CODE,
-      terms: "yes",
-      ...(checked ? { newsletter: "yes" } : {}),
-    });
-    return confirmToken(await (await callback()).text());
+  async function newSignup() {
+    await begin();
+    return await (await callback()).text();
   }
-  it("shows the free account disclosure, terms and optional checked newsletter field", async () => {
+  it("starts with enabled providers and no account agreements", async () => {
     const html = await (await send(`/approve?user_code=${USER_CODE}`)).text();
-    expect(html).toContain("Create your free account.");
-    expect(html).toContain('href="https://openartifacts.ai/terms"');
+    expect(html).toContain("Sign in to OpenArtifacts.");
+    expect(html).not.toContain('name="terms"');
+    expect(html).not.toContain('name="newsletter"');
+    expect(html).not.toContain(" disabled>");
+  });
+  it("asks a new user for unchecked Terms and optional checked newsletter after OAuth", async () => {
+    const html = await newSignup();
     expect(html).toContain('name="terms" value="yes" required');
     expect(html).not.toContain('name="terms" value="yes" checked');
-    expect(html).toContain('formaction="/approve/start/google" disabled');
-    expect(html).toContain('formaction="/approve/start/github" disabled');
     expect(html).toContain('name="newsletter" value="yes" checked');
-    expect(html).toContain('formaction="/approve/start/github"');
-    expect(html).not.toContain('name="newsletter" value="yes" checked required');
+    expect(html).toContain("disabled>Create account and approve device");
+    expect(await accountCount()).toBe(0);
   });
-  it.each([true, false])(
-    "records checked=%s only on confirmation and preserves it on later sign-ins",
-    async (checked) => {
-      const token = await startChoice(checked);
-      expect(await preference()).toEqual({
-        newsletter_opt_in: null,
-        newsletter_choice_at: null,
-      });
+  it.each([undefined, "no"])(
+    "cannot create an account without explicit Terms (%s)",
+    async (terms) => {
+      const token = confirmToken(await newSignup());
       expect(
         (
           await post("/approve/confirm", {
             confirm_token: token,
+            ...(terms ? { terms } : {}),
+          })
+        ).status,
+      ).toBe(400);
+      expect(await accountCount()).toBe(0);
+      expect((await readCode())?.approved_at).toBeNull();
+    },
+  );
+  it.each([true, false])(
+    "records newsletter=%s only when creating the account",
+    async (checked) => {
+      const token = confirmToken(await newSignup());
+      expect(await preference()).toBeNull();
+      expect(
+        (
+          await post("/approve/confirm", {
+            confirm_token: token,
+            terms: "yes",
             ...(checked ? { newsletter: "yes" } : {}),
           })
         ).status,
@@ -1004,54 +1086,117 @@ describe("signup newsletter choice", () => {
       const saved = await preference();
       expect(saved?.newsletter_opt_in).toBe(checked ? 1 : 0);
       expect(saved?.newsletter_choice_at).toBeTypeOf("number");
-      expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(400);
+      expect((await post("/approve/confirm", { confirm_token: token, terms: "yes" })).status).toBe(
+        400,
+      );
       await seedCode();
-      const next = await startChoice(!checked);
-      expect((await post("/approve/confirm", { confirm_token: next })).status).toBe(200);
+      const html = await newSignup();
+      expect(html).not.toContain('name="terms"');
+      expect(html).not.toContain('name="newsletter"');
+      expect(
+        (
+          await post("/approve/confirm", {
+            confirm_token: confirmToken(html),
+            newsletter: checked ? "no" : "yes",
+          })
+        ).status,
+      ).toBe(200);
       expect(await preference()).toEqual(saved);
     },
   );
-  it("does not record a choice for a denied or expired confirmation", async () => {
-    let token = await startChoice(true);
-    expect((await post("/approve/deny", { confirm_token: token })).status).toBe(200);
-    expect(await preference()).toEqual({
-      newsletter_opt_in: null,
-      newsletter_choice_at: null,
-    });
+  it("skips agreements for an existing account even without a newsletter preference", async () => {
+    await approve("google", USER_CODE, "ada@example.com", "sub-ada@example.com");
+    await env.DB.prepare(
+      "UPDATE accounts SET newsletter_opt_in = NULL, newsletter_choice_at = NULL",
+    ).run();
     await seedCode();
-    token = await startChoice(true);
-    await env.DB.prepare("UPDATE device_codes SET expires_at = 0").run();
-    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(400);
+    const html = await newSignup();
+    expect(html).not.toContain('name="terms"');
+    expect(html).not.toContain('name="newsletter"');
+    expect(
+      (
+        await post("/approve/confirm", {
+          confirm_token: confirmToken(html),
+          newsletter: "yes",
+        })
+      ).status,
+    ).toBe(200);
     expect(await preference()).toEqual({
       newsletter_opt_in: null,
       newsletter_choice_at: null,
     });
   });
-  it("rolls the preference back when the approval write fails", async () => {
-    const token = await startChoice(true);
+  it.each(["deny", "expire"])("creates nothing after %s", async (outcome) => {
+    const token = confirmToken(await newSignup());
+    if (outcome === "deny") await post("/approve/deny", { confirm_token: token });
+    else await env.DB.prepare("UPDATE device_codes SET expires_at = 0").run();
+    expect(
+      (
+        await post("/approve/confirm", {
+          confirm_token: token,
+          terms: "yes",
+          newsletter: "yes",
+        })
+      ).status,
+    ).toBe(400);
+    expect(await accountCount()).toBe(0);
+  });
+  it("rolls back account creation if approval fails", async () => {
+    const token = confirmToken(await newSignup());
     await env.DB.prepare(
       "CREATE TRIGGER fail_approval BEFORE UPDATE OF approved_at ON device_codes BEGIN SELECT RAISE(ABORT, 'test failure'); END",
     ).run();
-    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(500);
-    expect(await preference()).toEqual({
-      newsletter_opt_in: null,
-      newsletter_choice_at: null,
-    });
+    expect(
+      (
+        await post("/approve/confirm", {
+          confirm_token: token,
+          terms: "yes",
+          newsletter: "yes",
+        })
+      ).status,
+    ).toBe(500);
+    expect(await accountCount()).toBe(0);
     expect((await readCode())?.approved_at).toBeNull();
   });
-});
-
-it("lets the proven browser opt out of the handshake newsletter choice", async () => {
-  await post("/approve/start/google", {
-    user_code: USER_CODE,
-    terms: "yes",
-    newsletter: "yes",
-  });
-  const html = await (await callback()).text();
-  expect(html).toContain('name="newsletter" value="yes" checked');
-  await post("/approve/confirm", { confirm_token: confirmToken(html) });
-  const row = await env.DB.prepare("SELECT newsletter_opt_in FROM accounts").first<{
-    newsletter_opt_in: number;
-  }>();
-  expect(row?.newsletter_opt_in).toBe(0);
+  it.each([true, false])(
+    "safely resolves overlapping new signups with sameSubject=%s",
+    async (sameSubject) => {
+      await seedCode("SECOND-CODE");
+      await begin("google", USER_CODE);
+      const first = confirmToken(
+        await (
+          await callback({
+            oauth: oauthAnswering("ada@example.com", "subject-first"),
+          })
+        ).text(),
+      );
+      await begin("google", "SECOND-CODE");
+      const second = confirmToken(
+        await (
+          await callback({
+            state: await startedState("SECOND-CODE"),
+            oauth: oauthAnswering(
+              sameSubject ? "other@example.com" : "ada@example.com",
+              sameSubject ? "subject-first" : "subject-second",
+            ),
+          })
+        ).text(),
+      );
+      const results = await Promise.all([
+        post("/approve/confirm", {
+          confirm_token: first,
+          terms: "yes",
+          newsletter: "yes",
+        }),
+        post("/approve/confirm", { confirm_token: second, terms: "yes" }),
+      ]);
+      expect(results.map((r) => r.status).sort()).toEqual(sameSubject ? [200, 200] : [200, 400]);
+      expect(await accountCount()).toBe(1);
+      const ids = [
+        (await readCode())?.account_id,
+        (await readCode("SECOND-CODE"))?.account_id,
+      ].filter(Boolean);
+      expect(new Set(ids).size).toBe(1);
+    },
+  );
 });

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -220,8 +220,8 @@ describe("GET /approve", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(html).toContain("Continue with Google");
-    expect(html).toContain("Continue with GitHub");
+    expect(html).toContain("Sign in with Google");
+    expect(html).toContain("Sign in with GitHub");
     expect(html).toContain(`>${USER_CODE}</div>`);
     expect(response.headers.has("set-cookie")).toBe(false);
   });
@@ -235,7 +235,7 @@ describe("GET /approve", () => {
   it("starts a handshake from a form, never from a link", async () => {
     const html = await (await send(`/approve?user_code=${USER_CODE}`)).text();
 
-    expect(html).toContain('<form method="post" action="/approve/start/google">');
+    expect(html).toContain('<form class="signup" method="post" action="/approve/start/google">');
     expect(html).toContain(`name="user_code" value="${USER_CODE}"`);
     expect(html).not.toContain('href="/approve/start');
     expect((await send(`/approve/start/google?user_code=${USER_CODE}`)).status).toBe(404);
@@ -246,8 +246,8 @@ describe("GET /approve", () => {
       await send(`/approve?user_code=${USER_CODE}`, {}, { OAUTH_GITHUB_CLIENT_SECRET: "" })
     ).text();
 
-    expect(html).toContain("Continue with Google");
-    expect(html).not.toContain("Continue with GitHub");
+    expect(html).toContain("Sign in with Google");
+    expect(html).not.toContain("Sign in with GitHub");
   });
 
   it("accepts the code in the case the terminal printed it or the user typed it", async () => {
@@ -284,7 +284,7 @@ describe("GET /approve", () => {
     const response = await send(`/approve?user_code=${USER_CODE.toLowerCase()}`);
 
     expect(response.status).toBe(200);
-    expect(await response.text()).toContain("Continue with Google");
+    expect(await response.text()).toContain("Sign in with Google");
   });
 
   it("asks again rather than dead-ending when the code is malformed", async () => {
@@ -367,7 +367,7 @@ describe("guessing a user code", () => {
 
     const other = await lookupFrom("198.51.100.8");
     expect(other.status).toBe(200);
-    expect(await other.text()).toContain("Continue with Google");
+    expect(await other.text()).toContain("Sign in with Google");
   });
 
   it("counts starting a handshake too, since that also says whether a code is live", async () => {
@@ -415,7 +415,7 @@ describe("a lookup a page made rather than a person", () => {
     // was never charged on their behalf.
     const mine = await lookupFrom(address);
     expect(mine.status).toBe(200);
-    expect(await mine.text()).toContain("Continue with Google");
+    expect(await mine.text()).toContain("Sign in with Google");
   });
 
   it("lets a person opening the link through, and counts that", async () => {
@@ -933,4 +933,100 @@ describe("the serving origin", () => {
     expect(redirected.status).toBe(307);
     expect(redirected.headers.has("set-cookie")).toBe(false);
   });
+});
+
+describe("signup newsletter choice", () => {
+  async function preference() {
+    return env.DB.prepare(
+      "SELECT newsletter_opt_in, newsletter_choice_at FROM accounts WHERE email = ?",
+    )
+      .bind("ada@example.com")
+      .first<{
+        newsletter_opt_in: number | null;
+        newsletter_choice_at: number | null;
+      }>();
+  }
+  async function startChoice(checked: boolean) {
+    await post("/approve/start/google", {
+      user_code: USER_CODE,
+      ...(checked ? { newsletter: "yes" } : {}),
+    });
+    return confirmToken(await (await callback()).text());
+  }
+  it("shows the free account disclosure, terms and optional checked newsletter field", async () => {
+    const html = await (await send(`/approve?user_code=${USER_CODE}`)).text();
+    expect(html).toContain("Create your free account.");
+    expect(html).toContain('href="https://openartifacts.ai/terms"');
+    expect(html).toContain('name="newsletter" value="yes" checked');
+    expect(html).toContain('formaction="/approve/start/github"');
+    expect(html).not.toContain('name="newsletter" value="yes" checked required');
+  });
+  it.each([true, false])(
+    "records checked=%s only on confirmation and preserves it on later sign-ins",
+    async (checked) => {
+      const token = await startChoice(checked);
+      expect(await preference()).toEqual({
+        newsletter_opt_in: null,
+        newsletter_choice_at: null,
+      });
+      expect(
+        (
+          await post("/approve/confirm", {
+            confirm_token: token,
+            ...(checked ? { newsletter: "yes" } : {}),
+          })
+        ).status,
+      ).toBe(200);
+      const saved = await preference();
+      expect(saved?.newsletter_opt_in).toBe(checked ? 1 : 0);
+      expect(saved?.newsletter_choice_at).toBeTypeOf("number");
+      expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(400);
+      await seedCode();
+      const next = await startChoice(!checked);
+      expect((await post("/approve/confirm", { confirm_token: next })).status).toBe(200);
+      expect(await preference()).toEqual(saved);
+    },
+  );
+  it("does not record a choice for a denied or expired confirmation", async () => {
+    let token = await startChoice(true);
+    expect((await post("/approve/deny", { confirm_token: token })).status).toBe(200);
+    expect(await preference()).toEqual({
+      newsletter_opt_in: null,
+      newsletter_choice_at: null,
+    });
+    await seedCode();
+    token = await startChoice(true);
+    await env.DB.prepare("UPDATE device_codes SET expires_at = 0").run();
+    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(400);
+    expect(await preference()).toEqual({
+      newsletter_opt_in: null,
+      newsletter_choice_at: null,
+    });
+  });
+  it("rolls the preference back when the approval write fails", async () => {
+    const token = await startChoice(true);
+    await env.DB.prepare(
+      "CREATE TRIGGER fail_approval BEFORE UPDATE OF approved_at ON device_codes BEGIN SELECT RAISE(ABORT, 'test failure'); END",
+    ).run();
+    expect((await post("/approve/confirm", { confirm_token: token })).status).toBe(500);
+    expect(await preference()).toEqual({
+      newsletter_opt_in: null,
+      newsletter_choice_at: null,
+    });
+    expect((await readCode())?.approved_at).toBeNull();
+  });
+});
+
+it("lets the proven browser opt out of the handshake newsletter choice", async () => {
+  await post("/approve/start/google", {
+    user_code: USER_CODE,
+    newsletter: "yes",
+  });
+  const html = await (await callback()).text();
+  expect(html).toContain('name="newsletter" value="yes" checked');
+  await post("/approve/confirm", { confirm_token: confirmToken(html) });
+  const row = await env.DB.prepare("SELECT newsletter_opt_in FROM accounts").first<{
+    newsletter_opt_in: number;
+  }>();
+  expect(row?.newsletter_opt_in).toBe(0);
 });

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -133,7 +133,7 @@ async function startedState(userCode = USER_CODE): Promise<string> {
 
 /** Start a handshake the way the chooser's button does. */
 function begin(provider: ProviderId = "google", userCode = USER_CODE): Promise<Response> {
-  return post(`/approve/start/${provider}`, { user_code: userCode });
+  return post(`/approve/start/${provider}`, { user_code: userCode, terms: "yes" });
 }
 
 /**
@@ -379,7 +379,7 @@ describe("guessing a user code", () => {
       {
         method: "POST",
         headers: { "cf-connecting-ip": address },
-        body: new URLSearchParams({ user_code: USER_CODE }),
+        body: new URLSearchParams({ user_code: USER_CODE, terms: "yes" }),
       },
       { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
     );
@@ -447,7 +447,7 @@ describe("a lookup a page made rather than a person", () => {
       {
         method: "POST",
         headers: { "cf-connecting-ip": "198.51.100.23", "sec-fetch-dest": "iframe" },
-        body: new URLSearchParams({ user_code: USER_CODE }),
+        body: new URLSearchParams({ user_code: USER_CODE, terms: "yes" }),
       },
       { APPROVAL_LOOKUP_LIMITER: env.APPROVAL_LOOKUP_LIMITER },
     );
@@ -458,6 +458,19 @@ describe("a lookup a page made rather than a person", () => {
 });
 
 describe("POST /approve/start/{provider}", () => {
+  it.each([undefined, "no"])(
+    "requires explicit terms agreement before starting a handshake (%s)",
+    async (terms) => {
+      const response = await post("/approve/start/google", {
+        user_code: USER_CODE,
+        ...(terms ? { terms } : {}),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("Agree to the Terms before signing in.");
+      expect((await readCode())?.state).toBeNull();
+      expect(await accountCount()).toBe(0);
+    },
+  );
   it("sends the browser to Google with PKCE and records the handshake on the code", async () => {
     const response = await begin("google");
 
@@ -500,10 +513,14 @@ describe("POST /approve/start/{provider}", () => {
   });
 
   it("has no route for a provider this deployment cannot use", async () => {
-    expect((await post("/approve/start/gitlab", { user_code: USER_CODE })).status).toBe(404);
+    expect((await post("/approve/start/gitlab", { user_code: USER_CODE, terms: "yes" })).status).toBe(404);
     expect(
       (
-        await post("/approve/start/github", { user_code: USER_CODE }, { OAUTH_GITHUB_CLIENT_ID: "" })
+        await post(
+          "/approve/start/github",
+          { user_code: USER_CODE, terms: "yes" },
+          { OAUTH_GITHUB_CLIENT_ID: "" },
+        )
       ).status,
     ).toBe(404);
   });
@@ -512,7 +529,9 @@ describe("POST /approve/start/{provider}", () => {
     expect((await post("/approve/start/google", {})).status).toBe(400);
 
     await seedCode("EXPIRED-2", NOW - 1);
-    expect((await post("/approve/start/google", { user_code: "EXPIRED-2" })).status).toBe(404);
+    expect(
+      (await post("/approve/start/google", { user_code: "EXPIRED-2", terms: "yes" })).status,
+    ).toBe(404);
   });
 });
 
@@ -771,7 +790,7 @@ describe("approving more than once", () => {
     await approve();
     const owner = (await readCode())?.account_id;
 
-    expect((await post("/approve/start/google", { user_code: USER_CODE })).status).toBe(404);
+    expect((await post("/approve/start/google", { user_code: USER_CODE, terms: "yes" })).status).toBe(404);
     expect((await send(`/approve?user_code=${USER_CODE}`)).status).toBe(404);
     expect((await readCode())?.account_id).toBe(owner);
   });
@@ -823,7 +842,7 @@ describe("the approval surface inside the router", () => {
     const response = await send("/approve/start/google", {
       method: "POST",
       headers: { "content-type": "multipart/form-data; boundary=x" },
-      body: new URLSearchParams({ user_code: USER_CODE }),
+      body: new URLSearchParams({ user_code: USER_CODE, terms: "yes" }),
     });
 
     expect(response.status).toBe(404);
@@ -949,6 +968,7 @@ describe("signup newsletter choice", () => {
   async function startChoice(checked: boolean) {
     await post("/approve/start/google", {
       user_code: USER_CODE,
+      terms: "yes",
       ...(checked ? { newsletter: "yes" } : {}),
     });
     return confirmToken(await (await callback()).text());
@@ -957,6 +977,10 @@ describe("signup newsletter choice", () => {
     const html = await (await send(`/approve?user_code=${USER_CODE}`)).text();
     expect(html).toContain("Create your free account.");
     expect(html).toContain('href="https://openartifacts.ai/terms"');
+    expect(html).toContain('name="terms" value="yes" required');
+    expect(html).not.toContain('name="terms" value="yes" checked');
+    expect(html).toContain('formaction="/approve/start/google" disabled');
+    expect(html).toContain('formaction="/approve/start/github" disabled');
     expect(html).toContain('name="newsletter" value="yes" checked');
     expect(html).toContain('formaction="/approve/start/github"');
     expect(html).not.toContain('name="newsletter" value="yes" checked required');
@@ -1020,6 +1044,7 @@ describe("signup newsletter choice", () => {
 it("lets the proven browser opt out of the handshake newsletter choice", async () => {
   await post("/approve/start/google", {
     user_code: USER_CODE,
+    terms: "yes",
     newsletter: "yes",
   });
   const html = await (await callback()).text();

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,3 +1,4 @@
+import { env as testEnv } from "cloudflare:test";
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -9,7 +10,7 @@ import {
   resolvePublisher,
 } from "../src/auth.js";
 import { LICENSE_CACHE_TTL_MS, type Env } from "../src/config.js";
-import type { PublisherRow, PublisherStore } from "../src/db.js";
+import { d1PublisherStore, type PublisherRow, type PublisherStore } from "../src/db.js";
 import { DOC_ID_LENGTH } from "../src/ids.js";
 import worker from "../src/index.js";
 
@@ -49,11 +50,14 @@ function memoryStore(...seed: PublisherRow[]): MemoryStore {
     async read(keyHash) {
       return rows.get(keyHash) ?? null;
     },
-    async remove(keyHash) {
-      rows.delete(keyHash);
+    async reject(keyHash, at) {
+      rows.set(keyHash, { ...(rows.get(keyHash) ?? { key_hash: keyHash, plan: "", owner: "", validated_at: 0 }), rejected_at: at });
     },
     async save(row) {
-      rows.set(row.key_hash, { ...row });
+      const rejected = rows.get(row.key_hash)?.rejected_at;
+      if (rejected != null && row.validated_at <= rejected) return false;
+      rows.set(row.key_hash, { ...row, ...(rejected == null ? {} : { rejected_at: rejected }) });
+      return true;
     },
   };
 }
@@ -346,8 +350,8 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    // An unauthorized key never acquires a cached validation.
-    expect(store.rows.size).toBe(0);
+    // Rejection ordering is retained, but cannot authorize any request.
+    expect(store.rows.get(KEY_HASH)?.rejected_at).toBe(NOW);
   };
 
   // How the real server reports a key it has no row for, or one flagged deleted:
@@ -378,7 +382,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    expect(store.rows.has(KEY_HASH)).toBe(false);
+    expect(store.rows.get(KEY_HASH)?.rejected_at).toBe(NOW);
   });
 
   it("locks out a revoked key that still has a cached validation", async () => {
@@ -414,7 +418,7 @@ describe("rejected credentials cannot use outage fallback", () => {
       })).toMatchObject({ ok: false, reason: "license_unavailable" });
 
       expect(await resolvePublisher(KEY, env(), {
-        store, now, fetch: licenseServer(validBeliever).fetch,
+        store, now: () => NOW + 1, fetch: licenseServer(validBeliever).fetch,
       })).toEqual({ ok: true, publisher: { owner: ACCOUNT, plan: "believer" } });
       expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
     });
@@ -435,6 +439,65 @@ describe("rejected credentials cannot use outage fallback", () => {
     })).toMatchObject({ ok: false, reason: "invalid_license" });
     finish(new Response("down", { status: 503 }));
     expect(await outage).toMatchObject({ ok: false, reason: "license_unavailable" });
+  });
+});
+
+describe("license rejection ordering in D1", () => {
+  for (const cold of [false, true]) {
+    it(`blocks an older successful response after rejection (${cold ? "cold" : "cached"} key)`, async () => {
+      const store = d1PublisherStore(testEnv.DB);
+      if (!cold) await store.save(validatedAt(LICENSE_CACHE_TTL_MS));
+      let started!: () => void;
+      const pending = new Promise<void>((resolve) => { started = resolve; });
+      let finish!: (response: Response) => void;
+      const response = new Promise<Response>((resolve) => { finish = resolve; });
+      const older = resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+        now, fetch: licenseServer(() => { started(); return response; }).fetch,
+      });
+      await pending;
+      expect(await resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+        now: () => NOW + 1, fetch: licenseServer(trpcError("NOT_FOUND", 404)).fetch,
+      })).toMatchObject({ ok: false, reason: "invalid_license" });
+      finish(validBeliever());
+      expect(await older).toMatchObject({ ok: false, reason: "invalid_license" });
+      expect((await store.read(KEY_HASH))?.rejected_at).toBe(NOW + 1);
+      expect(await resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+        now: () => NOW + 2, fetch: licenseServer(() => new Response("down", { status: 503 })).fetch,
+      })).toMatchObject({ ok: false, reason: "license_unavailable" });
+      expect(await resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+        now: () => NOW + 3, fetch: licenseServer(validBeliever).fetch,
+      })).toMatchObject({ ok: true, publisher: { owner: ACCOUNT } });
+    });
+  }
+
+  it("retains rejection ordering after a fresh recovery and rejects same-millisecond checks", async () => {
+    const store = d1PublisherStore(testEnv.DB);
+    await store.reject(KEY_HASH, NOW);
+    expect(await store.save({ ...validatedAt(0), validated_at: NOW })).toBe(false);
+    expect(await store.save({ ...validatedAt(0), validated_at: NOW + 1 })).toBe(true);
+    expect(await store.save({ ...validatedAt(0), validated_at: NOW - 1 })).toBe(false);
+    expect(await resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+      now: () => NOW + 2, fetch: licenseServer(() => { throw new Error("must use recovered cache"); }).fetch,
+    })).toMatchObject({ ok: true, publisher: { owner: ACCOUNT } });
+  });
+
+  it("lets an explicit late denial revoke a success that completed first", async () => {
+    let started!: () => void;
+    const pending = new Promise<void>((resolve) => { started = resolve; });
+    let finish!: (response: Response) => void;
+    const response = new Promise<Response>((resolve) => { finish = resolve; });
+    const denial = resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+      now, fetch: licenseServer(() => { started(); return response; }).fetch,
+    });
+    await pending;
+    expect(await resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+      now, fetch: licenseServer(validBeliever).fetch,
+    })).toMatchObject({ ok: true });
+    finish(trpcError("NOT_FOUND", 404)());
+    expect(await denial).toMatchObject({ ok: false, reason: "invalid_license" });
+    expect(await resolvePublisher(KEY, env({ DB: testEnv.DB }), {
+      now, fetch: licenseServer(() => new Response("down", { status: 503 })).fetch,
+    })).toMatchObject({ ok: false, reason: "license_unavailable" });
   });
 });
 
@@ -669,7 +732,7 @@ describe("authenticateRequest", () => {
     const store = {
       read: () => Promise.reject(new Error("must not be read")),
       save: () => Promise.reject(new Error("must not be written")),
-      remove: () => Promise.reject(new Error("must not be removed")),
+      reject: () => Promise.reject(new Error("must not be rejected")),
     } satisfies PublisherStore;
 
     for (const header of [undefined, "", "Basic hunter2", "Bearer", `Token ${KEY}`]) {
@@ -702,9 +765,10 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
         return rows.get(String(args[0])) ?? null;
       },
       async run() {
-        if (/^\s*DELETE FROM publishers/i.test(sql)) {
-          rows.delete(String(args[0]));
-          return { success: true };
+        if (sql.includes("MAX(COALESCE")) {
+          const id = String(args[0]);
+          rows.set(id, { ...(rows.get(id) ?? { key_hash: id, plan: "", owner: "", validated_at: 0 }), rejected_at: Number(args[1]) });
+          return { success: true, meta: { changes: 1 } };
         }
         if (!/^\s*INSERT/i.test(sql)) throw new Error(`run() on non-insert: ${sql}`);
         rows.set(String(args[0]), {
@@ -713,7 +777,7 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
           validated_at: Number(args[2]),
           owner: String(args[3]),
         });
-        return { success: true };
+        return { success: true, meta: { changes: 1 } };
       },
       // Reached only once a request is past the gate: `GET /api/v1/docs` is the
       // first handler on the other side of it, and all it wants to know is that

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -49,6 +49,9 @@ function memoryStore(...seed: PublisherRow[]): MemoryStore {
     async read(keyHash) {
       return rows.get(keyHash) ?? null;
     },
+    async remove(keyHash) {
+      rows.delete(keyHash);
+    },
     async save(row) {
       rows.set(row.key_hash, { ...row });
     },
@@ -343,8 +346,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    // Nothing is written, so an unauthorized key never gets a publishers row a
-    // later doc insert records as its owner.
+    // An unauthorized key never acquires a cached validation.
     expect(store.rows.size).toBe(0);
   };
 
@@ -365,7 +367,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     denied(answers({ isValid: false, backendAccess: true })),
   );
 
-  it("leaves an existing row untouched when the key has since lapsed", async () => {
+  it("forgets a cached validation when the key has since lapsed", async () => {
     const stale = validatedAt(2 * 60 * 60 * 1000);
     const store = memoryStore(stale);
 
@@ -376,9 +378,7 @@ describe("resolvePublisher — a key the license server rejects", () => {
     });
 
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
-    // The row stays: it is the only record of which account owns the docs.
-    // It simply stops resolving.
-    expect(store.rows.get(KEY_HASH)).toEqual(stale);
+    expect(store.rows.has(KEY_HASH)).toBe(false);
   });
 
   it("locks out a revoked key that still has a cached validation", async () => {
@@ -394,6 +394,47 @@ describe("resolvePublisher — a key the license server rejects", () => {
     // If it did, revocation would never take effect: each request would fail to
     // revalidate and be waved through on the stale row, forever.
     expect(result).toMatchObject({ ok: false, reason: "invalid_license" });
+  });
+});
+
+describe("rejected credentials cannot use outage fallback", () => {
+  for (const [label, reply] of [
+    ["NOT_FOUND", trpcError("NOT_FOUND", 404)],
+    ["invalid", answers({ isValid: false })],
+    ["no backend access", answers({ isValid: true, backendAccess: false })],
+  ] as const) {
+    it(`forgets ${label} until a fresh validation succeeds`, async () => {
+      const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
+      expect(await resolvePublisher(KEY, env(), {
+        store, now, fetch: licenseServer(reply).fetch,
+      })).toMatchObject({ ok: false, reason: "invalid_license" });
+
+      expect(await resolvePublisher(KEY, env(), {
+        store, now, fetch: licenseServer(() => Promise.reject(new Error("down"))).fetch,
+      })).toMatchObject({ ok: false, reason: "license_unavailable" });
+
+      expect(await resolvePublisher(KEY, env(), {
+        store, now, fetch: licenseServer(validBeliever).fetch,
+      })).toEqual({ ok: true, publisher: { owner: ACCOUNT, plan: "believer" } });
+      expect(store.rows.get(KEY_HASH)?.owner).toBe(ACCOUNT);
+    });
+  }
+
+  it("does not reuse an outage request's snapshot after another request rejects the key", async () => {
+    const store = memoryStore(validatedAt(LICENSE_CACHE_TTL_MS));
+    let started!: () => void;
+    const pending = new Promise<void>((resolve) => { started = resolve; });
+    let finish!: (response: Response) => void;
+    const response = new Promise<Response>((resolve) => { finish = resolve; });
+    const outage = resolvePublisher(KEY, env(), {
+      store, now, fetch: licenseServer(() => { started(); return response; }).fetch,
+    });
+    await pending;
+    expect(await resolvePublisher(KEY, env(), {
+      store, now, fetch: licenseServer(trpcError("NOT_FOUND", 404)).fetch,
+    })).toMatchObject({ ok: false, reason: "invalid_license" });
+    finish(new Response("down", { status: 503 }));
+    expect(await outage).toMatchObject({ ok: false, reason: "license_unavailable" });
   });
 });
 
@@ -628,6 +669,7 @@ describe("authenticateRequest", () => {
     const store = {
       read: () => Promise.reject(new Error("must not be read")),
       save: () => Promise.reject(new Error("must not be written")),
+      remove: () => Promise.reject(new Error("must not be removed")),
     } satisfies PublisherStore;
 
     for (const header of [undefined, "", "Basic hunter2", "Bearer", `Token ${KEY}`]) {
@@ -660,6 +702,10 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
         return rows.get(String(args[0])) ?? null;
       },
       async run() {
+        if (/^\s*DELETE FROM publishers/i.test(sql)) {
+          rows.delete(String(args[0]));
+          return { success: true };
+        }
         if (!/^\s*INSERT/i.test(sql)) throw new Error(`run() on non-insert: ${sql}`);
         rows.set(String(args[0]), {
           key_hash: String(args[0]),
@@ -673,7 +719,7 @@ function fakeD1(): D1Database & { rows: Map<string, PublisherRow> } {
       // first handler on the other side of it, and all it wants to know is that
       // this publisher holds no docs. Auth is what these tests are about.
       async all() {
-        if (!/^\s*SELECT/i.test(sql)) throw new Error(`all() on non-select: ${sql}`);
+        if (!/^\s*(SELECT|WITH)/i.test(sql)) throw new Error(`all() on non-select: ${sql}`);
         return { results: [] };
       },
     };

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -864,7 +864,9 @@ describe("the whole flow, from an empty terminal to a token", () => {
     expect(chooser.status).toBe(200);
     expect(await chooser.text()).toContain(minted.user_code);
 
-    expect((await form("/approve/start/google", { user_code: minted.user_code })).status).toBe(303);
+    expect(
+      (await form("/approve/start/google", { user_code: minted.user_code, terms: "yes" })).status,
+    ).toBe(303);
 
     const state = (
       await env.DB.prepare("SELECT state FROM device_codes WHERE user_code = ?")
@@ -907,7 +909,7 @@ describe("the whole flow, from an empty terminal to a token", () => {
 
   it("lets the person deny instead, which kills the code the terminal is waiting on", async () => {
     const minted = await mint({ label: "A terminal that is not mine" });
-    await form("/approve/start/google", { user_code: minted.user_code });
+    await form("/approve/start/google", { user_code: minted.user_code, terms: "yes" });
     const state = (
       await env.DB.prepare("SELECT state FROM device_codes WHERE user_code = ?")
         .bind(minted.user_code)

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -879,7 +879,8 @@ describe("the whole flow, from an empty terminal to a token", () => {
     // terminal waiting on this code is theirs. `bdi` keeps natural RTL labels
     // from changing the direction of the surrounding warning.
     expect(html).toContain("<b><bdi>Claude Code on loganmac</bdi></b>");
-    expect(html).toContain("Deny");
+    expect(html).toContain("If this is not your terminal, close this page.");
+    expect(html).not.toContain('value="deny"');
 
     const confirmToken = /name="confirm_token" value="([^"]+)"/.exec(html)?.[1] ?? "";
     expect((await form("/approve/confirm", { terms: "yes", confirm_token: confirmToken })).status).toBe(200);

--- a/test/device.test.ts
+++ b/test/device.test.ts
@@ -882,7 +882,7 @@ describe("the whole flow, from an empty terminal to a token", () => {
     expect(html).toContain("Deny");
 
     const confirmToken = /name="confirm_token" value="([^"]+)"/.exec(html)?.[1] ?? "";
-    expect((await form("/approve/confirm", { confirm_token: confirmToken })).status).toBe(200);
+    expect((await form("/approve/confirm", { terms: "yes", confirm_token: confirmToken })).status).toBe(200);
 
     const issued = await (await device("/device/token", { device_code: minted.device_code }))
       .json<Issued>();
@@ -920,7 +920,7 @@ describe("the whole flow, from an empty terminal to a token", () => {
     ).text();
     const confirmToken = /name="confirm_token" value="([^"]+)"/.exec(html)?.[1] ?? "";
 
-    const denied = await form("/approve/deny", { confirm_token: confirmToken });
+    const denied = await form("/approve/deny", { terms: "yes", confirm_token: confirmToken });
     expect(denied.status).toBe(200);
     expect(await denied.text()).toContain("Denied");
 
@@ -928,7 +928,7 @@ describe("the whole flow, from an empty terminal to a token", () => {
       "access_denied",
     );
     // The same press cannot then approve it: the confirm token is spent either way.
-    expect((await form("/approve/confirm", { confirm_token: confirmToken })).status).toBe(400);
+    expect((await form("/approve/confirm", { terms: "yes", confirm_token: confirmToken })).status).toBe(400);
     expect((await codeRow(minted.user_code))?.approved_at).toBeNull();
   });
 });

--- a/test/entitlement.test.ts
+++ b/test/entitlement.test.ts
@@ -1,0 +1,131 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, expect, it, vi } from "vitest";
+import { accountPlan } from "../src/entitlement.js";
+import { findOrCreateAccount } from "../src/db.js";
+import { linkExternalOwner } from "../src/owners.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newTokenId } from "../src/ids.js";
+import worker from "../src/index.js";
+const OWNER = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER = "oa_bbbbbbbbbbbbbbbbbbbbbbbbbb";
+const NOW = 10_000_000;
+const remote = () => ({ ...env, LICENSE_API_URL: "https://license.example.test", LICENSE_API_KEY: "service-only" });
+const answer = (plan: "default" | "plus", expiresAt: number | null) => Response.json({ result: { data: { json: { plan, expiresAt } } } });
+const stored = () => env.DB.prepare("SELECT plan, plan_expires_at AS expiresAt, plan_checked_at AS checkedAt FROM accounts WHERE id = ?").bind(OWNER).first();
+const seed = (plan: string, expiry: number | null, checked: number | null) => env.DB.prepare("UPDATE accounts SET plan = ?, plan_expires_at = ?, plan_checked_at = ? WHERE id = ?").bind(plan, expiry, checked, OWNER).run();
+let token: string;
+beforeEach(async () => {
+  await findOrCreateAccount(env.DB, OWNER, "owner@example.test", NOW);
+  token = newApiToken();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, ?)").bind(newTokenId(), await sha256Hex(token), OWNER, NOW).run();
+});
+async function request(method: string, path: string, body?: unknown, credential = token) {
+  const ctx = createExecutionContext();
+  const result = await worker.fetch(new Request(`https://local.test${path}`, {
+    method, headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), { ...remote(), ADMIN_API_KEY: "admin", SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "" }, ctx);
+  await waitOnExecutionContext(ctx); return result;
+}
+
+it("new free accounts publish without a remote request; stale cache pulls only Worker identity", async () => {
+  const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
+    expect(_url).toBe("https://license.example.test/api/trpc/license.openArtifactsEntitlement");
+    expect(init?.method).toBe("POST");
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer service-only");
+    expect(JSON.parse(init!.body as string)).toEqual({ json: { accountId: OWNER } });
+    return answer("plus", NOW + 9_000_000);
+  });
+  expect(await accountPlan(remote(), OWNER, { now: () => NOW, fetch: fetcher })).toEqual({ plan: "free", status: "cached" });
+  expect(fetcher).not.toHaveBeenCalled();
+  expect(await accountPlan(remote(), OWNER, { now: () => NOW + 3_600_000, fetch: fetcher })).toEqual({ plan: "pro", status: "refreshed" });
+  expect(fetcher).toHaveBeenCalledTimes(1);
+  expect(await stored()).toEqual({ plan: "pro", expiresAt: NOW + 9_000_000, checkedAt: NOW + 3_600_000 });
+});
+
+it("forced account refresh reports success/outage and management never calls remote", async () => {
+  const clock = vi.spyOn(Date, "now").mockReturnValue(NOW);
+  const fetcher = vi.spyOn(globalThis, "fetch").mockImplementation(async () => answer("plus", NOW + 1000));
+  try {
+    expect((await request("POST", "/api/v1/docs", { html: "<p>free</p>" })).status).toBe(201);
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(await (await request("GET", "/api/v1/account")).json()).toMatchObject({ plan: "pro", refresh: { status: "refreshed", expiresAt: NOW + 1000 } });
+    fetcher.mockRejectedValue(new Error("outage"));
+    expect(await (await request("GET", "/api/v1/account")).json()).toMatchObject({ plan: "pro", refresh: { status: "unavailable" } });
+    clock.mockReturnValue(NOW + 2000);
+    expect(await (await request("GET", "/api/v1/account")).json()).toMatchObject({ plan: "free", refresh: { status: "unavailable" } });
+    fetcher.mockClear();
+    const list = await request("GET", "/api/v1/docs");
+    const body = await list.json<{ docs: { docId: string }[] }>();
+    expect((await request("DELETE", `/api/v1/docs/${body.docs[0]!.docId}`)).status).toBe(204);
+    expect(fetcher).not.toHaveBeenCalled();
+    expect((await request("POST", "/api/v1/docs", { html: "<p>still free during outage</p>" })).status).toBe(201);
+  } finally { fetcher.mockRestore(); clock.mockRestore(); }
+});
+
+it("paid expiry forces refresh even within TTL; lifetime refreshes by TTL and outages retain only unexpired access", async () => {
+  const fetcher = vi.fn<typeof fetch>(async () => answer("plus", NOW + 5000));
+  await seed("pro", NOW, NOW - 1);
+  expect((await accountPlan(remote(), OWNER, { now: () => NOW, fetch: fetcher })).plan).toBe("pro");
+  expect(fetcher).toHaveBeenCalledTimes(1);
+  await seed("pro", null, NOW - 3_600_000);
+  fetcher.mockRejectedValue(new Error("outage"));
+  expect(await accountPlan(remote(), OWNER, { now: () => NOW, fetch: fetcher })).toEqual({ plan: "pro", status: "unavailable" });
+  await seed("pro", NOW - 1, NOW - 1);
+  expect((await accountPlan(remote(), OWNER, { now: () => NOW, fetch: fetcher })).plan).toBe("free");
+  expect(await stored()).toEqual({ plan: "pro", expiresAt: NOW - 1, checkedAt: NOW - 1 });
+});
+
+it("newer concurrent refresh wins, including the result returned by the older request", async () => {
+  await seed("free", null, null);
+  let release!: (r: Response) => void, started!: () => void;
+  const ready = new Promise<void>(r => { started = r; });
+  const first = accountPlan(remote(), OWNER, { now: () => NOW, forceAccountRefresh: true, fetch: async () => { started(); return await new Promise<Response>(r => { release = r; }); } });
+  await ready;
+  expect(await accountPlan(remote(), OWNER, { now: () => NOW + 1, fetch: async () => answer("default", null) })).toEqual({ plan: "free", status: "refreshed" });
+  release(answer("plus", null));
+  expect(await first).toEqual({ plan: "free", status: "cached" });
+  expect(await stored()).toEqual({ plan: "free", expiresAt: null, checkedAt: NOW + 1 });
+});
+
+it("manual assignment and a new link each invalidate an older in-flight response", async () => {
+  for (const linking of [false, true]) {
+    await seed("free", null, NOW);
+    let release!: (r: Response) => void, started!: () => void;
+    const ready = new Promise<void>(r => { started = r; });
+    const first = accountPlan(remote(), OWNER, { now: () => NOW, forceAccountRefresh: true, fetch: async () => { started(); return await new Promise<Response>(r => { release = r; }); } });
+    await ready;
+    if (linking) {
+      expect(await linkExternalOwner(env.DB, "external", OWNER, NOW)).toBe("linked");
+    } else {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(NOW);
+      try { expect((await request("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "free" }, "admin")).status).toBe(200); }
+      finally { clock.mockRestore(); }
+    }
+    release(answer("plus", null));
+    expect(await first).toEqual({ plan: "free", status: "cached" });
+  }
+  const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
+    expect(JSON.parse(init!.body as string)).toEqual({ json: { accountId: OWNER, externalOwner: "external" } });
+    return answer("plus", null);
+  });
+  expect((await accountPlan(remote(), OWNER, { now: () => NOW + 1, fetch: fetcher })).plan).toBe("pro");
+  expect(await stored()).toEqual({ plan: "pro", expiresAt: null, checkedAt: NOW + 1 });
+});
+
+it("unavailable or malformed responses preserve snapshots and self-hosted default configuration", async () => {
+  for (const json of [null, {}, { plan: "unknown", expiresAt: null }, { plan: "plus", expiresAt: -1 }, { plan: "plus", expiresAt: "tomorrow" }, { plan: "plus" }]) {
+    expect(await accountPlan(remote(), OWNER, { now: () => NOW, forceAccountRefresh: true, fetch: async () => Response.json({ result: { data: { json } } }) })).toEqual({ plan: "free", status: "unavailable" });
+  }
+  const custom = { ...env, DEFAULT_PLAN: "trial", PLAN_LIMITS: '{"trial":{"documents":2,"pushesPerDay":3,"htmlBytes":1024}}' };
+  await seed("trial", null, NOW);
+  expect(await accountPlan(custom, OWNER, { forceAccountRefresh: true })).toEqual({ plan: "trial", status: "unavailable" });
+  expect(await stored()).toEqual({ plan: "trial", expiresAt: null, checkedAt: NOW });
+  const columns = (await env.DB.prepare("PRAGMA table_info(accounts)").all<{ name: string }>()).results.map(r => r.name);
+  expect(columns).toContain("plan_checked_at"); expect(columns).not.toContain("plan_revision");
+  const handoff = (await env.DB.prepare("PRAGMA table_info(account_handoffs)").all<{ name: string }>()).results.map(r => r.name);
+  expect(handoff).not.toContain("purpose");
+  await findOrCreateAccount(env.DB, OTHER, "other@example.test", NOW);
+  expect(await linkExternalOwner(env.DB, "external", OTHER, NOW)).toBe("linked");
+  expect((await env.DB.prepare("SELECT plan_checked_at FROM accounts WHERE id = ?").bind(OTHER).first())).toEqual({ plan_checked_at: null });
+});

--- a/test/entitlement.test.ts
+++ b/test/entitlement.test.ts
@@ -169,3 +169,16 @@ it("malformed publishing configuration cannot block expired-account management",
     await expect(accountPlan({ ...env, ...config }, OWNER, { now: () => NOW })).rejects.toThrow();
   }
 });
+
+
+it("unsupported document methods return 404 without publishing-plan resolution", async () => {
+  await seed("pro", NOW - 1, NOW);
+  for (const [method, path] of [["POST", "/api/v1/docs/id"], ["PUT", "/api/v1/docs"], ["PUT", "/api/v1/docs/id/extra"]]) {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(new Request(`https://local.test${path}`, {
+      method, headers: { authorization: `Bearer ${token}` },
+    }), { ...env, PLAN_LIMITS: "broken", SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "" }, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(404);
+  }
+});

--- a/test/entitlement.test.ts
+++ b/test/entitlement.test.ts
@@ -129,3 +129,28 @@ it("unavailable or malformed responses preserve snapshots and self-hosted defaul
   expect(await linkExternalOwner(env.DB, "external", OTHER, NOW)).toBe("linked");
   expect((await env.DB.prepare("SELECT plan_checked_at FROM accounts WHERE id = ?").bind(OTHER).first())).toEqual({ plan_checked_at: null });
 });
+
+it("backs off automatic retries without extending expired access; forced refresh retries immediately", async () => {
+  await seed("pro", NOW - 1, NOW - 3_600_000);
+  const fetcher = vi.fn<typeof fetch>(async () => { throw new Error("offline"); });
+  expect(await accountPlan(remote(), OWNER, { now: () => NOW, fetch: fetcher })).toEqual({ plan: "free", status: "unavailable" });
+  expect((await accountPlan(remote(), OWNER, { now: () => NOW + 1, fetch: fetcher })).plan).toBe("free");
+  expect(fetcher).toHaveBeenCalledTimes(1);
+  await accountPlan(remote(), OWNER, { now: () => NOW + 2, fetch: fetcher, forceAccountRefresh: true });
+  expect(fetcher).toHaveBeenCalledTimes(2);
+  await accountPlan(remote(), OWNER, { now: () => NOW + 60_002, fetch: fetcher });
+  expect(fetcher).toHaveBeenCalledTimes(3);
+});
+
+it("reports a successful concurrent refresh when an older request fails", async () => {
+  await seed("free", null, null);
+  let fail!: (error: Error) => void, started!: () => void;
+  const ready = new Promise<void>(resolve => { started = resolve; });
+  const first = accountPlan(remote(), OWNER, { now: () => NOW, forceAccountRefresh: true,
+    fetch: async () => { started(); return await new Promise<Response>((_, reject) => { fail = reject; }); } });
+  await ready;
+  await accountPlan(remote(), OWNER, { now: () => NOW + 1, forceAccountRefresh: true, fetch: async () => answer("plus", NOW + 10_000) });
+  fail(new Error("offline"));
+  expect(await first).toEqual({ plan: "pro", status: "cached" });
+  expect(await env.DB.prepare("SELECT plan_retry_after FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan_retry_after: null });
+});

--- a/test/entitlement.test.ts
+++ b/test/entitlement.test.ts
@@ -154,3 +154,18 @@ it("reports a successful concurrent refresh when an older request fails", async 
   expect(await first).toEqual({ plan: "pro", status: "cached" });
   expect(await env.DB.prepare("SELECT plan_retry_after FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan_retry_after: null });
 });
+
+
+it("malformed publishing configuration cannot block expired-account management", async () => {
+  await seed("pro", NOW - 1, NOW);
+  for (const config of [{ PLAN_LIMITS: "broken" }, { DEFAULT_PLAN: "missing" }]) {
+    expect(await accountPlan({ ...env, ...config }, OWNER, { skipAccountRefresh: true, now: () => NOW })).toEqual({ plan: "pro", status: "cached" });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(new Request("https://local.test/api/v1/docs", {
+      headers: { authorization: `Bearer ${token}` },
+    }), { ...env, ...config, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "" }, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    await expect(accountPlan({ ...env, ...config }, OWNER, { now: () => NOW })).rejects.toThrow();
+  }
+});

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -735,7 +735,7 @@ describe("a publisher whose plan may no longer publish", () => {
   });
 });
 
-it("evicts a rejected credential without losing its documents or another key's access", async () => {
+it("marks a rejected credential without losing its documents or another key's access", async () => {
   await seedPublisher(KEY_B, ownerA);
   const doc = await publish(KEY_A, "Keep this document");
   const before = await docRow(doc.docId);
@@ -751,8 +751,8 @@ it("evicts a rejected credential without losing its documents or another key's a
     }, { status: 404 })) as typeof fetch,
   });
   expect(rejected).toMatchObject({ ok: false, reason: "invalid_license" });
-  expect(await env.DB.prepare("SELECT key_hash FROM publishers WHERE key_hash = ?")
-    .bind(await sha256Hex(KEY_A)).first()).toBeNull();
+  expect(await env.DB.prepare("SELECT rejected_at FROM publishers WHERE key_hash = ?")
+    .bind(await sha256Hex(KEY_A)).first()).toEqual({ rejected_at: expect.any(Number) });
   expect(await docRow(doc.docId)).toEqual(before);
   expect(await objectKeys(doc.docId)).toEqual(keys);
   expect(await env.DB.prepare("SELECT n FROM versions WHERE doc_id = ?")

--- a/test/manage.test.ts
+++ b/test/manage.test.ts
@@ -1,7 +1,7 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { deleteDoc } from "../src/api/manage.js";
-import type { Publisher } from "../src/auth.js";
+import { resolvePublisher, type Publisher } from "../src/auth.js";
 import type { Env } from "../src/config.js";
 import type { DocRow } from "../src/db.js";
 import { DOC_ID_LENGTH } from "../src/ids.js";
@@ -733,4 +733,33 @@ describe("a publisher whose plan may no longer publish", () => {
     expect(await objectKeys(created.docId)).toEqual([versionObjectKey(created.docId, 1)]);
     expect((await docRow(created.docId))?.latest_version).toBe(1);
   });
+});
+
+it("evicts a rejected credential without losing its documents or another key's access", async () => {
+  await seedPublisher(KEY_B, ownerA);
+  const doc = await publish(KEY_A, "Keep this document");
+  const before = await docRow(doc.docId);
+  const keys = await objectKeys(doc.docId);
+  await env.DB.prepare("UPDATE publishers SET validated_at = 0 WHERE key_hash = ?")
+    .bind(await sha256Hex(KEY_A)).run();
+
+  const rejected = await resolvePublisher(KEY_A, {
+    ...env, LICENSE_API_URL: "https://license.test", LICENSE_API_KEY: "test-server-key",
+  }, {
+    fetch: (async () => Response.json({
+      error: { json: { data: { code: "NOT_FOUND" } } },
+    }, { status: 404 })) as typeof fetch,
+  });
+  expect(rejected).toMatchObject({ ok: false, reason: "invalid_license" });
+  expect(await env.DB.prepare("SELECT key_hash FROM publishers WHERE key_hash = ?")
+    .bind(await sha256Hex(KEY_A)).first()).toBeNull();
+  expect(await docRow(doc.docId)).toEqual(before);
+  expect(await objectKeys(doc.docId)).toEqual(keys);
+  expect(await env.DB.prepare("SELECT n FROM versions WHERE doc_id = ?")
+    .bind(doc.docId).first()).toEqual({ n: 1 });
+  const response = await list(KEY_B);
+  expect(response.status).toBe(200);
+  expect(await response.text()).toContain(doc.docId);
+  expect(await resolvePublisher(KEY_A, { ...env, LICENSE_API_URL: "" }))
+    .toMatchObject({ ok: false, reason: "license_unavailable" });
 });

--- a/test/newsletter.test.ts
+++ b/test/newsletter.test.ts
@@ -1,0 +1,27 @@
+import { env } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+import { findOrCreateAccount } from "../src/db.js";
+import { syncNewsletter } from "../src/newsletter.js";
+import { accountPlan } from "../src/entitlement.js";
+
+it("only stored opt-in is delivered, and later plan refresh retries without blocking access", async () => {
+  const id = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+  await findOrCreateAccount(env.DB, id, "person@example.test", 1000);
+  const configured = { ...env, LICENSE_API_URL: "https://license.example.test", LICENSE_API_KEY: "service" };
+  const fetcher = vi.fn<typeof fetch>(async () => { throw new Error("offline"); });
+  await syncNewsletter(configured, id, fetcher);
+  expect(fetcher).not.toHaveBeenCalled();
+  await env.DB.prepare("UPDATE accounts SET newsletter_opt_in = 1 WHERE id = ?").bind(id).run();
+  await expect(syncNewsletter(configured, id, fetcher)).resolves.toBeUndefined();
+  expect(JSON.parse(fetcher.mock.calls[0]![1]!.body as string)).toEqual({ json: { email: "person@example.test" } });
+  expect(new Headers(fetcher.mock.calls[0]![1]!.headers).get("authorization")).toBe("Bearer service");
+  fetcher.mockImplementation(async (url) => String(url).endsWith("openArtifactsNewsletter")
+    ? Response.json({ result: { data: { json: { ok: true } } } })
+    : Response.json({ result: { data: { json: { plan: "default", expiresAt: null } } } }));
+  expect(await accountPlan(configured, id, { forceAccountRefresh: true, fetch: fetcher })).toMatchObject({ plan: "free", status: "refreshed" });
+  expect(fetcher.mock.calls.filter(([url]) => String(url).endsWith("openArtifactsNewsletter"))).toHaveLength(2);
+  await env.DB.prepare("UPDATE accounts SET newsletter_opt_in = 0 WHERE id = ?").bind(id).run();
+  fetcher.mockClear();
+  await syncNewsletter(configured, id, fetcher);
+  expect(fetcher).not.toHaveBeenCalled();
+});

--- a/test/newsletter.test.ts
+++ b/test/newsletter.test.ts
@@ -20,6 +20,10 @@ it("only stored opt-in is delivered, and later plan refresh retries without bloc
     : Response.json({ result: { data: { json: { plan: "default", expiresAt: null } } } }));
   expect(await accountPlan(configured, id, { forceAccountRefresh: true, fetch: fetcher })).toMatchObject({ plan: "free", status: "refreshed" });
   expect(fetcher.mock.calls.filter(([url]) => String(url).endsWith("openArtifactsNewsletter"))).toHaveLength(2);
+  fetcher.mockClear();
+  await syncNewsletter(configured, id, fetcher);
+  expect(fetcher).not.toHaveBeenCalled();
+  expect(await env.DB.prepare("SELECT newsletter_opt_in, newsletter_synced_at FROM accounts WHERE id = ?").bind(id).first()).toMatchObject({ newsletter_opt_in: 1, newsletter_synced_at: expect.any(Number) });
   await env.DB.prepare("UPDATE accounts SET newsletter_opt_in = 0 WHERE id = ?").bind(id).run();
   fetcher.mockClear();
   await syncNewsletter(configured, id, fetcher);

--- a/test/owners.test.ts
+++ b/test/owners.test.ts
@@ -1,0 +1,167 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, expect, it } from "vitest";
+import { insertDocWithinQuota, listPublisherDocs, ownsLiveDoc, reserveNextVersion, softDeleteDoc } from "../src/db.js";
+import { sha256Hex } from "../src/hash.js";
+import { newApiToken, newDocId, newTokenId } from "../src/ids.js";
+import { linkExternalOwner } from "../src/owners.js";
+import { refundDailyPush, reserveDailyPush } from "../src/quota.js";
+import worker from "../src/index.js";
+
+const ACCOUNT = "oa_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_ACCOUNT = "oa_bbbbbbbbbbbbbbbbbbbbbbbbbb";
+const EXTERNAL = "external-owner-a";
+const OTHER_EXTERNAL = "external-owner-b";
+const DAY = "2026-09-09";
+const KEY = "test-license-a";
+const SECOND_KEY = "test-license-a2";
+let token: string;
+let tokenId: string;
+
+beforeEach(async () => {
+  for (const account of [ACCOUNT, OTHER_ACCOUNT]) {
+    await env.DB.prepare("INSERT INTO accounts (id, email, created_at, plan) VALUES (?, ?, 0, 'pro')")
+      .bind(account, `${account}@example.test`).run();
+  }
+  token = newApiToken();
+  tokenId = newTokenId();
+  await env.DB.prepare("INSERT INTO tokens (id, token_hash, account_id, created_at) VALUES (?, ?, ?, 0)")
+    .bind(tokenId, await sha256Hex(token), ACCOUNT).run();
+  for (const key of [KEY, SECOND_KEY]) {
+    await env.DB.prepare("INSERT INTO publishers (key_hash, plan, owner, validated_at) VALUES (?, 'plus', ?, ?)")
+      .bind(await sha256Hex(key), EXTERNAL, Date.now()).run();
+  }
+});
+
+const link = () => linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 123);
+const doc = (owner: string, at = 0) => ({ id: newDocId(), owner, title: owner, created_at: at, updated_at: at });
+
+async function send(method: string, path: string, credential: string, body?: unknown) {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`https://local.test${path}`, {
+    method,
+    headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }), { ...env, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "" }, ctx);
+  await waitOnExecutionContext(ctx);
+  const bytes = await response.arrayBuffer();
+  return new Response(response.status === 204 ? null : bytes, { status: response.status, headers: response.headers });
+}
+
+async function publish(credential: string) {
+  const response = await send("POST", "/api/v1/docs", credential, { title: "Kept", html: "<!doctype html><html><body>Kept</body></html>" });
+  expect(response.status).toBe(201);
+  return await response.json() as { docId: string; url: string; version: number };
+}
+
+it("links one existing account once, without transfers, chains, or missing accounts", async () => {
+  expect(await link()).toBe("linked");
+  expect(await linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 999)).toBe("linked");
+  expect(await linkExternalOwner(env.DB, EXTERNAL, OTHER_ACCOUNT, 999)).toBe("conflict");
+  expect(await linkExternalOwner(env.DB, OTHER_EXTERNAL, ACCOUNT, 999)).toBe("conflict");
+  expect(await linkExternalOwner(env.DB, OTHER_EXTERNAL, "oa_cccccccccccccccccccccccccc", 999)).toBe("account_not_found");
+  for (const external of ["", " ", " trailing ", ACCOUNT, "x".repeat(257)]) {
+    expect(await linkExternalOwner(env.DB, external, OTHER_ACCOUNT, 999)).toBe("invalid");
+  }
+  for (const account of [EXTERNAL, "oa_", "oa_" + "!".repeat(26)]) {
+    expect(await linkExternalOwner(env.DB, OTHER_EXTERNAL, account, 999)).toBe("invalid");
+  }
+  expect(await env.DB.prepare("SELECT * FROM owner_links").all()).toMatchObject({ results: [
+    { external_owner: EXTERNAL, account_id: ACCOUNT, created_at: 123 },
+  ] });
+  await expect(env.DB.prepare("UPDATE owner_links SET account_id = ?").bind(OTHER_ACCOUNT).run()).rejects.toThrow();
+  await expect(env.DB.prepare("DELETE FROM owner_links").run()).rejects.toThrow();
+});
+
+it("resolves competing links atomically with one winner", async () => {
+  const results = await Promise.all([
+    linkExternalOwner(env.DB, EXTERNAL, ACCOUNT, 1),
+    linkExternalOwner(env.DB, EXTERNAL, OTHER_ACCOUNT, 1),
+  ]);
+  expect(results.sort()).toEqual(["conflict", "linked"]);
+});
+
+it("joins both live collections with stable pagination and preserves deleted provenance", async () => {
+  const a = doc(EXTERNAL, 1);
+  const b = doc(ACCOUNT, 2);
+  const c = doc(EXTERNAL, 3);
+  const unrelated = doc(OTHER_ACCOUNT, 4);
+  for (const row of [a, b, c, unrelated]) expect(await insertDocWithinQuota(env.DB, row, 10)).toBe(true);
+  await softDeleteDoc(env.DB, c.id, EXTERNAL, 4);
+  expect(await ownsLiveDoc(env.DB, a.id, ACCOUNT)).toBe(false);
+  await link();
+  for (const owner of [ACCOUNT, EXTERNAL]) {
+    const first = await listPublisherDocs(env.DB, owner, null, 1);
+    expect(first.map((r) => r.id)).toEqual([b.id]);
+    expect((await listPublisherDocs(env.DB, owner, { created_at: b.created_at, id: b.id }, 1)).map((r) => r.id)).toEqual([a.id]);
+    expect(await ownsLiveDoc(env.DB, unrelated.id, owner)).toBe(false);
+    expect(await reserveNextVersion(env.DB, unrelated.id, owner)).toBeNull();
+    expect(await softDeleteDoc(env.DB, unrelated.id, owner, 5)).toBe(false);
+  }
+  expect(await reserveNextVersion(env.DB, a.id, ACCOUNT)).toBe(2);
+  expect(await softDeleteDoc(env.DB, b.id, EXTERNAL, 5)).toBe(true);
+  expect(await env.DB.prepare("SELECT owner, deleted_at FROM docs WHERE id = ?").bind(c.id).first())
+    .toEqual({ owner: EXTERNAL, deleted_at: 4 });
+});
+
+it("counts both document owners inside reservation, including requests started before linking", async () => {
+  const oldRequest = doc(EXTERNAL);
+  expect(await insertDocWithinQuota(env.DB, doc(ACCOUNT), 3)).toBe(true);
+  await link();
+  const attempts = await Promise.all([
+    insertDocWithinQuota(env.DB, oldRequest, 2),
+    insertDocWithinQuota(env.DB, doc(ACCOUNT), 2),
+  ]);
+  expect(attempts.filter(Boolean)).toHaveLength(1);
+  expect(await insertDocWithinQuota(env.DB, doc(EXTERNAL), 2)).toBe(false);
+  expect(await insertDocWithinQuota(env.DB, doc(ACCOUNT), 2)).toBe(false);
+});
+
+it("combines existing daily usage and refunds its original bucket across linking", async () => {
+  expect(await reserveDailyPush(env.DB, EXTERNAL, DAY, 3)).toBe(true);
+  expect(await reserveDailyPush(env.DB, ACCOUNT, DAY, 3)).toBe(true);
+  await link();
+  const claims = await Promise.all([
+    reserveDailyPush(env.DB, EXTERNAL, DAY, 3), reserveDailyPush(env.DB, ACCOUNT, DAY, 3),
+  ]);
+  expect(claims.filter(Boolean)).toHaveLength(1);
+  await refundDailyPush(env.DB, EXTERNAL, DAY);
+  expect(await reserveDailyPush(env.DB, ACCOUNT, DAY, 3)).toBe(true);
+  expect(await reserveDailyPush(env.DB, EXTERNAL, DAY, 3)).toBe(false);
+  expect(await reserveDailyPush(env.DB, EXTERNAL, "2026-09-10", 3)).toBe(true);
+  expect(await reserveDailyPush(env.DB, OTHER_EXTERNAL, DAY, 3)).toBe(true);
+  expect(await env.DB.prepare("SELECT SUM(pushes) AS n FROM push_quota WHERE day = ? AND owner IN (?, ?)")
+    .bind(DAY, EXTERNAL, ACCOUNT).first()).toEqual({ n: 3 });
+});
+
+it("handles linking between document and daily reservations without quota reset", async () => {
+  const pending = doc(EXTERNAL);
+  expect(await insertDocWithinQuota(env.DB, pending, 1)).toBe(true);
+  expect(await reserveDailyPush(env.DB, ACCOUNT, DAY, 1)).toBe(true);
+  await link();
+  expect(await reserveDailyPush(env.DB, EXTERNAL, DAY, 1)).toBe(false);
+  expect(await insertDocWithinQuota(env.DB, doc(ACCOUNT), 1)).toBe(false);
+});
+
+it("keeps URLs, versions, active tokens, and legacy key access without token administration", async () => {
+  const legacy = await publish(KEY);
+  const native = await publish(token);
+  const original = await env.DOCS.get(`docs/${legacy.docId}/v1.html`);
+  const originalBytes = await original!.text();
+  await link();
+  for (const credential of [KEY, SECOND_KEY, token]) {
+    const response = await send("GET", "/api/v1/docs", credential);
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain(legacy.docId);
+    expect(text).toContain(native.docId);
+  }
+  const update = await send("PUT", `/api/v1/docs/${legacy.docId}`, token, { html: "<!doctype html><html><body>Updated</body></html>" });
+  expect(update.status).toBe(200);
+  expect(await update.json()).toMatchObject({ docId: legacy.docId, url: legacy.url, version: 2 });
+  expect(await (await env.DOCS.get(`docs/${legacy.docId}/v1.html`))!.text()).toBe(originalBytes);
+  expect(await (await send("GET", "/api/v1/tokens", KEY)).json()).toEqual({ tokens: [] });
+  expect((await send("DELETE", `/api/v1/tokens/${tokenId}`, KEY)).status).toBe(404);
+  expect((await send("GET", "/api/v1/tokens", token)).status).toBe(200);
+  expect((await send("DELETE", `/api/v1/docs/${native.docId}`, SECOND_KEY)).status).toBe(204);
+  expect((await send("GET", `/d/${native.docId}`, token)).status).toBe(410);
+});

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -1,5 +1,6 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePublisher } from "../src/auth.js";
 import type { Env } from "../src/config.js";
 import { MAX_DOC_BYTES } from "../src/config.js";
 import { findOrCreateAccount, resolveAccountForIdentity } from "../src/db.js";
@@ -54,7 +55,7 @@ describe("configured account plans", () => {
   });
 
   it("loads the agreed hosted values from wrangler, not a separate test copy", () => {
-    expect(planLimits(local(), "free")).toEqual({ documents: 3, pushesPerDay: 6, htmlBytes: 1048576 });
+    expect(planLimits(local(), "free")).toEqual({ documents: 1, pushesPerDay: 6, htmlBytes: 1048576 });
     expect(planLimits(local(), "pro")).toEqual({ documents: 500, pushesPerDay: 100, htmlBytes: 10485760 });
     for (const PLAN_LIMITS of [undefined, ""]) {
       expect(planLimits(local({ PLAN_LIMITS }), "free")).toEqual(planLimits(local(), "free"));
@@ -74,7 +75,7 @@ describe("configured account plans", () => {
     const other = await issue();
     const doc = await (await create()).json<{ docId: string }>();
     for (let i = 0; i < 5; i++) expect((await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "updated" }, {}, other)).status).toBe(200);
-    const rejected = await create();
+    const rejected = await send("PUT", `/api/v1/docs/${doc.docId}`, { html: "one too many" });
     expect(rejected.status).toBe(402);
     expect(await error(rejected)).toMatchObject({ error: { limit: "pushesPerDay", plan: "free" } });
     expect(await usage()).toBe(6);
@@ -196,5 +197,80 @@ describe("service-only plan changes", () => {
     }
     expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan: "free" });
     expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "pro" }, hosts, ADMIN, "https://api.test")).status).toBe(200);
+  });
+});
+
+const snapshot = (plan: string, expiresAt: number | null, revision: number) =>
+  send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan, expiresAt, revision }, {}, ADMIN);
+const storedSnapshot = () => env.DB.prepare("SELECT plan, plan_expires_at AS expiresAt, plan_revision AS revision FROM accounts WHERE id = ?")
+  .bind(OWNER).first();
+
+describe("ordered and expiring account plans", () => {
+  it("applies newer snapshots, accepts identical retries, and refuses old or changed revisions", async () => {
+    const state = { plan: "pro", expiresAt: 123456789, revision: 2 };
+    expect(await (await snapshot(state.plan, state.expiresAt, state.revision)).json()).toEqual({ owner: OWNER, ...state });
+    expect(await (await snapshot(state.plan, state.expiresAt, state.revision)).json()).toEqual({ owner: OWNER, ...state });
+    expect((await snapshot("free", null, 1)).status).toBe(409);
+    expect((await snapshot("free", state.expiresAt, 2)).status).toBe(409);
+    expect((await snapshot("pro", null, 2)).status).toBe(409);
+    expect(await storedSnapshot()).toEqual(state);
+    expect((await snapshot("free", null, 3)).status).toBe(200);
+    expect((await send("PUT", "/admin/v1/accounts/missing/plan", { plan: "pro", expiresAt: null, revision: 1 }, {}, ADMIN)).status).toBe(404);
+  });
+
+  it("keeps the highest revision when two snapshots arrive concurrently", async () => {
+    const results = await Promise.all([snapshot("pro", null, 10), snapshot("free", 0, 11)]);
+    expect([200, 409]).toContain(results[0]!.status);
+    expect(results[1]!.status).toBe(200);
+    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: 0, revision: 11 });
+  });
+
+  it("rejects partial, extra, noninteger and unsafe snapshot fields without modifying the account", async () => {
+    for (const body of [
+      { plan: "pro", revision: 1 }, { plan: "pro", expiresAt: null },
+      ...[0, -1, 1.5, "2", Number.MAX_SAFE_INTEGER + 1, null].map((revision) => ({ plan: "pro", expiresAt: null, revision })),
+      ...[-1, 1.5, "2", Number.MAX_SAFE_INTEGER + 1].map((expiresAt) => ({ plan: "pro", expiresAt, revision: 1 })),
+      { plan: "pro", expiresAt: null, revision: 1, owner: OWNER },
+    ]) expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, body, {}, ADMIN)).status).toBe(400);
+    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: null, revision: 0 });
+  });
+
+  it("expires at the exact boundary in authentication and account status without changing the snapshot", async () => {
+    await snapshot("pro", 1000, 1);
+    for (const [at, plan] of [[999, "pro"], [1000, "free"], [1001, "free"]] as const) {
+      expect(await resolvePublisher(token, local(), { now: () => at })).toMatchObject({ ok: true, publisher: { plan } });
+      const clock = vi.spyOn(Date, "now").mockReturnValue(at);
+      try {
+        const status = await send("GET", "/api/v1/account");
+        expect(await status.json()).toMatchObject({ plan, limits: planLimits(local(), plan) });
+      } finally { clock.mockRestore(); }
+    }
+    expect(await storedSnapshot()).toEqual({ plan: "pro", expiresAt: 1000, revision: 1 });
+    await snapshot("pro", null, 2);
+    expect(await resolvePublisher(token, local(), { now: () => Number.MAX_SAFE_INTEGER })).toMatchObject({ ok: true, publisher: { plan: "pro" } });
+    await snapshot("pro", 0, 3);
+    expect(await resolvePublisher(token, local({ DEFAULT_PLAN: "trial", PLAN_LIMITS: JSON.stringify({ trial: { documents: 2, pushesPerDay: 3, htmlBytes: 1024 } }) }), { now: () => 1 }))
+      .toMatchObject({ ok: true, publisher: { plan: "trial" } });
+  });
+
+  it("preserves manual response shape and revision fence while clearing expiry", async () => {
+    await snapshot("pro", 0, 4);
+    expect(await (await setPlan("free")).json()).toEqual({ owner: OWNER, plan: "free" });
+    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: null, revision: 4 });
+    expect((await snapshot("pro", 0, 4)).status).toBe(409);
+    expect((await snapshot("pro", null, 5)).status).toBe(200);
+  });
+
+  it("preserves over-limit history, updating and unsharing when a snapshot expires", async () => {
+    await snapshot("pro", null, 1);
+    const docs: string[] = [];
+    for (let n = 0; n < 4; n++) docs.push((await (await create()).json<{ docId: string }>()).docId);
+    await snapshot("pro", 0, 2);
+    const listing = await send("GET", "/api/v1/docs");
+    expect(await listing.json()).toMatchObject({ docs: expect.arrayContaining(docs.map((docId) => expect.objectContaining({ docId }))) });
+    expect((await create()).status).toBe(402);
+    expect((await send("PUT", `/api/v1/docs/${docs[0]}`, { html: "still editable" })).status).toBe(200);
+    expect((await send("DELETE", `/api/v1/docs/${docs[1]}`)).status).toBe(204);
+    expect(await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(docs[1]).first()).toMatchObject({ deleted_at: expect.any(Number) });
   });
 });

--- a/test/plans.test.ts
+++ b/test/plans.test.ts
@@ -1,6 +1,5 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolvePublisher } from "../src/auth.js";
 import type { Env } from "../src/config.js";
 import { MAX_DOC_BYTES } from "../src/config.js";
 import { findOrCreateAccount, resolveAccountForIdentity } from "../src/db.js";
@@ -15,7 +14,7 @@ const ADMIN = "test-service-secret";
 let token: string;
 const local = (overrides: Partial<Env> = {}): Env => ({
   ...env, SERVING_HOST: "", API_HOST: "", LEGACY_SERVING_HOST: "", RETIRED_API_HOST: "",
-  ADMIN_API_KEY: ADMIN, ...overrides,
+  ADMIN_API_KEY: ADMIN, UPGRADE_URL: undefined, ...overrides,
 });
 async function issue(owner = OWNER) {
   const value = newApiToken();
@@ -130,10 +129,10 @@ describe("configured account plans", () => {
     expect(await usage()).toBe(5);
   });
 
-  it("returns an optional checkout URL carrying only the authenticated owner", async () => {
-    const response = await create("x".repeat(1048577), { UPGRADE_URL: "https://billing.test/upgrade?owner=forged&source=cli" });
+  it("returns a generic optional account URL without adding identity", async () => {
+    const response = await create("x".repeat(1048577), { UPGRADE_URL: "https://billing.test/account?source=cli" });
     const details = (await error(response)).error;
-    expect(details.upgrade_url).toBe(`https://billing.test/upgrade?owner=${OWNER}&source=cli`);
+    expect(details.upgrade_url).toBe("https://billing.test/account?source=cli");
     expect(details).not.toHaveProperty("upgradeUrl");
     expect(JSON.stringify(details)).not.toContain(token);
     expect((await error(await create("x".repeat(1048577)))).error).not.toHaveProperty("upgrade_url");
@@ -197,80 +196,5 @@ describe("service-only plan changes", () => {
     }
     expect(await env.DB.prepare("SELECT plan FROM accounts WHERE id = ?").bind(OWNER).first()).toEqual({ plan: "free" });
     expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan: "pro" }, hosts, ADMIN, "https://api.test")).status).toBe(200);
-  });
-});
-
-const snapshot = (plan: string, expiresAt: number | null, revision: number) =>
-  send("PUT", `/admin/v1/accounts/${OWNER}/plan`, { plan, expiresAt, revision }, {}, ADMIN);
-const storedSnapshot = () => env.DB.prepare("SELECT plan, plan_expires_at AS expiresAt, plan_revision AS revision FROM accounts WHERE id = ?")
-  .bind(OWNER).first();
-
-describe("ordered and expiring account plans", () => {
-  it("applies newer snapshots, accepts identical retries, and refuses old or changed revisions", async () => {
-    const state = { plan: "pro", expiresAt: 123456789, revision: 2 };
-    expect(await (await snapshot(state.plan, state.expiresAt, state.revision)).json()).toEqual({ owner: OWNER, ...state });
-    expect(await (await snapshot(state.plan, state.expiresAt, state.revision)).json()).toEqual({ owner: OWNER, ...state });
-    expect((await snapshot("free", null, 1)).status).toBe(409);
-    expect((await snapshot("free", state.expiresAt, 2)).status).toBe(409);
-    expect((await snapshot("pro", null, 2)).status).toBe(409);
-    expect(await storedSnapshot()).toEqual(state);
-    expect((await snapshot("free", null, 3)).status).toBe(200);
-    expect((await send("PUT", "/admin/v1/accounts/missing/plan", { plan: "pro", expiresAt: null, revision: 1 }, {}, ADMIN)).status).toBe(404);
-  });
-
-  it("keeps the highest revision when two snapshots arrive concurrently", async () => {
-    const results = await Promise.all([snapshot("pro", null, 10), snapshot("free", 0, 11)]);
-    expect([200, 409]).toContain(results[0]!.status);
-    expect(results[1]!.status).toBe(200);
-    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: 0, revision: 11 });
-  });
-
-  it("rejects partial, extra, noninteger and unsafe snapshot fields without modifying the account", async () => {
-    for (const body of [
-      { plan: "pro", revision: 1 }, { plan: "pro", expiresAt: null },
-      ...[0, -1, 1.5, "2", Number.MAX_SAFE_INTEGER + 1, null].map((revision) => ({ plan: "pro", expiresAt: null, revision })),
-      ...[-1, 1.5, "2", Number.MAX_SAFE_INTEGER + 1].map((expiresAt) => ({ plan: "pro", expiresAt, revision: 1 })),
-      { plan: "pro", expiresAt: null, revision: 1, owner: OWNER },
-    ]) expect((await send("PUT", `/admin/v1/accounts/${OWNER}/plan`, body, {}, ADMIN)).status).toBe(400);
-    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: null, revision: 0 });
-  });
-
-  it("expires at the exact boundary in authentication and account status without changing the snapshot", async () => {
-    await snapshot("pro", 1000, 1);
-    for (const [at, plan] of [[999, "pro"], [1000, "free"], [1001, "free"]] as const) {
-      expect(await resolvePublisher(token, local(), { now: () => at })).toMatchObject({ ok: true, publisher: { plan } });
-      const clock = vi.spyOn(Date, "now").mockReturnValue(at);
-      try {
-        const status = await send("GET", "/api/v1/account");
-        expect(await status.json()).toMatchObject({ plan, limits: planLimits(local(), plan) });
-      } finally { clock.mockRestore(); }
-    }
-    expect(await storedSnapshot()).toEqual({ plan: "pro", expiresAt: 1000, revision: 1 });
-    await snapshot("pro", null, 2);
-    expect(await resolvePublisher(token, local(), { now: () => Number.MAX_SAFE_INTEGER })).toMatchObject({ ok: true, publisher: { plan: "pro" } });
-    await snapshot("pro", 0, 3);
-    expect(await resolvePublisher(token, local({ DEFAULT_PLAN: "trial", PLAN_LIMITS: JSON.stringify({ trial: { documents: 2, pushesPerDay: 3, htmlBytes: 1024 } }) }), { now: () => 1 }))
-      .toMatchObject({ ok: true, publisher: { plan: "trial" } });
-  });
-
-  it("preserves manual response shape and revision fence while clearing expiry", async () => {
-    await snapshot("pro", 0, 4);
-    expect(await (await setPlan("free")).json()).toEqual({ owner: OWNER, plan: "free" });
-    expect(await storedSnapshot()).toEqual({ plan: "free", expiresAt: null, revision: 4 });
-    expect((await snapshot("pro", 0, 4)).status).toBe(409);
-    expect((await snapshot("pro", null, 5)).status).toBe(200);
-  });
-
-  it("preserves over-limit history, updating and unsharing when a snapshot expires", async () => {
-    await snapshot("pro", null, 1);
-    const docs: string[] = [];
-    for (let n = 0; n < 4; n++) docs.push((await (await create()).json<{ docId: string }>()).docId);
-    await snapshot("pro", 0, 2);
-    const listing = await send("GET", "/api/v1/docs");
-    expect(await listing.json()).toMatchObject({ docs: expect.arrayContaining(docs.map((docId) => expect.objectContaining({ docId }))) });
-    expect((await create()).status).toBe(402);
-    expect((await send("PUT", `/api/v1/docs/${docs[0]}`, { html: "still editable" })).status).toBe(200);
-    expect((await send("DELETE", `/api/v1/docs/${docs[1]}`)).status).toBe(204);
-    expect(await env.DB.prepare("SELECT deleted_at FROM docs WHERE id = ?").bind(docs[1]).first()).toMatchObject({ deleted_at: expect.any(Number) });
   });
 });

--- a/test/publishing-route.test.ts
+++ b/test/publishing-route.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from "vitest";
+import { isPublishingRequest } from "../src/auth.js";
+it("requires the API path boundary before publishing-plan resolution", () => {
+  for (const path of ["/api/v1docs", "/api/v1docs/doc", "/other/docs"]) {
+    expect(isPublishingRequest(new Request(`https://api.example${path}`, { method: "POST" }))).toBe(false);
+    expect(isPublishingRequest(new Request(`https://api.example${path}`, { method: "PUT" }))).toBe(false);
+  }
+  expect(isPublishingRequest(new Request("https://api.example/api/v1/docs", { method: "POST" }))).toBe(true);
+});

--- a/test/release-workflow.node.cjs
+++ b/test/release-workflow.node.cjs
@@ -120,6 +120,9 @@ test("hosted deploy requires both account URLs without imposing them on self-hos
   assert.doesNotThrow(() => checkHostedAccountActions(config));
   for (const name of ["ACCOUNT_ACTION_URL", "UPGRADE_URL"]) {
     assert.throws(() => checkHostedAccountActions(config.replace(`"${name}": "https://openartifacts.ai/account"`, `"${name}": ""`)), /must point/);
+    assert.throws(() => checkHostedAccountActions(config.replace(`"${name}": "https://openartifacts.ai/account",`, `// "${name}": "https://openartifacts.ai/account",`)), /must point/);
+    assert.throws(() => checkHostedAccountActions(config.replace(`"${name}": "https://openartifacts.ai/account",`, `/* "${name}": "https://openartifacts.ai/account", */`)), /must point/);
   }
-  assert.doesNotThrow(() => checkHostedAccountActions('{"API_HOST":"self.example"}'));
+  assert.doesNotThrow(() => checkHostedAccountActions('{"vars":{"API_HOST":"self.example",}}'));
+  assert.throws(() => checkHostedAccountActions('{"vars":'), /Invalid Wrangler/);
 });

--- a/test/release-workflow.node.cjs
+++ b/test/release-workflow.node.cjs
@@ -113,3 +113,13 @@ test("publication rejects non-patch candidates using registry metadata and prese
   }
   assert.equal(recheck("0.2.3", true), "exists=true\n");
 });
+
+const { checkHostedAccountActions } = require("../scripts/check-account-actions.cjs");
+test("hosted deploy requires both account URLs without imposing them on self-hosts", () => {
+  const config = readFileSync(new URL("../wrangler.jsonc", `file://${__filename}`), "utf8");
+  assert.doesNotThrow(() => checkHostedAccountActions(config));
+  for (const name of ["ACCOUNT_ACTION_URL", "UPGRADE_URL"]) {
+    assert.throws(() => checkHostedAccountActions(config.replace(`"${name}": "https://openartifacts.ai/account"`, `"${name}": ""`)), /must point/);
+  }
+  assert.doesNotThrow(() => checkHostedAccountActions('{"API_HOST":"self.example"}'));
+});

--- a/test/release-workflow.node.cjs
+++ b/test/release-workflow.node.cjs
@@ -45,7 +45,7 @@ test("publication uses pristine source, not files from the test job", () => {
   assert.match(jobs.publish, /if: steps\.recheck\.outputs\.exists != 'true'/);
 });
 
-const { checkReleasePR } = require("../scripts/check-release-pr.cjs");
+const { checkReleasePR, checkNextPatch } = require("../scripts/check-release-pr.cjs");
 const candidate = { baseVersion: "0.2.0", version: "0.2.1", lockVersion: "0.2.1" };
 
 test("version bumps require the exact matching release title", () => {
@@ -58,7 +58,7 @@ test("version bumps require the exact matching release title", () => {
 test("ordinary PRs need no release title, but release titles must match even without a bump", () => {
   const unchanged = { ...candidate, baseVersion: "0.2.1" };
   assert.doesNotThrow(() => checkReleasePR({ ...unchanged, title: "Fix publishing" }));
-  assert.doesNotThrow(() => checkReleasePR({ ...unchanged, title: "v0.2.1" }));
+  assert.throws(() => checkReleasePR({ ...unchanged, title: "v0.2.1" }), /next patch/);
   assert.throws(() => checkReleasePR({ ...unchanged, title: "v0.3.0" }), /exact PR title/);
 });
 
@@ -71,4 +71,45 @@ test("CI reruns title validation on PR edits and retains the base revision", () 
   assert.match(ci, /types: \[opened, synchronize, reopened, edited\]/);
   assert.match(ci, /fetch-depth: 0/);
   assert.match(ci, /if: github.event_name == 'pull_request'\n\s+run: node scripts\/check-release-pr.cjs/);
+});
+
+
+test("releases accept only the next patch, never minor, major, skipped, or older versions", () => {
+  assert.doesNotThrow(() => checkNextPatch("0.2.2", "0.2.3"));
+  assert.doesNotThrow(() => checkNextPatch("0.2.9", "0.2.10"));
+  for (const version of ["0.3.0", "1.0.0", "0.2.4", "0.2.1", "0.2.2", "0.2.3-beta.1"]) {
+    assert.throws(() => checkNextPatch("0.2.2", version), /next patch/);
+    assert.throws(() => checkReleasePR({ baseVersion: "0.2.2", version, lockVersion: version, title: `v${version}` }));
+  }
+  for (const base of [undefined, "latest", "0.02.2", "0.2.2-beta.1"]) {
+    assert.throws(() => checkNextPatch(base, "0.2.3"), /next patch/);
+  }
+});
+
+test("the final publishing boundary reuses the patch rule after the registry recheck", () => {
+  assert.match(jobs.publish, /const \{ checkNextPatch \} = require\("\.\/scripts\/check-release-pr\.cjs"\);\n\s+checkNextPatch\(latest, requested\);/);
+  assert.match(jobs.publish, /if \(exists\) \{[\s\S]*exists=true[\s\S]*\} else \{[\s\S]*checkNextPatch/);
+  assert.doesNotMatch(jobs.publish, /const compare =/);
+});
+
+test("publication rejects non-patch candidates using registry metadata and preserves replay skips", () => {
+  const { runInNewContext } = require("node:vm");
+  const code = /node <<'NODE'\n([\s\S]*?)\n\s+NODE/.exec(jobs.publish)[1];
+  function recheck(version, exists = false) {
+    let output = "";
+    runInNewContext(code, {
+      require: (name) => name === "node:fs" ? {
+        readFileSync: () => JSON.stringify({ "dist-tags": { latest: "0.2.2" }, versions: exists ? { [version]: {} } : {} }),
+        appendFileSync: (_path, value) => { output += value; },
+      } : { checkNextPatch },
+      process: { env: { VERSION: version, GITHUB_OUTPUT: "fixture" } },
+      console: { log() {} },
+    });
+    return output;
+  }
+  assert.equal(recheck("0.2.3"), "exists=false\n");
+  for (const version of ["0.3.0", "1.0.0", "0.2.4", "0.2.1", "0.2.2"]) {
+    assert.throws(() => recheck(version), /next patch/);
+  }
+  assert.equal(recheck("0.2.3", true), "exists=true\n");
 });

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -169,17 +169,20 @@ describe("Authorization: Bearer <token>", () => {
       token,
       local({ LICENSE_API_URL: "https://license.test", LICENSE_API_KEY: "ours" }),
       {
-        fetch: async () => {
+        fetch: async (url, init) => {
+          expect(String(url).endsWith("license.openArtifactsEntitlement")).toBe(true);
+          expect(JSON.stringify(init)).not.toContain(token);
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer ours");
           calls += 1;
           return Response.json({});
         },
       },
     );
 
-    expect(calls).toBe(0);
+    expect(calls).toBe(1);
     expect(resolved).toEqual({
       ok: true,
-      publisher: { owner: ACCOUNT_A, plan: "free", authKind: "account" },
+      publisher: { owner: ACCOUNT_A, plan: "free", authKind: "account", accountRefresh: "unavailable" },
     });
   });
 
@@ -251,6 +254,7 @@ describe("free account document limit", () => {
         message: "Your account can hold 1 published document. Unshare enough documents to get below this limit before publishing another.",
         limit: "documents",
         plan: "free",
+        upgrade_url: "https://openartifacts.ai/account",
       },
     });
     expect(await storage()).toEqual(before);

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -237,12 +237,10 @@ describe("free account document limit", () => {
     objects: (await env.DOCS.list()).objects.map((object) => object.key),
   });
 
-  it("allows three across tokens, rejects the fourth without writes, and isolates other accounts", async () => {
+  it("allows one across tokens, rejects the second without writes, and isolates other accounts", async () => {
     const first = await issueToken(ACCOUNT_A);
     const second = await issueToken(ACCOUNT_A);
-    for (const token of [first.token, second.token, first.token]) {
-      expect((await create(token)).status).toBe(201);
-    }
+    expect((await create(first.token)).status).toBe(201);
 
     const before = await storage();
     const refused = await create(second.token);
@@ -250,7 +248,7 @@ describe("free account document limit", () => {
     expect(await refused.json()).toEqual({
       error: {
         code: "limit_reached",
-        message: "Your account can hold 3 published documents. Unshare one to publish another.",
+        message: "Your account can hold 1 published document. Unshare enough documents to get below this limit before publishing another.",
         limit: "documents",
         plan: "free",
       },
@@ -263,7 +261,7 @@ describe("free account document limit", () => {
 
   it("does not reset document capacity when yesterday's push allowance rolls over", async () => {
     const { token } = await issueToken(ACCOUNT_A);
-    for (let i = 0; i < 3; i++) await publish(token, `Doc ${i}`);
+    await publish(token, "First");
     await env.DB.prepare("UPDATE push_quota SET day = '2000-01-01'").run();
     const before = await storage();
     expect((await create(token)).status).toBe(402);
@@ -273,8 +271,6 @@ describe("free account document limit", () => {
   it("keeps updates and public reads working at the limit, and unshare frees one slot", async () => {
     const { token } = await issueToken(ACCOUNT_A);
     const first = await publish(token, "First");
-    await publish(token, "Second");
-    await publish(token, "Third");
     expect((await send("PUT", `/api/v1/docs/${first.docId}`, token, { html: page("v2") })).status)
       .toBe(200);
     expect((await send("GET", `/d/${first.docId}`, null)).status).toBe(200);
@@ -285,28 +281,26 @@ describe("free account document limit", () => {
     expect((await create(token)).status).toBe(402);
   });
 
-  it("atomically gives concurrent tokens only the remaining slot", async () => {
+  it("atomically gives concurrent first creates from two tokens only one slot", async () => {
     const first = await issueToken(ACCOUNT_A);
     const second = await issueToken(ACCOUNT_A);
-    await publish(first.token, "First");
-    await publish(first.token, "Second");
     const replies = await Promise.all([create(first.token), create(second.token)]);
     expect(replies.map((response) => response.status).sort()).toEqual([201, 402]);
-    expect(await tokensSeeDoc(first.token)).toHaveLength(3);
-    expect((await env.DOCS.list()).objects).toHaveLength(3);
-    expect((await storage()).pushes).toMatchObject([{ pushes: 3 }]);
+    expect(await tokensSeeDoc(first.token)).toHaveLength(1);
+    expect((await env.DOCS.list()).objects).toHaveLength(1);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 1 }]);
   });
 
-  it("preserves existing over-cap documents and blocks creates until below the cap", async () => {
+  it("preserves three preexisting documents and requires all withdrawn before a new create", async () => {
     const { token } = await issueToken(ACCOUNT_A);
     const docs: PushResponse[] = [];
-    for (let i = 0; i < 4; i++) {
-      const response = await create(token, cap(4));
+    for (let i = 0; i < 3; i++) {
+      const response = await create(token, cap(3));
       expect(response.status).toBe(201);
       docs.push(await response.json<PushResponse>());
     }
     expect((await create(token)).status).toBe(402);
-    expect(await tokensSeeDoc(token)).toHaveLength(4);
+    expect(await tokensSeeDoc(token)).toHaveLength(3);
     for (const doc of docs) {
       expect((await send("GET", `/d/${doc.docId}`, null)).status).toBe(200);
     }
@@ -315,13 +309,19 @@ describe("free account document limit", () => {
     await send("DELETE", `/api/v1/docs/${docs[0]!.docId}`, token);
     expect((await create(token)).status).toBe(402);
     await send("DELETE", `/api/v1/docs/${docs[1]!.docId}`, token);
+    expect((await create(token)).status).toBe(402);
+    await send("DELETE", `/api/v1/docs/${docs[2]!.docId}`, token);
+    expect(await tokensSeeDoc(token)).toHaveLength(0);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 4 }]);
     expect((await create(token)).status).toBe(201);
+    expect((await storage()).pushes).toMatchObject([{ pushes: 5 }]);
   });
 
   it("honors a self-hosted account cap without changing paid license limits", async () => {
     const { token } = await issueToken(ACCOUNT_A);
-    expect((await create(token, cap(1))).status).toBe(201);
-    expect((await create(token, cap(1))).status).toBe(402);
+    expect((await create(token, cap(2))).status).toBe(201);
+    expect((await create(token, cap(2))).status).toBe(201);
+    expect((await create(token, cap(2))).status).toBe(402);
     for (let i = 0; i < 4; i++) {
       expect((await create(LICENSE_KEY, cap(1))).status).toBe(201);
     }

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -251,7 +251,7 @@ describe("free account document limit", () => {
     expect(await refused.json()).toEqual({
       error: {
         code: "limit_reached",
-        message: "Your account can hold 1 published document. Unshare enough documents to get below this limit before publishing another.",
+        message: "Your account can hold 1 published document. Unshare enough documents to get below this limit before publishing another. Run openartifacts account --open to manage your plan.",
         limit: "documents",
         plan: "free",
         upgrade_url: "https://openartifacts.ai/account",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -114,6 +114,8 @@
     "LEGACY_SERVING_HOST": "symposium.site",
     "RETIRED_API_HOST": "api.symposium.md",
     "DEFAULT_PLAN": "free",
+    "ACCOUNT_ACTION_URL": "https://openartifacts.ai/account",
+    "UPGRADE_URL": "https://openartifacts.ai/account",
     "PLAN_LIMITS": "{\"free\":{\"documents\":1,\"pushesPerDay\":6,\"htmlBytes\":1048576},\"pro\":{\"documents\":500,\"pushesPerDay\":100,\"htmlBytes\":10485760}}"
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -114,6 +114,6 @@
     "LEGACY_SERVING_HOST": "symposium.site",
     "RETIRED_API_HOST": "api.symposium.md",
     "DEFAULT_PLAN": "free",
-    "PLAN_LIMITS": "{\"free\":{\"documents\":3,\"pushesPerDay\":6,\"htmlBytes\":1048576},\"pro\":{\"documents\":500,\"pushesPerDay\":100,\"htmlBytes\":10485760}}"
+    "PLAN_LIMITS": "{\"free\":{\"documents\":1,\"pushesPerDay\":6,\"htmlBytes\":1048576},\"pro\":{\"documents\":500,\"pushesPerDay\":100,\"htmlBytes\":10485760}}"
   }
 }


### PR DESCRIPTION
Relates to #72

## Why

A person signing in from an agent needs a free first publication and a way to use an existing publishing history or manage paid capacity. The CLI currently cannot show account usage or open a proven browser account session.

## What

Add `account` to refresh plan and usage, and `account --open` for browser account management. Linked credentials share history and quotas without changing document URLs. One document is free; paid access is pulled on demand and cached with its actual expiry. Release the CLI as 0.2.3.

| Situation | Result |
| --- | --- |
| First free publication | Works without the entitlement service |
| Purchase or license link | `account` refreshes current access and reports the outcome |
| Entitlement outage | Listing and withdrawal remain local; finite paid access expires into free limits |
| Revoked token or rejected license | Cannot regain access through an old proof or stale license cache |

## Non goal

Provider billing and hosted prices, unlinking or moving document rows, operator controls, metrics, private sharing and new preview infrastructure are outside this change.

## Screenshot

The Worker renders provider sign-in, new-account consent and device approval pages. Local previews were inspected during implementation; screenshots are not attached. Billing/account management remains in the private integration.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real D1/R2 tests cover ownership, limits, proofs, revocation and cache races |
| A defect would fail CI or be obvious on first use | ❌ | Deployed service configuration and agent acceptance require rollout verification |
| A revert fully restores prior state, including persisted data | ❌ | Permanent links require an ownership-aware rollback floor |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Joined authorization and browser proofs are added |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Account endpoints, cache schema and CLI output are added |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Joined quota accounting and concurrent entitlement reads affect publishing |
| No hot-path behavior lacks deterministic coverage | ✅ | Entitlement expiry/outage and concurrent link/manual/refresh cases use real D1 |
| No new dependency | ✅ | No new runtime dependency |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | Cross-service deployment order and installed-agent behavior require acceptance |

Review: inspect `src/owners.ts` joined-owner SQL, `src/db.ts` authorization/reservation queries, `src/auth.ts` credential resolution, `src/entitlement.ts` conditional cache writes, `src/account.ts` proof creation/consumption, `src/admin.ts` manual assignment, and `packages/openartifacts/src/cli.js` account handling. Run Verification including outages and conflicting links.

## Verification

Latest local checks: 493 Worker tests, 16 CLI tests and typechecks pass. Migration 0011 preserves license rejection ordering and bounds automatic entitlement retries without extending paid validity. Explicit account refresh bypasses retry delay. The deployment instructions record the link-aware and rejection-aware rollback floor. New users accept Terms after OAuth before account creation; existing users bypass signup consent. Saved newsletter opt-in is delivered to the optional private integration after signup and retried on account-plan refresh. Failures do not fail signup or publishing.


1. Apply migrations to a disposable local D1, sign in, publish one HTML document, and attempt a second. Confirm useful account guidance and preserved updates/withdrawal.
2. Open account management, explicitly consume the proof through the trusted service and link an existing owner. Confirm both histories and summed quotas; reject conflicting links, replayed proofs and revoked tokens. Legacy keys must not manage OAuth tokens.
3. Run `account` against paid, expired and unavailable entitlement responses. Confirm refresh outcomes, local listing/withdrawal, and that an older response cannot overwrite a newer refresh or manual plan assignment.
4. Pack the CLI and install in disposable Claude Code/Codex configuration. Verify rendered review and explicit approval precede publication. Before authorized release, verify exact title `v0.2.3` and both package-version entries match the next patch of npm latest.

## Note

Cached lifetime access remains available during an entitlement outage and changes after a successful refresh. Manual plan assignments update the cache and can be replaced by a later refresh. Migrations and the private account service must precede launch promotion; merging or publishing is not part of this handoff.


