### PR TITLE
v0.2.4

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -363,11 +363,15 @@ why the client uploads HTML at all. What the policy forbids is a doc using the
 origin against its readers: no form submission, no framing, no `<base>`
 retargeting. The origin is cookieless and holds nothing but already-public docs.
 
-Four things are injected as the document is served: a
+The following are injected as the document is served: a
 `<meta name="robots" content="noindex,nofollow">` in the head, a
 `<link rel="icon">` beside it carrying the OpenArtifacts mark as a `data:` URI, a
-`Shared from Copilot for Obsidian` byline at the top of the body, and a
-`Powered by openartifacts.ai` byline before `</body>`. A document that ships its own
+`Shared from Copilot for Obsidian` byline at the top of the body only for
+Copilot-rendered HTML (identified by the
+`style#openartifacts-obsidian-publish-baseline` marker in the head), and a
+`Powered by openartifacts.ai` byline before `</body>`. Unmarked HTML gets no
+source header. The marker identifies a document format, not authenticated
+uploader identity. A document that ships its own
 icon keeps that markup — both links are then in the head, and which one the tab
 shows is the browser's choice. Nothing else is touched — the
 markup is never sanitized, rewritten or reformatted, and what R2 stores is the

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -368,7 +368,9 @@ The following are injected as the document is served: a
 `<link rel="icon">` beside it carrying the OpenArtifacts mark as a `data:` URI, a
 `Shared from Copilot for Obsidian` byline at the top of the body only for
 Copilot-rendered HTML (identified by the
-`style#openartifacts-obsidian-publish-baseline` marker in the head), and a
+`style#openartifacts-obsidian-publish-baseline` marker in the head, or
+`style#symposium-obsidian-publish-baseline` from before the OpenArtifacts
+rename), and a
 `Powered by openartifacts.ai` byline before `</body>`. Unmarked HTML gets no
 source header. The marker identifies a document format, not authenticated
 uploader identity. A document that ships its own

