### PR TITLE
ci: wait out npm replication lag in the release verify step

### DIFF
--- a/.github/workflows/release-openartifacts.yml
+++ b/.github/workflows/release-openartifacts.yml
@@ -177,14 +177,17 @@ jobs:
         if: steps.recheck.outputs.exists != 'true'
         run: npm publish --workspace packages/openartifacts --ignore-scripts --access public --provenance
 
-      # Five minutes, because `npm publish` returning success only means the
-      # write was accepted: the version stays 404 on the public registry until
-      # replication catches up. Measured from the end of the publish step, 0.2.3
-      # took 75s to appear and 0.2.4 took 126s (runs 34674797705 and
-      # 34709093524), so the previous 10x3s window gave up well before either was
-      # visible and turned two good releases red. Still `--fail`, so a version
-      # that never appears is still a failure -- this waits longer, it does not
-      # stop checking.
+      # Five minutes, because a successful publish step only means the registry
+      # accepted the write: the version stays 404 to readers until replication
+      # catches up. Measured from the end of that step, 0.2.3 took 75s to appear
+      # and 0.2.4 took 126s (runs 34674797705 and 34709093524), so the previous
+      # 10x3s window gave up long before either was visible and turned two good
+      # releases red. Still `--fail`, so a version that never appears is still a
+      # failure: this waits longer, it does not stop checking.
+      #
+      # Phrasing note: release-workflow.node.cjs requires --ignore-scripts on
+      # every line in this job naming the publish command, comments included, so
+      # this one deliberately does not spell that command out.
       - name: Verify published version
         env:
           VERSION: ${{ needs.gate.outputs.version }}

--- a/.github/workflows/release-openartifacts.yml
+++ b/.github/workflows/release-openartifacts.yml
@@ -177,12 +177,20 @@ jobs:
         if: steps.recheck.outputs.exists != 'true'
         run: npm publish --workspace packages/openartifacts --ignore-scripts --access public --provenance
 
+      # Five minutes, because `npm publish` returning success only means the
+      # write was accepted: the version stays 404 on the public registry until
+      # replication catches up. Measured from the end of the publish step, 0.2.3
+      # took 75s to appear and 0.2.4 took 126s (runs 34674797705 and
+      # 34709093524), so the previous 10x3s window gave up well before either was
+      # visible and turned two good releases red. Still `--fail`, so a version
+      # that never appears is still a failure -- this waits longer, it does not
+      # stop checking.
       - name: Verify published version
         env:
           VERSION: ${{ needs.gate.outputs.version }}
         run: |
-          curl --fail --silent --show-error --location --retry 10 \
-            --retry-all-errors --retry-delay 3 \
+          curl --fail --silent --show-error --location --retry 60 \
+            --retry-all-errors --retry-delay 5 \
             "https://registry.npmjs.org/openartifacts/$VERSION" \
             --output /dev/null
           echo "openartifacts $VERSION is available from npm"


### PR DESCRIPTION
## Motivation

The `Verify published version` step in `release-openartifacts.yml` fails on every release, after the release has already published correctly. Both 0.2.3 and 0.2.4 went red this way.

`npm publish` returning success means the registry accepted the write, not that the version is readable yet. The step polled for ~33s (`--retry 10 --retry-delay 3`) and then failed the job.

Measured from the end of the publish step:

| version | publish step ended | visible on registry | lag | poll gave up |
|---|---|---|---|---|
| 0.2.3 | 05:09:21Z | 05:10:36Z | **75s** | 05:09:53Z |
| 0.2.4 | 17:44:53Z | 17:46:59Z | **126s** | 17:45:25Z |

(runs [34674797705](https://github.com/Brevilabs/OpenArtifacts/actions/runs/34674797705) and [34709093524](https://github.com/Brevilabs/OpenArtifacts/actions/runs/34709093524))

Both gave up well before the version could possibly have appeared.

## What changed

`--retry 10 --retry-delay 3` → `--retry 60 --retry-delay 5`, i.e. ~33s → 5 minutes, plus a comment recording the measured lag so the number isn't mistaken for a guess.

## Non-goals

Not a release PR — the title is deliberately not a bare `vX.Y.Z`, so the release path does not trigger.

Nothing about what gets published changes. This is only how long the workflow waits before deciding the publish failed.

## Risk

Low, and the failure mode is unchanged in both directions:

- `--fail` is kept, so a version that never appears still fails the job — this waits longer, it does not stop checking.
- The version-specific endpoint `registry.npmjs.org/openartifacts/$VERSION` is kept, rather than anything that could pass on a stale `latest` dist-tag.
- The longer window costs nothing on the happy path: an already-visible version returns on the first request. I verified this — `curl` against `0.2.4` returns in 0s, while a version that does not exist retries and then exits non-zero.

The one behavior change worth naming: a genuinely failed publish now takes 5 minutes to report instead of 33 seconds. That seemed clearly the right trade against a workflow that is red on every successful release, since a red-by-default release run trains everyone to ignore it and a real failure would look identical.

## How to review

Read the diff; it is one step in one workflow. To confirm the retry actually applies to a `404` (it does — `--retry-all-errors` is what makes `--fail`'s 404 retryable):

```bash
curl --fail --silent --show-error --location --retry 3 --retry-all-errors --retry-delay 2 \
  "https://registry.npmjs.org/openartifacts/99.99.99" --output /dev/null   # 4 attempts, exits 56
```

## Verification

`npm test` (498 Worker + 16 CLI) and `npm run typecheck` pass locally, though neither exercises this file. CI on this PR is the real check that the workflow still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)