--- a/package-lock.json
+++ b/package-lock.json
@@ -3857,7 +3857,7 @@
       }
     },
     "packages/openartifacts": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "bin": {
         "openartifacts": "bin/openartifacts.js"

--- a/packages/openartifacts/package.json
+++ b/packages/openartifacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openartifacts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Install the OpenArtifacts agent skill and publish agent-rendered HTML from the terminal",
   "keywords": [
     "agent-skills",

--- a/packages/openartifacts/skill/openartifacts/SKILL.md
+++ b/packages/openartifacts/skill/openartifacts/SKILL.md
@@ -78,7 +78,13 @@ the user to paste a credential into the chat.
 
 Use `openartifacts account` to report the current plan, limits, usage, and linked
 status. When the user asks to upgrade, manage billing, or link their existing
-Copilot account, run `openartifacts account --open`. Relay the returned short-lived browser URL. The user
+Copilot account, run `openartifacts account --open`. The command opens the browser
+and prints a short-lived account URL. Show that exact URL as a clickable Markdown
+link; never use a placeholder or substitute the plain `/account` address. If the
+link cannot be clicked or the browser does not open, provide the full URL in a code
+block so the user can copy it into their browser. If it expires, run the command
+again and share the fresh link. Treat these URLs as private account access links;
+do not put them in published documents, issues, or logs. The user
 enters a license key and confirms linking only on that page, never in chat or
 command arguments. These commands require an OAuth-issued account token; follow
 the CLI guidance if an environment license key overrides the stored token.
@@ -87,7 +93,12 @@ the CLI guidance if an environment license key overrides the stored token.
 
 Relay the CLI's message verbatim and do not retry blindly. For `quota_exceeded`, say
 whether to wait or unshare an unused page. For `limit_reached`, show the limit.
-Relay guidance to run `openartifacts account --open` only when the CLI response
-includes it; self-hosted servers may not offer browser account management. Generate
-that browser link only when supported and the user asks to upgrade; do not treat
-a limit error as purchase authorization.
+When a `limit_reached` response includes guidance to run
+`openartifacts account --open`, run it automatically and share the returned account
+link using the instructions above. Tell the user they have reached their publishing
+limit and can choose a plan on that page. Do not require a separate request to
+generate the link. If generating it fails, relay the error and the command so the
+user can try it themselves; never invent a URL. Self-hosted servers may not offer
+browser account management, so do not assume support when the response lacks this
+guidance. Opening the account page is not authorization to choose a plan, start
+checkout, pay, or retry publishing automatically.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -122,7 +122,7 @@ MARKER="openartifacts-smoke-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
 cat >"$WORK/push.json" <<EOF
 {"title":"OpenArtifacts smoke check $MARKER",
- "html":"<!doctype html><html lang=en><head><meta charset=utf-8><title>smoke</title></head><body><p>$MARKER</p></body></html>"}
+ "html":"<!doctype html><html lang=en><head><meta charset=utf-8><title>smoke</title><style id=\"openartifacts-obsidian-publish-baseline\"></style></head><body><p>$MARKER</p></body></html>"}
 EOF
 
 printf 'smoke: %s\n\n' "$BASE_URL"

--- a/src/render.ts
+++ b/src/render.ts
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 6;
+export const RENDER_REVISION = 7;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
@@ -217,12 +217,81 @@ const BYLINE_LINK =
   "all:initial;font:inherit;display:inline;cursor:pointer;" +
   'color:#888;text-decoration:underline"';
 
-/** Hosting attribution only: the publishing app is not recorded. */
+/** The Copilot mark's outline, from `mark-mono-cream.svg` in the product site. */
+const MARK_PATH =
+  "M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 " +
+  "2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 " +
+  "27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z";
+
+/**
+ * The mark as a data URI, not as an element.
+ *
+ * Inlined rather than linked, because a byline that depends on another host's
+ * uptime is a byline that is sometimes a broken-image icon, and the document
+ * may be read from a mirror or a cache long after this deploy. `img-src` on the
+ * serving surface admits `data:`, so nothing in the CSP has to move.
+ *
+ * A data URI rather than an inline `<svg>` because the mark shares the DOM with
+ * an interactive document (D6). Prepending the header puts our element *first*,
+ * so a figure that opens with `d3.select("svg")` or `document.querySelector(
+ * "svg")` — the ordinary way to grab a chart's root — would find the logo and
+ * draw into it. That is a real document breaking on a real selector, not a
+ * hostile one. The byline's own grey is baked in place of `currentColor`, which
+ * costs nothing: `BYLINE_BASE` pins the colour anyway.
+ */
+const COPILOT_MARK_SRC =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="4 4 152 127" fill="#888">' +
+      `<path d="${MARK_PATH}"/></svg>`,
+  );
+
+/**
+ * And a `<span>` rather than an `<img>`, for the same reason one step further:
+ * `querySelectorAll("img")` is how a lightbox or a caption pass finds a
+ * document's figures, and the mark must not be one of them. A background image
+ * on an empty span answers to neither selector.
+ */
+const COPILOT_MARK =
+  '<span aria-hidden="true" style="all:initial;display:inline-block;' +
+  "width:17px;height:14px;vertical-align:-0.15em;flex:none;" +
+  // `url()` unquoted: `encodeURIComponent` leaves nothing in the value that
+  // would close the CSS function or the HTML attribute around it.
+  `background:url(${COPILOT_MARK_SRC}) center/contain no-repeat"></span>`;
+
+/**
+ * The header's link carries the mark as well as the name, so both are clickable.
+ * `inline-flex` to keep them on one line at a shared baseline, and the underline
+ * moves to the text — an underlined logo reads as a rendering fault.
+ */
+const BYLINE_LINK_WITH_MARK =
+  'target="_blank" rel="noopener noreferrer" style="' +
+  "all:initial;font:inherit;display:inline-flex;align-items:center;gap:0.4em;" +
+  'cursor:pointer;color:#888;text-decoration:none"';
+
+/**
+ * The two spans the header needs for layout, each reset like everything else it
+ * adds.
+ *
+ * The rule is one per element, without exception: `all:initial` on the container
+ * does not reach descendants, so a span left bare is a span a document's
+ * `span { font-size: 0 }` or `span { position: absolute }` reaches — and a
+ * stylesheet with a broad `span` rule is ordinary rather than hostile. `font`
+ * and `color` come straight back, since the point is to inherit the byline's,
+ * not the document's.
+ */
+const SPAN_RESET = "all:initial;font:inherit;color:inherit;";
+
+/** Where the document came from. Injected at the top of the body. */
 export const OPENARTIFACTS_HEADER =
   '<div class="openartifacts-header" style="' +
   BYLINE_BASE +
   ";margin:0 0 2rem;padding:0.75rem 0;border-bottom:1px solid rgba(128,128,128,0.25)\">" +
-  `Shared with <a href="https://openartifacts.ai" ${BYLINE_LINK}>OpenArtifacts</a></div>`;
+  `<span style="${SPAN_RESET}display:inline-flex;align-items:center;gap:0.4em">Shared from ` +
+  `<a href="https://obsidiancopilot.com" ${BYLINE_LINK_WITH_MARK}>` +
+  COPILOT_MARK +
+  `<span style="${SPAN_RESET}text-decoration:underline">Copilot for Obsidian</span>` +
+  "</a></span></div>";
 
 /** What served it. Injected immediately before `</body>`. */
 export const OPENARTIFACTS_FOOTER =
@@ -296,6 +365,7 @@ const AS_HTML = { html: true } as const;
  */
 export function renderServedHtml(response: Response, branding = true): Response {
   const head = branding ? NOINDEX_META + FAVICON_LINK + SOCIAL_CARD_META : NOINDEX_META;
+  let fromCopilot = false;
   let headPlaced = false;
   let cardTitlePlaced = false;
   let headerPlaced = false;
@@ -308,6 +378,11 @@ export function renderServedHtml(response: Response, branding = true): Response 
   let titleClosed = false;
 
   return new HTMLRewriter()
+    // Copilot's existing HTML renderer emits this marker. It describes the
+    // document format, not authenticated identity or publishing entitlement.
+    .on('style[id="openartifacts-obsidian-publish-baseline"]', {
+      element() { fromCopilot = true; },
+    })
     // `head > title` and not `title`: an inline `<svg>` may carry a `<title>`
     // of its own as its accessible name, and a chart's "Revenue by quarter" is
     // not what the document is called.
@@ -357,7 +432,7 @@ export function renderServedHtml(response: Response, branding = true): Response 
         // before `c`.
         if (headerPlaced) return;
         headerPlaced = true;
-        if (branding) body.prepend(OPENARTIFACTS_HEADER, AS_HTML);
+        if (branding && fromCopilot) body.prepend(OPENARTIFACTS_HEADER, AS_HTML);
         body.onEndTag((endTag) => {
           footerPlaced = true;
           if (branding) endTag.before(OPENARTIFACTS_FOOTER, AS_HTML);
@@ -371,7 +446,7 @@ export function renderServedHtml(response: Response, branding = true): Response 
           const titleMeta = socialTitleMeta(documentTitle);
           if (titleMeta.length > 0) end.append(titleMeta, AS_HTML);
         }
-        if (branding && !headerPlaced) end.append(OPENARTIFACTS_HEADER, AS_HTML);
+        if (branding && fromCopilot && !headerPlaced) end.append(OPENARTIFACTS_HEADER, AS_HTML);
         if (branding && !footerPlaced) end.append(OPENARTIFACTS_FOOTER, AS_HTML);
       },
     })

--- a/src/render.ts
+++ b/src/render.ts
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 7;
+export const RENDER_REVISION = 6;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the

--- a/src/render.ts
+++ b/src/render.ts
@@ -45,7 +45,7 @@
  * constants in this file, so the thing that changes them is an edit to this
  * file, and a reviewer can see whether the number moved with it.
  */
-export const RENDER_REVISION = 5;
+export const RENDER_REVISION = 6;
 
 /**
  * Belt to the `X-Robots-Tag` header's braces (D9). The header is the
@@ -217,81 +217,12 @@ const BYLINE_LINK =
   "all:initial;font:inherit;display:inline;cursor:pointer;" +
   'color:#888;text-decoration:underline"';
 
-/** The Copilot mark's outline, from `mark-mono-cream.svg` in the product site. */
-const MARK_PATH =
-  "M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 " +
-  "2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 " +
-  "27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z";
-
-/**
- * The mark as a data URI, not as an element.
- *
- * Inlined rather than linked, because a byline that depends on another host's
- * uptime is a byline that is sometimes a broken-image icon, and the document
- * may be read from a mirror or a cache long after this deploy. `img-src` on the
- * serving surface admits `data:`, so nothing in the CSP has to move.
- *
- * A data URI rather than an inline `<svg>` because the mark shares the DOM with
- * an interactive document (D6). Prepending the header puts our element *first*,
- * so a figure that opens with `d3.select("svg")` or `document.querySelector(
- * "svg")` — the ordinary way to grab a chart's root — would find the logo and
- * draw into it. That is a real document breaking on a real selector, not a
- * hostile one. The byline's own grey is baked in place of `currentColor`, which
- * costs nothing: `BYLINE_BASE` pins the colour anyway.
- */
-const COPILOT_MARK_SRC =
-  "data:image/svg+xml," +
-  encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="4 4 152 127" fill="#888">' +
-      `<path d="${MARK_PATH}"/></svg>`,
-  );
-
-/**
- * And a `<span>` rather than an `<img>`, for the same reason one step further:
- * `querySelectorAll("img")` is how a lightbox or a caption pass finds a
- * document's figures, and the mark must not be one of them. A background image
- * on an empty span answers to neither selector.
- */
-const COPILOT_MARK =
-  '<span aria-hidden="true" style="all:initial;display:inline-block;' +
-  "width:17px;height:14px;vertical-align:-0.15em;flex:none;" +
-  // `url()` unquoted: `encodeURIComponent` leaves nothing in the value that
-  // would close the CSS function or the HTML attribute around it.
-  `background:url(${COPILOT_MARK_SRC}) center/contain no-repeat"></span>`;
-
-/**
- * The header's link carries the mark as well as the name, so both are clickable.
- * `inline-flex` to keep them on one line at a shared baseline, and the underline
- * moves to the text — an underlined logo reads as a rendering fault.
- */
-const BYLINE_LINK_WITH_MARK =
-  'target="_blank" rel="noopener noreferrer" style="' +
-  "all:initial;font:inherit;display:inline-flex;align-items:center;gap:0.4em;" +
-  'cursor:pointer;color:#888;text-decoration:none"';
-
-/**
- * The two spans the header needs for layout, each reset like everything else it
- * adds.
- *
- * The rule is one per element, without exception: `all:initial` on the container
- * does not reach descendants, so a span left bare is a span a document's
- * `span { font-size: 0 }` or `span { position: absolute }` reaches — and a
- * stylesheet with a broad `span` rule is ordinary rather than hostile. `font`
- * and `color` come straight back, since the point is to inherit the byline's,
- * not the document's.
- */
-const SPAN_RESET = "all:initial;font:inherit;color:inherit;";
-
-/** Where the document came from. Injected at the top of the body. */
+/** Hosting attribution only: the publishing app is not recorded. */
 export const OPENARTIFACTS_HEADER =
   '<div class="openartifacts-header" style="' +
   BYLINE_BASE +
   ";margin:0 0 2rem;padding:0.75rem 0;border-bottom:1px solid rgba(128,128,128,0.25)\">" +
-  `<span style="${SPAN_RESET}display:inline-flex;align-items:center;gap:0.4em">Shared from ` +
-  `<a href="https://obsidiancopilot.com" ${BYLINE_LINK_WITH_MARK}>` +
-  COPILOT_MARK +
-  `<span style="${SPAN_RESET}text-decoration:underline">Copilot for Obsidian</span>` +
-  "</a></span></div>";
+  `Shared with <a href="https://openartifacts.ai" ${BYLINE_LINK}>OpenArtifacts</a></div>`;
 
 /** What served it. Injected immediately before `</body>`. */
 export const OPENARTIFACTS_FOOTER =

--- a/src/render.ts
+++ b/src/render.ts
@@ -380,9 +380,16 @@ export function renderServedHtml(response: Response, branding = true): Response 
   return new HTMLRewriter()
     // Copilot's existing HTML renderer emits this marker. It describes the
     // document format, not authenticated identity or publishing entitlement.
-    .on('style[id="openartifacts-obsidian-publish-baseline"]', {
-      element() { fromCopilot = true; },
-    })
+    // Two ids, because the renderer was renamed at the OpenArtifacts cutover
+    // (Copilot 4.0.5): pages published by 4.0.0-4.0.4 through the Symposium
+    // path carry the `symposium-` id and this Worker still serves them, so
+    // dropping it would strip the byline off every pre-cutover document.
+    .on(
+      'style[id="openartifacts-obsidian-publish-baseline"], style[id="symposium-obsidian-publish-baseline"]',
+      {
+        element() { fromCopilot = true; },
+      },
+    )
     // `head > title` and not `title`: an inline `<svg>` may carry a `<title>`
     // of its own as its accessible name, and a chart's "Revenue by quarter" is
     // not what the document is called.

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/render.js";
 
 const bake = async (html: string, branding = true): Promise<string> =>
-  await renderServedHtml(new Response(html), branding).text();
+  await renderServedHtml(new Response(html.replace(/^(<!doctype[^>]*>)?/i, '$&<style id="openartifacts-obsidian-publish-baseline"></style>')), branding).text();
 
 /** A document shaped like the ones Obsidian renders. */
 const page = (body: string) =>
@@ -138,12 +138,11 @@ describe("renderServedHtml — what gets injected", () => {
     expect(baked).toContain("<title>Revenue by quarter</title>");
   });
 
-  it("attributes hosting without claiming which app published the document", async () => {
+  it("attributes documents carrying the Copilot renderer marker", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
-    expect(baked).toContain("Shared with ");
-    expect(baked).not.toContain("Copilot for Obsidian");
-    expect(baked).toContain(">OpenArtifacts</a>");
+    expect(baked).toContain("Shared from ");
+    expect(baked).toContain(">Copilot for Obsidian</span>");
   });
 
   // The header is prepended, so anything it adds is the *first* of its kind in
@@ -168,7 +167,7 @@ describe("renderServedHtml — what gets injected", () => {
   });
 
   it("links both bylines out, which is the whole point of carrying them", async () => {
-    expect(OPENARTIFACTS_HEADER).toContain('href="https://openartifacts.ai"');
+    expect(OPENARTIFACTS_HEADER).toContain('href="https://obsidiancopilot.com"');
     expect(OPENARTIFACTS_FOOTER).toContain('href="https://openartifacts.ai"');
   });
 
@@ -187,7 +186,7 @@ describe("renderServedHtml — what gets injected", () => {
 
     // Both links use inline layout.
     expect(OPENARTIFACTS_FOOTER).toContain("display:inline;");
-    expect(OPENARTIFACTS_HEADER).toContain("display:inline;");
+    expect(OPENARTIFACTS_HEADER).toContain("display:inline-flex");
 
     // One reset per element the byline adds — no exceptions, since a bare span
     // is one a document's `span { font-size: 0 }` reaches. Counted against the
@@ -443,4 +442,11 @@ describe("renderServedHtml — branding off", () => {
     expect(bare).toContain(NOINDEX_META);
     expect(bare).not.toContain(OPENARTIFACTS_HEADER);
   });
+});
+
+it("omits the top header for unmarked agent HTML while retaining the footer", async () => {
+  const html = await renderServedHtml(new Response(page("<p>Codex publication</p>"))).text();
+  expect(html).not.toContain(OPENARTIFACTS_HEADER);
+  expect(html).not.toContain("Shared from");
+  expect(html).toContain(OPENARTIFACTS_FOOTER);
 });

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -31,7 +31,7 @@ describe("renderServedHtml — what gets injected", () => {
     expect(NOINDEX_META).toBe('<meta name="robots" content="noindex,nofollow">');
   });
 
-  // Keep the favicon inline: an icon fetched from another
+  // Inline for the reason the Copilot mark is: an icon fetched from another
   // host is a blank tab whenever that host is unreachable, and these bytes
   // outlive the deploy that produced them.
   it("carries the tab icon inline, in the brand's own colours", () => {
@@ -145,6 +145,20 @@ describe("renderServedHtml — what gets injected", () => {
     expect(baked).toContain(">Copilot for Obsidian</span>");
   });
 
+  // Inlined rather than linked: a byline that fetches its logo from another host
+  // is a broken-image icon whenever that host is unreachable, and these bytes
+  // outlive the deploy that produced them.
+  it("carries the Copilot mark inline, in the byline's own grey", () => {
+    // Inline, so the mark does not depend on another host being up, and no
+    // request leaves the page to fetch it.
+    expect(OPENARTIFACTS_HEADER).toContain("background:url(data:image/svg+xml,");
+    expect(OPENARTIFACTS_HEADER).toContain(encodeURIComponent('fill="#888"'));
+    // Decorative: the link text already names the product.
+    expect(OPENARTIFACTS_HEADER).toContain('aria-hidden="true"');
+    expect(OPENARTIFACTS_HEADER).toContain("width:17px");
+    expect(OPENARTIFACTS_HEADER).toContain("height:14px");
+  });
+
   // The header is prepended, so anything it adds is the *first* of its kind in
   // the document. A figure that opens with `d3.select("svg")` or
   // `querySelectorAll("img")[0]` would then find the logo and draw into it, and
@@ -180,11 +194,13 @@ describe("renderServedHtml — what gets injected", () => {
       for (const restored of ["font:inherit", "cursor:pointer", "color:#888"]) {
         expect(byline).toContain(restored);
       }
-      // Both hosting links remain visibly underlined.
+      // Underlined either way, but the header puts it on the text rather than
+      // the anchor, so the mark beside it is not underlined too.
       expect(byline).toContain("text-decoration:underline");
     }
 
-    // Both links use inline layout.
+    // Asserted apart, because a shared `display:inline` check would pass for the
+    // header only by being a prefix of `inline-flex`.
     expect(OPENARTIFACTS_FOOTER).toContain("display:inline;");
     expect(OPENARTIFACTS_HEADER).toContain("display:inline-flex");
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -460,6 +460,20 @@ describe("renderServedHtml — branding off", () => {
   });
 });
 
+// Copilot 4.0.0-4.0.4 published through the Symposium path, which emitted the
+// same baseline stylesheet under the `symposium-` id. Those pages are still
+// served from R2, so the marker they carry has to keep earning the byline.
+it("attributes pre-cutover Symposium-marked documents too", async () => {
+  const marked = page("<p>hello</p>").replace(
+    "<title>A note</title>",
+    '<title>A note</title>\n<style id="symposium-obsidian-publish-baseline"></style>',
+  );
+  const html = await renderServedHtml(new Response(marked)).text();
+
+  expect(html).toContain(OPENARTIFACTS_HEADER);
+  expect(html).toContain("Shared from ");
+});
+
 it("omits the top header for unmarked agent HTML while retaining the footer", async () => {
   const html = await renderServedHtml(new Response(page("<p>Codex publication</p>"))).text();
   expect(html).not.toContain(OPENARTIFACTS_HEADER);

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -31,7 +31,7 @@ describe("renderServedHtml — what gets injected", () => {
     expect(NOINDEX_META).toBe('<meta name="robots" content="noindex,nofollow">');
   });
 
-  // Inline for the reason the Copilot mark is: an icon fetched from another
+  // Keep the favicon inline: an icon fetched from another
   // host is a blank tab whenever that host is unreachable, and these bytes
   // outlive the deploy that produced them.
   it("carries the tab icon inline, in the brand's own colours", () => {
@@ -138,25 +138,12 @@ describe("renderServedHtml — what gets injected", () => {
     expect(baked).toContain("<title>Revenue by quarter</title>");
   });
 
-  it("says where the document came from, in text a reader can see", async () => {
+  it("attributes hosting without claiming which app published the document", async () => {
     const baked = await bake(page("<p>hello</p>"));
 
-    expect(baked).toContain("Shared from ");
-    expect(baked).toContain(">Copilot for Obsidian</span>");
-  });
-
-  // Inlined rather than linked: a byline that fetches its logo from another host
-  // is a broken-image icon whenever that host is unreachable, and these bytes
-  // outlive the deploy that produced them.
-  it("carries the Copilot mark inline, in the byline's own grey", () => {
-    // Inline, so the mark does not depend on another host being up, and no
-    // request leaves the page to fetch it.
-    expect(OPENARTIFACTS_HEADER).toContain("background:url(data:image/svg+xml,");
-    expect(OPENARTIFACTS_HEADER).toContain(encodeURIComponent('fill="#888"'));
-    // Decorative: the link text already names the product.
-    expect(OPENARTIFACTS_HEADER).toContain('aria-hidden="true"');
-    expect(OPENARTIFACTS_HEADER).toContain("width:17px");
-    expect(OPENARTIFACTS_HEADER).toContain("height:14px");
+    expect(baked).toContain("Shared with ");
+    expect(baked).not.toContain("Copilot for Obsidian");
+    expect(baked).toContain(">OpenArtifacts</a>");
   });
 
   // The header is prepended, so anything it adds is the *first* of its kind in
@@ -181,7 +168,7 @@ describe("renderServedHtml — what gets injected", () => {
   });
 
   it("links both bylines out, which is the whole point of carrying them", async () => {
-    expect(OPENARTIFACTS_HEADER).toContain('href="https://obsidiancopilot.com"');
+    expect(OPENARTIFACTS_HEADER).toContain('href="https://openartifacts.ai"');
     expect(OPENARTIFACTS_FOOTER).toContain('href="https://openartifacts.ai"');
   });
 
@@ -194,15 +181,13 @@ describe("renderServedHtml — what gets injected", () => {
       for (const restored of ["font:inherit", "cursor:pointer", "color:#888"]) {
         expect(byline).toContain(restored);
       }
-      // Underlined either way, but the header puts it on the text rather than
-      // the anchor, so the mark beside it is not underlined too.
+      // Both hosting links remain visibly underlined.
       expect(byline).toContain("text-decoration:underline");
     }
 
-    // Asserted apart, because a shared `display:inline` check would pass for the
-    // header only by being a prefix of `inline-flex`.
+    // Both links use inline layout.
     expect(OPENARTIFACTS_FOOTER).toContain("display:inline;");
-    expect(OPENARTIFACTS_HEADER).toContain("display:inline-flex");
+    expect(OPENARTIFACTS_HEADER).toContain("display:inline;");
 
     // One reset per element the byline adds — no exceptions, since a bare span
     // is one a document's `span { font-size: 0 }` reaches. Counted against the

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -195,8 +195,8 @@ describe("GET /d/{docId}", () => {
   // document they pushed. Documents stored before injection moved carry their
   // own baked copy and would show two footers until re-pushed; nothing pushed
   // through this path can, because nothing is ever baked into the bytes.
-  it("adds exactly one of each to a freshly pushed document", async () => {
-    const docId = await push({ title: "A note", html: page("<p>hello</p>") });
+  it("adds exactly one of each to a freshly pushed Copilot document", async () => {
+    const docId = await push({ title: "A note", html: page("<p>hello</p>").replace("</head>", '<style id="openartifacts-obsidian-publish-baseline"></style></head>') });
 
     const html = await (await get(`/d/${docId}`)).text();
 


### PR DESCRIPTION
## Why

A document published from Codex incorrectly displayed a Copilot source header. Agents also need to give users a working account link when they reach the free publishing limit.

## What

Release CLI v0.2.4 with skill instructions to generate a fresh account link automatically when the server offers account management after a publishing limit error. Include copyable-URL and expired-link guidance; opening the account does not authorize a purchase.

Keep the existing Copilot header only on HTML with the stylesheet marker emitted by Copilot's renderer. Other HTML gets no source header; the OpenArtifacts footer stays. Render revision advances from 5 to 6. Update the serving contract and the Copilot smoke fixture to match.

## Non goal

No schema, billing, authentication, or publishing API changes. The marker identifies rendered format, not authenticated uploader identity.

## Screenshot

The live Codex test document exposed the incorrect header. No new screenshot captured for this revision; rendering behavior is covered by tests.

## Risk

Future Copilot renderers must retain the marker or update this presentation contract. Pinned immutable caches can retain the old rendering until expiration. Installed agents must rerun the latest installer to receive the updated skill.

## Verification

Worker and CLI suites and typechecks; smoke script syntax checked. The live smoke script was not run because it creates and deletes production content. Package and lockfile versions match the release title v0.2.4.
